### PR TITLE
Fix casing of MFA API arguments

### DIFF
--- a/src/mfa/interfaces/challenge-factor-options.ts
+++ b/src/mfa/interfaces/challenge-factor-options.ts
@@ -1,8 +1,8 @@
 export type ChallengeFactorOptions =
   | {
-      authentication_factor_id: string;
+      authenticationFactorId: string;
     }
   | {
-      authentication_factor_id: string;
-      sms_template: string;
+      authenticationFactorId: string;
+      smsTemplate: string;
     };

--- a/src/mfa/interfaces/verify-factor-options.ts
+++ b/src/mfa/interfaces/verify-factor-options.ts
@@ -1,4 +1,4 @@
 export type VerifyFactorOptions = {
-  authentication_challenge_id: string;
+  authenticationChallengeId: string;
   code: string;
 };

--- a/src/mfa/mfa.spec.ts
+++ b/src/mfa/mfa.spec.ts
@@ -142,21 +142,26 @@ describe('MFA', () => {
     describe('with no sms template', () => {
       it('challenge a factor with no sms template', async () => {
         const mock = new MockAdapter(axios);
-        mock.onPost('/auth/factors/challenge').reply(200, {
-          object: 'authentication_challenge',
-          id: 'auth_challenge_1234',
-          created_at: '2022-03-15T20:39:19.892Z',
-          updated_at: '2022-03-15T20:39:19.892Z',
-          expires_at: '2022-03-15T21:39:19.892Z',
-          code: '12345',
-          authentication_factor_id: 'auth_factor_1234',
-        });
+        mock
+          .onPost('/auth/factors/challenge', {
+            authentication_factor_id: 'auth_factor_1234',
+          })
+          .reply(200, {
+            object: 'authentication_challenge',
+            id: 'auth_challenge_1234',
+            created_at: '2022-03-15T20:39:19.892Z',
+            updated_at: '2022-03-15T20:39:19.892Z',
+            expires_at: '2022-03-15T21:39:19.892Z',
+            code: '12345',
+            authentication_factor_id: 'auth_factor_1234',
+          });
+
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
           apiHostname: 'api.workos.dev',
         });
 
         const challengeResponse = await workos.mfa.challengeFactor({
-          authentication_factor_id: 'auth_factor_1234',
+          authenticationFactorId: 'auth_factor_1234',
         });
 
         expect(challengeResponse).toMatchInlineSnapshot(`
@@ -172,25 +177,31 @@ describe('MFA', () => {
         `);
       });
     });
-    describe('with totp', () => {
+
+    describe('with sms template', () => {
       it('challenge a factor with sms template', async () => {
         const mock = new MockAdapter(axios);
-        mock.onPost('/auth/factors/challenge').reply(200, {
-          object: 'authentication_challenge',
-          id: 'auth_challenge_1234',
-          created_at: '2022-03-15T20:39:19.892Z',
-          updated_at: '2022-03-15T20:39:19.892Z',
-          expires_at: '2022-03-15T21:39:19.892Z',
-          code: '12345',
-          authentication_factor_id: 'auth_factor_1234',
-        });
+        mock
+          .onPost('/auth/factors/challenge', {
+            authentication_factor_id: 'auth_factor_1234',
+            sms_template: 'This is your code: 12345',
+          })
+          .reply(200, {
+            object: 'authentication_challenge',
+            id: 'auth_challenge_1234',
+            created_at: '2022-03-15T20:39:19.892Z',
+            updated_at: '2022-03-15T20:39:19.892Z',
+            expires_at: '2022-03-15T21:39:19.892Z',
+            code: '12345',
+            authentication_factor_id: 'auth_factor_1234',
+          });
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
           apiHostname: 'api.workos.dev',
         });
 
         const challengeResponse = await workos.mfa.challengeFactor({
-          authentication_factor_id: 'auth_factor_1234',
-          sms_template: 'This is your code: 12345',
+          authenticationFactorId: 'auth_factor_1234',
+          smsTemplate: 'This is your code: 12345',
         });
 
         expect(challengeResponse).toMatchInlineSnapshot(`
@@ -212,24 +223,29 @@ describe('MFA', () => {
     describe('verify with successful response', () => {
       it('verifies a successful factor', async () => {
         const mock = new MockAdapter(axios);
-        mock.onPost('/auth/factors/verify').reply(200, {
-          challenge: {
-            object: 'authentication_challenge',
-            id: 'auth_challenge_1234',
-            created_at: '2022-03-15T20:39:19.892Z',
-            updated_at: '2022-03-15T20:39:19.892Z',
-            expires_at: '2022-03-15T21:39:19.892Z',
+        mock
+          .onPost('/auth/factors/verify', {
+            authentication_challenge_id: 'auth_challenge_1234',
             code: '12345',
-            authentication_factor_id: 'auth_factor_1234',
-          },
-          valid: true,
-        });
+          })
+          .reply(200, {
+            challenge: {
+              object: 'authentication_challenge',
+              id: 'auth_challenge_1234',
+              created_at: '2022-03-15T20:39:19.892Z',
+              updated_at: '2022-03-15T20:39:19.892Z',
+              expires_at: '2022-03-15T21:39:19.892Z',
+              code: '12345',
+              authentication_factor_id: 'auth_factor_1234',
+            },
+            valid: true,
+          });
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
           apiHostname: 'api.workos.dev',
         });
 
         const verifyResponse = await workos.mfa.verifyFactor({
-          authentication_challenge_id: 'auth_challenge_1234',
+          authenticationChallengeId: 'auth_challenge_1234',
           code: '12345',
         });
         expect(verifyResponse).toMatchInlineSnapshot(`

--- a/src/mfa/mfa.ts
+++ b/src/mfa/mfa.ts
@@ -19,17 +19,43 @@ export class Mfa {
   }
 
   async enrollFactor(options: EnrollFactorOptions): Promise<Factor> {
-    const { data } = await this.workos.post('/auth/factors/enroll', options);
+    const { data } = await this.workos.post('/auth/factors/enroll', {
+      type: options.type,
+      ...(() => {
+        switch (options.type) {
+          case 'sms':
+            return {
+              phone_number: options.phoneNumber,
+            };
+          case 'totp':
+            return {
+              totp_issuer: options.issuer,
+              totp_user: options.user,
+            };
+          default:
+            return {};
+        }
+      })(),
+    });
+
     return data;
   }
 
   async challengeFactor(options: ChallengeFactorOptions): Promise<Challenge> {
-    const { data } = await this.workos.post('/auth/factors/challenge', options);
+    const { data } = await this.workos.post('/auth/factors/challenge', {
+      authentication_factor_id: options.authenticationFactorId,
+      sms_template: 'smsTemplate' in options ? options.smsTemplate : undefined,
+    });
+
     return data;
   }
 
   async verifyFactor(options: VerifyFactorOptions): Promise<VerifyResponse> {
-    const { data } = await this.workos.post('/auth/factors/verify', options);
+    const { data } = await this.workos.post('/auth/factors/verify', {
+      authentication_challenge_id: options.authenticationChallengeId,
+      code: options.code,
+    });
+
     return data;
   }
 }


### PR DESCRIPTION
Currently the enrollment method won't work as its passing camel cased arguments directly to the HTTP request.

- Fixes `enrollFactor` method
- Updates `challengeFactor` and `verifyFactor` method to consume camel cased arguments for consistency
- Updates unit tests to match the request body for mocks so that this logic is covered going forward

Note: I've tested against the API