### PR TITLE
Remove `environment_id` fields

### DIFF
--- a/src/audit-trail/interfaces/event.interface.ts
+++ b/src/audit-trail/interfaces/event.interface.ts
@@ -16,7 +16,6 @@ export interface Event {
   actor_id: string;
   target_name: string;
   target_id: string;
-  environment_id: string;
   occurred_at: Date;
   action: EventAction;
   metadata?: {

--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -16,7 +16,6 @@ describe('DirectorySync', () => {
     id: 'directory_123',
     created_at: '2020-05-06 04:21:48.649164',
     domain: 'foo-corp.com',
-    environment_id: 'environment_01EPZWK497BAJ96SW5Q99RWH3C',
     external_key: '9asBRBVHz2ASEkgg',
     name: 'Foo',
     object: 'directory',

--- a/src/directory-sync/interfaces/directory.interface.ts
+++ b/src/directory-sync/interfaces/directory.interface.ts
@@ -4,7 +4,6 @@ export interface Directory {
   domain: string;
   external_key: string;
   name: string;
-  environment_id: string;
   organization_id?: string;
   state: 'unlinked' | 'linked' | 'invalid_credentials';
   type: string;

--- a/src/mfa/interfaces/factor.interface.ts
+++ b/src/mfa/interfaces/factor.interface.ts
@@ -7,7 +7,6 @@ export interface Factor {
   created_at: string;
   updated_at: string;
   type: string;
-  environment_id: string;
   sms: Sms;
   totp: Totp;
 }

--- a/src/mfa/mfa.spec.ts
+++ b/src/mfa/mfa.spec.ts
@@ -35,7 +35,6 @@ describe('MFA', () => {
           created_at: '2022-03-15T20:39:19.892Z',
           updated_at: '2022-03-15T20:39:19.892Z',
           type: 'generic_otp',
-          environment_id: 'environment_1234',
         });
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
           apiHostname: 'api.workos.dev',
@@ -48,7 +47,6 @@ describe('MFA', () => {
         expect(enrollResponse).toMatchInlineSnapshot(`
           Object {
             "created_at": "2022-03-15T20:39:19.892Z",
-            "environment_id": "environment_1234",
             "id": "auth_factor_1234",
             "object": "authentication_factor",
             "type": "generic_otp",
@@ -66,7 +64,6 @@ describe('MFA', () => {
           created_at: '2022-03-15T20:39:19.892Z',
           updated_at: '2022-03-15T20:39:19.892Z',
           type: 'totp',
-          environment_id: 'environment_1234',
           totp: {
             qr_code: 'qr-code-test',
             secret: 'secret-test',
@@ -85,7 +82,6 @@ describe('MFA', () => {
         expect(enrollResponse).toMatchInlineSnapshot(`
           Object {
             "created_at": "2022-03-15T20:39:19.892Z",
-            "environment_id": "environment_1234",
             "id": "auth_factor_1234",
             "object": "authentication_factor",
             "totp": Object {
@@ -107,7 +103,6 @@ describe('MFA', () => {
           created_at: '2022-03-15T20:39:19.892Z',
           updated_at: '2022-03-15T20:39:19.892Z',
           type: 'sms',
-          environment_id: 'environment_1234',
           sms: {
             phone_number: '+15555555555',
           },
@@ -124,7 +119,6 @@ describe('MFA', () => {
         expect(enrollResponse).toMatchInlineSnapshot(`
           Object {
             "created_at": "2022-03-15T20:39:19.892Z",
-            "environment_id": "environment_1234",
             "id": "auth_factor_1234",
             "object": "authentication_factor",
             "sms": Object {


### PR DESCRIPTION
This PR removes the `environment_id` fields from various objects, as these fields are not returned by the API.