### PR TITLE
Add validating state to ConnectionDomain interface

### DIFF
--- a/src/sso/interfaces/connection.interface.ts
+++ b/src/sso/interfaces/connection.interface.ts
@@ -12,7 +12,7 @@ export interface Connection {
   organization_id?: string;
   name: string;
   connection_type: ConnectionType;
-  state: 'draft' | 'active' | 'inactive';
+  state: 'draft' | 'active' | 'inactive' | 'validating';
   /**
    * @deprecated The status parameter has been deprecated. Please use state.
    */


### PR DESCRIPTION
## Description
Add validating state to ConnectionDomain interface

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
