### PR TITLE
Use snake case for Events range params

### DIFF
--- a/src/events/interfaces/list-events-options.interface.ts
+++ b/src/events/interfaces/list-events-options.interface.ts
@@ -2,8 +2,8 @@ import { EventNames } from './event.interface';
 
 export interface ListEventOptions {
   events?: EventNames[];
-  rangeStart?: string;
-  rangeEnd?: string;
+  range_start?: string;
+  range_end?: string;
   limit?: number;
   after?: string;
 }


### PR DESCRIPTION
## Description
Use snake case for range params in the Events API. This makes Events consistent with the rest of our API.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
