### PR TITLE
Make expires_at nullable in MFA challenge interface

### DIFF
--- a/src/mfa/interfaces/challenge.interface.ts
+++ b/src/mfa/interfaces/challenge.interface.ts
@@ -3,7 +3,7 @@ export interface Challenge {
   id: string;
   created_at: string;
   updated_at: string;
-  expires_at: string;
+  expires_at?: string;
   code: string;
   authentication_factor_id: string;
 }


### PR DESCRIPTION
Updates the `expires_at` field to be nullable in the MFA Challenge interface.