### PR TITLE
Fix handling of `UnprocessableEntityException` responses

### DIFF
--- a/src/common/exceptions/unprocessable-entity.exception.ts
+++ b/src/common/exceptions/unprocessable-entity.exception.ts
@@ -7,20 +7,22 @@ export class UnprocessableEntityException extends Error {
   readonly name: string = 'UnprocessableEntityException';
   readonly message: string = 'Unprocessable entity';
   readonly code?: string;
+  readonly requestID: string;
 
-  constructor(
-    {
-      code,
-      errors,
-      message,
-    }: {
-      code?: string;
-      errors?: UnprocessableEntityError[];
-      message?: string;
-    },
-    readonly requestID: string,
-  ) {
+  constructor({
+    code,
+    errors,
+    message,
+    requestID,
+  }: {
+    code?: string;
+    errors?: UnprocessableEntityError[];
+    message?: string;
+    requestID: string;
+  }) {
     super();
+
+    this.requestID = requestID;
 
     if (message) {
       this.message = message;

--- a/src/common/exceptions/unprocessable-entity.exception.ts
+++ b/src/common/exceptions/unprocessable-entity.exception.ts
@@ -5,16 +5,39 @@ import { UnprocessableEntityError } from '../interfaces';
 export class UnprocessableEntityException extends Error {
   readonly status: number = 422;
   readonly name: string = 'UnprocessableEntityException';
-  readonly message: string;
+  readonly message: string = 'Unprocessable entity';
+  readonly code?: string;
 
-  constructor(errors: UnprocessableEntityError[], readonly requestID: string) {
+  constructor(
+    {
+      code,
+      errors,
+      message,
+    }: {
+      code?: string;
+      errors?: UnprocessableEntityError[];
+      message?: string;
+    },
+    readonly requestID: string,
+  ) {
     super();
-    const requirement: string = pluralize('requirement', errors.length);
 
-    this.message = `The following ${requirement} must be met:\n`;
+    if (message) {
+      this.message = message;
+    }
 
-    for (const { code } of errors) {
-      this.message = this.message.concat(`\t${code}\n`);
+    if (code) {
+      this.code = code;
+    }
+
+    if (errors) {
+      const requirement: string = pluralize('requirement', errors.length);
+
+      this.message = `The following ${requirement} must be met:\n`;
+
+      for (const { code } of errors) {
+        this.message = this.message.concat(`\t${code}\n`);
+      }
     }
   }
 }

--- a/src/mfa/interfaces/verify-factor-response.ts
+++ b/src/mfa/interfaces/verify-factor-response.ts
@@ -1,12 +1,6 @@
 import { Challenge } from './challenge.interface';
-export interface VerifyResponseSuccess {
+
+export interface VerifyResponse {
   challenge: Challenge;
   valid: boolean;
 }
-
-export interface VerifyResponseError {
-  code: string;
-  message: string;
-}
-
-export type VerifyResponse = VerifyResponseSuccess | VerifyResponseError;

--- a/src/mfa/mfa.spec.ts
+++ b/src/mfa/mfa.spec.ts
@@ -142,7 +142,7 @@ describe('MFA', () => {
           mock.onPost('/auth/factors/enroll').reply(
             422,
             {
-              message: "Phone number is invalid: 'foo'",
+              message: `Phone number is invalid: 'foo'`,
               code: 'invalid_phone_number',
             },
             {
@@ -305,8 +305,7 @@ describe('MFA', () => {
           .reply(
             422,
             {
-              message:
-                "The authentication challenge '12345' has already been verified.",
+              message: `The authentication challenge '12345' has already been verified.`,
               code: 'authentication_challenge_previously_verified',
             },
             {
@@ -338,7 +337,7 @@ describe('MFA', () => {
           .reply(
             422,
             {
-              message: "The authentication challenge '12345' has expired.",
+              message: `The authentication challenge '12345' has expired.`,
               code: 'authentication_challenge_expired',
             },
             {
@@ -368,7 +367,7 @@ describe('MFA', () => {
           .reply(
             422,
             {
-              message: "The authentication challenge '12345' has expired.",
+              message: `The authentication challenge '12345' has expired.`,
               code: 'authentication_challenge_expired',
             },
             {

--- a/src/mfa/mfa.spec.ts
+++ b/src/mfa/mfa.spec.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import { UnprocessableEntityException } from '../common/exceptions';
 
 import { WorkOS } from '../workos';
 
@@ -14,6 +15,7 @@ describe('MFA', () => {
       expect(factor).toMatchInlineSnapshot(`Object {}`);
     });
   });
+
   describe('deleteFactor', () => {
     it('sends request to delete a Factor', async () => {
       const mock = new MockAdapter(axios);
@@ -25,6 +27,7 @@ describe('MFA', () => {
       expect(mock.history.delete[0].url).toEqual('/auth/factors/conn_123');
     });
   });
+
   describe('enrollFactor', () => {
     describe('with generic', () => {
       it('enrolls a factor with generic type', async () => {
@@ -55,6 +58,7 @@ describe('MFA', () => {
         `);
       });
     });
+
     describe('with totp', () => {
       it('enrolls a factor with totp type', async () => {
         const mock = new MockAdapter(axios);
@@ -94,6 +98,7 @@ describe('MFA', () => {
         `);
       });
     });
+
     describe('with sms', () => {
       it('enrolls a factor with sms type', async () => {
         const mock = new MockAdapter(axios);
@@ -128,6 +133,34 @@ describe('MFA', () => {
             "updated_at": "2022-03-15T20:39:19.892Z",
           }
         `);
+      });
+
+      describe('when phone number is invalid', () => {
+        it('throws an exception', async () => {
+          const mock = new MockAdapter(axios);
+
+          mock.onPost('/auth/factors/enroll').reply(
+            422,
+            {
+              message: "Phone number is invalid: 'foo'",
+              code: 'invalid_phone_number',
+            },
+            {
+              'X-Request-ID': 'req_123',
+            },
+          );
+
+          const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
+            apiHostname: 'api.workos.dev',
+          });
+
+          await expect(
+            workos.mfa.enrollFactor({
+              type: 'sms',
+              phoneNumber: 'foo',
+            }),
+          ).rejects.toThrow(UnprocessableEntityException);
+        });
       });
     });
   });
@@ -234,6 +267,7 @@ describe('MFA', () => {
             },
             valid: true,
           });
+
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
           apiHostname: 'api.workos.dev',
         });
@@ -242,6 +276,7 @@ describe('MFA', () => {
           authenticationChallengeId: 'auth_challenge_1234',
           code: '12345',
         });
+
         expect(verifyResponse).toMatchInlineSnapshot(`
           Object {
             "challenge": Object {
@@ -256,6 +291,105 @@ describe('MFA', () => {
             "valid": true,
           }
         `);
+      });
+    });
+
+    describe('when the challenge has been previously verified', () => {
+      it('throws an exception', async () => {
+        const mock = new MockAdapter(axios);
+        mock
+          .onPost('/auth/factors/verify', {
+            authentication_challenge_id: 'auth_challenge_1234',
+            code: '12345',
+          })
+          .reply(
+            422,
+            {
+              message:
+                "The authentication challenge '12345' has already been verified.",
+              code: 'authentication_challenge_previously_verified',
+            },
+            {
+              'X-Request-ID': 'req_123',
+            },
+          );
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
+          apiHostname: 'api.workos.dev',
+        });
+
+        await expect(
+          workos.mfa.verifyFactor({
+            authenticationChallengeId: 'auth_challenge_1234',
+            code: '12345',
+          }),
+        ).rejects.toThrow(UnprocessableEntityException);
+      });
+    });
+
+    describe('when the challenge has expired', () => {
+      it('throws an exception', async () => {
+        const mock = new MockAdapter(axios);
+        mock
+          .onPost('/auth/factors/verify', {
+            authentication_challenge_id: 'auth_challenge_1234',
+            code: '12345',
+          })
+          .reply(
+            422,
+            {
+              message: "The authentication challenge '12345' has expired.",
+              code: 'authentication_challenge_expired',
+            },
+            {
+              'X-Request-ID': 'req_123',
+            },
+          );
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
+          apiHostname: 'api.workos.dev',
+        });
+
+        await expect(
+          workos.mfa.verifyFactor({
+            authenticationChallengeId: 'auth_challenge_1234',
+            code: '12345',
+          }),
+        ).rejects.toThrow(UnprocessableEntityException);
+      });
+
+      it('exception has code', async () => {
+        const mock = new MockAdapter(axios);
+        mock
+          .onPost('/auth/factors/verify', {
+            authentication_challenge_id: 'auth_challenge_1234',
+            code: '12345',
+          })
+          .reply(
+            422,
+            {
+              message: "The authentication challenge '12345' has expired.",
+              code: 'authentication_challenge_expired',
+            },
+            {
+              'X-Request-ID': 'req_123',
+            },
+          );
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
+          apiHostname: 'api.workos.dev',
+        });
+
+        try {
+          await workos.mfa.verifyFactor({
+            authenticationChallengeId: 'auth_challenge_1234',
+            code: '12345',
+          });
+        } catch (error) {
+          expect(error).toMatchObject({
+            code: 'authentication_challenge_expired',
+          });
+        }
       });
     });
   });

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -106,10 +106,12 @@ export class WorkOS {
           case 422: {
             const { errors } = data;
 
-            throw new UnprocessableEntityException(
-              { code, errors, message },
+            throw new UnprocessableEntityException({
+              code,
+              errors,
+              message,
               requestID,
-            );
+            });
           }
           case 404: {
             throw new NotFoundException(path, requestID);
@@ -165,10 +167,12 @@ export class WorkOS {
           case 422: {
             const { errors } = data;
 
-            throw new UnprocessableEntityException(
-              { code, errors, message },
+            throw new UnprocessableEntityException({
+              code,
+              errors,
+              message,
               requestID,
-            );
+            });
           }
           case 404: {
             throw new NotFoundException(path, requestID);
@@ -228,10 +232,12 @@ export class WorkOS {
           case 422: {
             const { errors } = data;
 
-            throw new UnprocessableEntityException(
-              { code, errors, message },
+            throw new UnprocessableEntityException({
+              code,
+              errors,
+              message,
               requestID,
-            );
+            });
           }
           case 404: {
             throw new NotFoundException(path, requestID);
@@ -280,10 +286,12 @@ export class WorkOS {
           case 422: {
             const { errors } = data;
 
-            throw new UnprocessableEntityException(
-              { code, errors, message },
+            throw new UnprocessableEntityException({
+              code,
+              errors,
+              message,
               requestID,
-            );
+            });
           }
           case 404: {
             throw new NotFoundException(path, requestID);

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -92,7 +92,12 @@ export class WorkOS {
       if (response) {
         const { status, data, headers } = response;
         const requestID = headers['X-Request-ID'];
-        const { error, error_description: errorDescription } = data;
+        const {
+          code,
+          error_description: errorDescription,
+          error,
+          message,
+        } = data;
 
         switch (status) {
           case 401: {
@@ -101,7 +106,10 @@ export class WorkOS {
           case 422: {
             const { errors } = data;
 
-            throw new UnprocessableEntityException(errors, requestID);
+            throw new UnprocessableEntityException(
+              { code, errors, message },
+              requestID,
+            );
           }
           case 404: {
             throw new NotFoundException(path, requestID);
@@ -143,7 +151,12 @@ export class WorkOS {
       if (response) {
         const { status, data, headers } = response;
         const requestID = headers['X-Request-ID'];
-        const { error, error_description: errorDescription } = data;
+        const {
+          code,
+          error_description: errorDescription,
+          error,
+          message,
+        } = data;
 
         switch (status) {
           case 401: {
@@ -152,7 +165,10 @@ export class WorkOS {
           case 422: {
             const { errors } = data;
 
-            throw new UnprocessableEntityException(errors, requestID);
+            throw new UnprocessableEntityException(
+              { code, errors, message },
+              requestID,
+            );
           }
           case 404: {
             throw new NotFoundException(path, requestID);
@@ -198,7 +214,12 @@ export class WorkOS {
       if (response) {
         const { status, data, headers } = response;
         const requestID = headers['X-Request-ID'];
-        const { error, error_description: errorDescription } = data;
+        const {
+          code,
+          error_description: errorDescription,
+          error,
+          message,
+        } = data;
 
         switch (status) {
           case 401: {
@@ -207,7 +228,10 @@ export class WorkOS {
           case 422: {
             const { errors } = data;
 
-            throw new UnprocessableEntityException(errors, requestID);
+            throw new UnprocessableEntityException(
+              { code, errors, message },
+              requestID,
+            );
           }
           case 404: {
             throw new NotFoundException(path, requestID);
@@ -242,7 +266,12 @@ export class WorkOS {
       if (response) {
         const { status, data, headers } = response;
         const requestID = headers['X-Request-ID'];
-        const { error, error_description: errorDescription } = data;
+        const {
+          code,
+          error_description: errorDescription,
+          error,
+          message,
+        } = data;
 
         switch (status) {
           case 401: {
@@ -251,7 +280,10 @@ export class WorkOS {
           case 422: {
             const { errors } = data;
 
-            throw new UnprocessableEntityException(errors, requestID);
+            throw new UnprocessableEntityException(
+              { code, errors, message },
+              requestID,
+            );
           }
           case 404: {
             throw new NotFoundException(path, requestID);


### PR DESCRIPTION
API currently can return `UnprocessableEntityException` with `code` and `message` properties. The Node SDK currently does not work with such responses, rather it always expects an `errors` property that it maps to generate a unique message.

This expands the `UnprocessableEntityException` error in the SDK to handle both cases.

I'm also removing a response type in the MFA API that can never be returned due to how the HTTP client handles non 200 status codes.

Should also be mentioned that this will also fix other exceptions outside of the MFA API as well.