### PR TITLE
Allow customizing Axios client

### DIFF
--- a/src/common/interfaces/workos-options.interface.ts
+++ b/src/common/interfaces/workos-options.interface.ts
@@ -1,5 +1,8 @@
+import { AxiosRequestConfig } from 'axios';
+
 export interface WorkOSOptions {
   apiHostname?: string;
   https?: boolean;
   port?: number;
+  axios?: Omit<AxiosRequestConfig, 'baseURL'>;
 }

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -69,6 +69,26 @@ describe('WorkOS', () => {
         expect(workos.baseURL).toEqual('https://localhost:4000');
       });
     });
+
+    describe('when the `axios` option is provided', () => {
+      it('applies the configuration to the Axios client', async () => {
+        mock.onPost().reply(200, 'OK', { 'X-Request-ID': 'a-request-id' });
+
+        const workos = new WorkOS('sk_test', {
+          axios: {
+            headers: {
+              'X-My-Custom-Header': 'Hey there!',
+            },
+          },
+        });
+
+        await workos.post('/somewhere', {});
+
+        expect(mock.history.post[0].headers).toMatchObject({
+          'X-My-Custom-Header': 'Hey there!',
+        });
+      });
+    });
   });
 
   describe('post', () => {

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -65,8 +65,10 @@ export class WorkOS {
     }
 
     this.client = axios.create({
+      ...options.axios,
       baseURL: this.baseURL,
       headers: {
+        ...options.axios?.headers,
         Authorization: `Bearer ${this.key}`,
         'User-Agent': `workos-node/${VERSION}`,
       },


### PR DESCRIPTION
This PR adds support for customizing the underlying Axios client.

Resolves SDK-577.