### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,5 @@
 # See GitHub's docs for more details:
-
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # TypeScript Team
-
-- @workos/typescript
+* @workos/typescript


### PR DESCRIPTION
This PR fixes a syntactic issue with the `CODEOWNERS` file.

AFAICT VS Code seems to interpret `CODEOWNERS` as Markdown, which means auto-formatting will mangle the file.