### PR TITLE
Add idp_id, created_at and updated_at fields to Directory Group interface

### DIFF
--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -27,8 +27,11 @@ describe('DirectorySync', () => {
 
   const groupResponse: Group = {
     id: 'dir_grp_123',
+    idp_id: '123',
     directory_id: 'dir_123',
     name: 'Foo Group',
+    created_at: `2021-10-27 15:21:50.640958`,
+    updated_at: '2021-10-27 15:21:50.640959',
     raw_attributes: {
       foo: 'bar',
     },

--- a/src/directory-sync/interfaces/group.interface.ts
+++ b/src/directory-sync/interfaces/group.interface.ts
@@ -1,6 +1,9 @@
 export interface Group {
   id: string;
+  idp_id: string;
   directory_id: string;
   name: string;
+  created_at: string;
+  updated_at: string;
   raw_attributes: any;
 }


### PR DESCRIPTION
Update the Directory Group interface to add currently missing fields being returned by the API. Specifically `idp_id`, `created_at` and `updated_at`.