### PR TITLE
v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.17.0",
+  "version": "3.0.0",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`SSO SSO getProfileAndToken with all information provided sends a reques
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/2.17.0",
+  "User-Agent": "workos-node/3.0.0",
 }
 `;
 
@@ -58,7 +58,7 @@ exports[`SSO SSO getProfileAndToken without a groups attribute sends a request t
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/2.17.0",
+  "User-Agent": "workos-node/3.0.0",
 }
 `;
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -25,7 +25,7 @@ import { Mfa } from './mfa/mfa';
 import { AuditLogs } from './audit-logs/audit-logs';
 import { BadRequestException } from './common/exceptions/bad-request.exception';
 
-const VERSION = '2.17.0';
+const VERSION = '3.0.0';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
 


### PR DESCRIPTION
## Added
- Added Connection type for Login.gov OIDC (https://github.com/workos/workos-node/pull/720)

## Updated

- Updated Node types version (https://github.com/workos/workos-node/pull/709, https://github.com/workos/workos-node/pull/710, https://github.com/workos/workos-node/pull/714, https://github.com/workos/workos-node/pull/719)
- Updated Node version (https://github.com/workos/workos-node/pull/705)
- Updated Prettier types version (https://github.com/workos/workos-node/pull/713, https://github.com/workos/workos-node/pull/715, https://github.com/workos/workos-node/pull/716)
- Updated Jest monorepo version (https://github.com/workos/workos-node/pull/599)
- Updated Axios mock version (https://github.com/workos/workos-node/pull/718)
- Updated Axios version - Breaking Change (https://github.com/workos/workos-node/pull/673)
- Updated TS version to v5 (https://github.com/workos/workos-node/pull/712)

## Removed

- Removed `query-string` dependency (https://github.com/workos/workos-node/pull/721)
