### PR TITLE
v2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.1",
+  "version": "2.6.0",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -21,7 +21,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/2.5.1",
+  "User-Agent": "workos-node/2.6.0",
 }
 `;
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -22,7 +22,7 @@ import { SSO } from './sso/sso';
 import { Webhooks } from './webhooks/webhooks';
 import { Mfa } from './mfa/mfa';
 
-const VERSION = '2.5.1';
+const VERSION = '2.6.0';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
 


### PR DESCRIPTION
### Changed

* Updated types for `Directory`, `User`, and `Group` entities in webhook payloads (#611)
* Updated various dependencies

### Removed

* Removed `environment_id` parameter from objects as this field is not returned by the API (#612)