### PR TITLE
Allow customizing some Axios instance properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,32 @@ import WorkOS from '@workos-inc/node';
 const workos = new WorkOS('sk_1234');
 ```
 
+## Axios customization
+
+Some users may need to customize the underlying Axios instance. For instance, you may need to pass an `https.Agent` with a root CA to allow older Node versions to call the API, or you may be running on a non-Node runtime and need to pass in a custom `adapter`.
+
+You can pass in one of three Axios options in the `WorkOSOptions` object:
+
+- `adapter`
+- `httpsAgent`
+- `proxy`
+
+Example of using a custom root CA for legacy Node support:
+
+```ts
+import { Agent } from 'https';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import WorkOS from '@workos-inc/node';
+
+const rootCA = readFileSync(join(__dirname, './isrg-root-x2.pem'));
+
+const agent = new Agent({ ca: rootCA });
+
+const workos = new WorkOS('sk_1234', { axios: { httpsAgent: agent } });
+```
+
 ## SDK Versioning
 
 For our SDKs WorkOS follows a Semantic Versioning ([SemVer](https://semver.org/)) process where all releases will have a version X.Y.Z (like 1.0.0) pattern wherein Z would be a bug fix (e.g., 1.0.1), Y would be a minor release (1.1.0) and X would be a major release (2.0.0). We permit any breaking changes to only be released in major versions and strongly recommend reading changelogs before making any major version upgrades.

--- a/src/common/interfaces/workos-options.interface.ts
+++ b/src/common/interfaces/workos-options.interface.ts
@@ -1,5 +1,8 @@
+import { AxiosRequestConfig } from 'axios';
+
 export interface WorkOSOptions {
   apiHostname?: string;
   https?: boolean;
   port?: number;
+  axios?: Pick<AxiosRequestConfig, 'adapter' | 'httpsAgent' | 'proxy'>;
 }

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -65,6 +65,7 @@ export class WorkOS {
     }
 
     this.client = axios.create({
+      ...this.options.axios,
       baseURL: this.baseURL,
       headers: {
         Authorization: `Bearer ${this.key}`,


### PR DESCRIPTION
Fixes #652
Fixes #627

This adds three specific Axios options to `WorkOSOptions`: `adapter`, `httpsAgent`, and `proxy`.

The first two options address the issues listed above. The `proxy` may be needed in some instances. I specifically used `Pick` to pull only these properties to keep the consumer from messing up the functionality by passing in a different `baseUrl` or other properties.

