### PR TITLE
v2.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.17.0",
+  "version": "2.18.0",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -21,7 +21,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/2.17.0",
+  "User-Agent": "workos-node/2.18.0",
 }
 `;
 
@@ -58,7 +58,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/2.17.0",
+  "User-Agent": "workos-node/2.18.0",
 }
 `;
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -24,7 +24,7 @@ import { Mfa } from './mfa/mfa';
 import { AuditLogs } from './audit-logs/audit-logs';
 import { BadRequestException } from './common/exceptions/bad-request.exception';
 
-const VERSION = '2.17.0';
+const VERSION = '2.18.0';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
 


### PR DESCRIPTION
## Description

### Added

- `actor_ids` parameter added to `auditLogs.createExport` method (#729)
- `actor_names` parameter added to `auditLogs.createExport` method (#729)

### Deprecated

- `actors` parameter of `auditLogs.createExport` method (#729)

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
