### PR TITLE
Add groups attribute to user profile

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,6 +16,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
+      - nvm install
       - nvm use
       - bash ~/workos-node/bin/restore-or-install
 

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -50,3 +50,32 @@ Object {
   },
 }
 `;
+
+exports[`SSO SSO getProfileAndToken without a groups attribute sends a request to the WorkOS api for a profile 1`] = `"client_id=proj_123&client_secret=sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU&grant_type=authorization_code&code=authorization_code"`;
+
+exports[`SSO SSO getProfileAndToken without a groups attribute sends a request to the WorkOS api for a profile 2`] = `
+Object {
+  "Accept": "application/json, text/plain, */*",
+  "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
+  "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+  "User-Agent": "workos-node/2.16.0",
+}
+`;
+
+exports[`SSO SSO getProfileAndToken without a groups attribute sends a request to the WorkOS api for a profile 3`] = `
+Object {
+  "connection_id": "conn_123",
+  "connection_type": "OktaSAML",
+  "email": "foo@test.com",
+  "first_name": "foo",
+  "id": "prof_123",
+  "idp_id": "123",
+  "last_name": "bar",
+  "organization_id": "org_123",
+  "raw_attributes": Object {
+    "email": "foo@test.com",
+    "first_name": "foo",
+    "last_name": "bar",
+  },
+}
+`;

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -31,6 +31,10 @@ Object {
   "connection_type": "OktaSAML",
   "email": "foo@test.com",
   "first_name": "foo",
+  "groups": Array [
+    "Admins",
+    "Developers",
+  ],
   "id": "prof_123",
   "idp_id": "123",
   "last_name": "bar",
@@ -38,6 +42,10 @@ Object {
   "raw_attributes": Object {
     "email": "foo@test.com",
     "first_name": "foo",
+    "groups": Array [
+      "Admins",
+      "Developers",
+    ],
     "last_name": "bar",
   },
 }

--- a/src/sso/interfaces/profile.interface.ts
+++ b/src/sso/interfaces/profile.interface.ts
@@ -9,5 +9,6 @@ export interface Profile {
   email: string;
   first_name?: string;
   last_name?: string;
+  groups?: string[];
   raw_attributes?: { [key: string]: any };
 }

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -181,10 +181,12 @@ describe('SSO', () => {
                     email: 'foo@test.com',
                     first_name: 'foo',
                     last_name: 'bar',
+                    groups: ['Admins', 'Developers'],
                     raw_attributes: {
                       email: 'foo@test.com',
                       first_name: 'foo',
                       last_name: 'bar',
+                      groups: ['Admins', 'Developers'],
                     },
                   },
                 },
@@ -229,10 +231,12 @@ describe('SSO', () => {
             email: 'foo@test.com',
             first_name: 'foo',
             last_name: 'bar',
+            groups: ['Admins', 'Developers'],
             raw_attributes: {
               email: 'foo@test.com',
               first_name: 'foo',
               last_name: 'bar',
+              groups: ['Admins', 'Developers'],
             },
           });
 


### PR DESCRIPTION
## Description

Adds groups attribute to user profile. Available behind a feature flag.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
