### PR TITLE
Fix misleading 404 messages

### DIFF
--- a/src/common/exceptions/not-found.exception.ts
+++ b/src/common/exceptions/not-found.exception.ts
@@ -2,9 +2,24 @@ export class NotFoundException extends Error {
   readonly status: number = 404;
   readonly name: string = 'NotFoundException';
   readonly message: string;
+  readonly code?: string;
+  readonly requestID: string;
 
-  constructor(path: string, readonly requestID: string) {
+  constructor({
+    code,
+    message,
+    path,
+    requestID,
+  }: {
+    code?: string;
+    message?: string;
+    path: string;
+    requestID: string;
+  }) {
     super();
-    this.message = `The requested path '${path}' could not be found.`;
+    this.code = code;
+    this.message =
+      message ?? `The requested path '${path}' could not be found.`;
+    this.requestID = requestID;
   }
 }

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -74,10 +74,11 @@ describe('WorkOS', () => {
   describe('post', () => {
     describe('when the api responds with a 404', () => {
       it('throws a NotFoundException', async () => {
+        const message = 'Not Found';
         mock.onPost().reply(
           404,
           {
-            message: 'Not Found',
+            message,
           },
           { 'X-Request-ID': 'a-request-id' },
         );
@@ -85,7 +86,11 @@ describe('WorkOS', () => {
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
         await expect(workos.post('/path', {})).rejects.toStrictEqual(
-          new NotFoundException('/path', 'a-request-id'),
+          new NotFoundException({
+            message,
+            path: '/path',
+            requestID: 'a-request-id',
+          }),
         );
       });
     });

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -93,6 +93,47 @@ describe('WorkOS', () => {
           }),
         );
       });
+
+      it('preserves the error code, status, and message from the underlying response', async () => {
+        const message = 'The thing you are looking for is not here.';
+        const code = 'thing-not-found';
+        mock.onPost().reply(
+          404,
+          {
+            code,
+            message,
+          },
+          { 'X-Request-ID': 'a-request-id' },
+        );
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        await expect(workos.post('/path', {})).rejects.toMatchObject({
+          code,
+          message,
+          status: 404,
+        });
+      });
+
+      it('includes the path in the message if there is no message in the response', async () => {
+        const code = 'thing-not-found';
+        const path = '/path/to/thing/that-aint-there';
+        mock.onPost().reply(
+          404,
+          {
+            code,
+          },
+          { 'X-Request-ID': 'a-request-id' },
+        );
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        await expect(workos.post(path, {})).rejects.toMatchObject({
+          code,
+          message: `The requested path '${path}' could not be found.`,
+          status: 404,
+        });
+      });
     });
 
     describe('when the api responds with a 500 and no error/error_description', () => {

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -144,7 +144,7 @@ export class WorkOS {
         params: query,
       });
     } catch (error) {
-      this.handleAxiosError({path, error});
+      this.handleAxiosError({ path, error });
 
       throw error;
     }
@@ -159,7 +159,7 @@ export class WorkOS {
     return process.emitWarning(warning, 'WorkOS');
   }
 
-  private handleAxiosError({path, error}: {path: string, error: unknown}) {
+  private handleAxiosError({ path, error }: { path: string; error: unknown }) {
     const { response } = error as AxiosError;
 
     if (response) {

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -90,59 +90,7 @@ export class WorkOS {
         headers: requestHeaders,
       });
     } catch (error) {
-      const { response } = error as AxiosError;
-
-      if (response) {
-        const { status, data, headers } = response;
-        const requestID = headers['X-Request-ID'];
-        const {
-          code,
-          error_description: errorDescription,
-          error,
-          errors,
-          message,
-        } = data;
-
-        switch (status) {
-          case 401: {
-            throw new UnauthorizedException(requestID);
-          }
-          case 422: {
-            const { errors } = data;
-
-            throw new UnprocessableEntityException({
-              code,
-              errors,
-              message,
-              requestID,
-            });
-          }
-          case 404: {
-            throw new NotFoundException(path, requestID);
-          }
-          default: {
-            if (error || errorDescription) {
-              throw new OauthException(
-                status,
-                requestID,
-                error,
-                errorDescription,
-              );
-            } else if (code && errors) {
-              // Note: ideally this should be mapped directly with a `400` status code.
-              // However, this would break existing logic for the `OauthException` exception.
-              throw new BadRequestException({
-                code,
-                errors,
-                message,
-                requestID,
-              });
-            } else {
-              throw new GenericServerException(status, data.message, requestID);
-            }
-          }
-        }
-      }
+      this.handleAxiosError({ path, error });
 
       throw error;
     }
@@ -161,49 +109,7 @@ export class WorkOS {
           : undefined,
       });
     } catch (error) {
-      const { response } = error as AxiosError;
-
-      if (response) {
-        const { status, data, headers } = response;
-        const requestID = headers['X-Request-ID'];
-        const {
-          code,
-          error_description: errorDescription,
-          error,
-          message,
-        } = data;
-
-        switch (status) {
-          case 401: {
-            throw new UnauthorizedException(requestID);
-          }
-          case 422: {
-            const { errors } = data;
-
-            throw new UnprocessableEntityException({
-              code,
-              errors,
-              message,
-              requestID,
-            });
-          }
-          case 404: {
-            throw new NotFoundException(path, requestID);
-          }
-          default: {
-            if (error || errorDescription) {
-              throw new OauthException(
-                status,
-                requestID,
-                error,
-                errorDescription,
-              );
-            } else {
-              throw new GenericServerException(status, data.message, requestID);
-            }
-          }
-        }
-      }
+      this.handleAxiosError({ path, error });
 
       throw error;
     }
@@ -226,49 +132,7 @@ export class WorkOS {
         headers: requestHeaders,
       });
     } catch (error) {
-      const { response } = error as AxiosError;
-
-      if (response) {
-        const { status, data, headers } = response;
-        const requestID = headers['X-Request-ID'];
-        const {
-          code,
-          error_description: errorDescription,
-          error,
-          message,
-        } = data;
-
-        switch (status) {
-          case 401: {
-            throw new UnauthorizedException(requestID);
-          }
-          case 422: {
-            const { errors } = data;
-
-            throw new UnprocessableEntityException({
-              code,
-              errors,
-              message,
-              requestID,
-            });
-          }
-          case 404: {
-            throw new NotFoundException(path, requestID);
-          }
-          default: {
-            if (error || errorDescription) {
-              throw new OauthException(
-                status,
-                requestID,
-                error,
-                errorDescription,
-              );
-            } else {
-              throw new GenericServerException(status, data.message, requestID);
-            }
-          }
-        }
-      }
+      this.handleAxiosError({ path, error });
 
       throw error;
     }
@@ -280,49 +144,7 @@ export class WorkOS {
         params: query,
       });
     } catch (error) {
-      const { response } = error as AxiosError;
-
-      if (response) {
-        const { status, data, headers } = response;
-        const requestID = headers['X-Request-ID'];
-        const {
-          code,
-          error_description: errorDescription,
-          error,
-          message,
-        } = data;
-
-        switch (status) {
-          case 401: {
-            throw new UnauthorizedException(requestID);
-          }
-          case 422: {
-            const { errors } = data;
-
-            throw new UnprocessableEntityException({
-              code,
-              errors,
-              message,
-              requestID,
-            });
-          }
-          case 404: {
-            throw new NotFoundException(path, requestID);
-          }
-          default: {
-            if (error || errorDescription) {
-              throw new OauthException(
-                status,
-                requestID,
-                error,
-                errorDescription,
-              );
-            } else {
-              throw new GenericServerException(status, data.message, requestID);
-            }
-          }
-        }
-      }
+      this.handleAxiosError({path, error});
 
       throw error;
     }
@@ -335,5 +157,66 @@ export class WorkOS {
     }
 
     return process.emitWarning(warning, 'WorkOS');
+  }
+
+  private handleAxiosError({path, error}: {path: string, error: unknown}) {
+    const { response } = error as AxiosError;
+
+    if (response) {
+      const { status, data, headers } = response;
+      const requestID = headers['X-Request-ID'];
+      const {
+        code,
+        error_description: errorDescription,
+        error,
+        errors,
+        message,
+      } = data;
+
+      switch (status) {
+        case 401: {
+          throw new UnauthorizedException(requestID);
+        }
+        case 422: {
+          const { errors } = data;
+
+          throw new UnprocessableEntityException({
+            code,
+            errors,
+            message,
+            requestID,
+          });
+        }
+        case 404: {
+          throw new NotFoundException({
+            code,
+            message,
+            path,
+            requestID,
+          });
+        }
+        default: {
+          if (error || errorDescription) {
+            throw new OauthException(
+              status,
+              requestID,
+              error,
+              errorDescription,
+            );
+          } else if (code && errors) {
+            // Note: ideally this should be mapped directly with a `400` status code.
+            // However, this would break existing logic for the `OauthException` exception.
+            throw new BadRequestException({
+              code,
+              errors,
+              message,
+              requestID,
+            });
+          } else {
+            throw new GenericServerException(status, data.message, requestID);
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes misleading 404 messages returned from the API and refactors error mapping.

Before:
```
The requested path '/audit_logs/events' could not be found.
    err: {
     "type": "NotFoundException",
     "message": "The requested path '/audit_logs/events' could not be found.",
     "stack":
         NotFoundException: The requested path '/audit_logs/events' could not be found.
            at WorkOS.<anonymous> (....)
      "status": 404,
      "name": "NotFoundException"
    }
```

After:
```
Audit Log Validator not found: 'user.login_succeeded.1'.
    err: {
      "type": "NotFoundException",
      "message": "Audit Log Validator not found: 'user.login_succeeded.1'.",
      "stack":
          NotFoundException: Audit Log Validator not found: 'user.login_succeeded.1'.
              at WorkOS.handleAxiosError (...)
      "status": 404,
      "name": "NotFoundException",
      "code": "entity_not_found"
    }
```