### PR TITLE
Add `actor_ids` parameter to `createExport`

### DIFF
--- a/src/audit-logs/audit-logs.spec.ts
+++ b/src/audit-logs/audit-logs.spec.ts
@@ -181,6 +181,8 @@ describe('AuditLogs', () => {
         const options: AuditLogExportOptions = {
           actions: ['foo', 'bar'],
           actors: ['Jon', 'Smith'],
+          actor_names: ['Jon', 'Smith'],
+          actor_ids: ['user_foo', 'user_bar'],
           organization_id: 'org_123',
           range_end: new Date(),
           range_start: new Date(),

--- a/src/audit-logs/interfaces/audit-log-export-options.interface.ts
+++ b/src/audit-logs/interfaces/audit-log-export-options.interface.ts
@@ -1,6 +1,11 @@
 export interface AuditLogExportOptions {
   actions?: string[];
+  /**
+   * @deprecated Please use `actor_names` instead.
+   */
   actors?: string[];
+  actor_names?: string[];
+  actor_ids?: string[];
   organization_id: string;
   range_end: Date;
   range_start: Date;


### PR DESCRIPTION
## Description

Adds `actor_ids` and deprecates `actors` in favor of `actor_names`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
