### PR TITLE
Fix typo in `MockAdapter`

### DIFF
--- a/src/audit-logs/audit-logs.spec.ts
+++ b/src/audit-logs/audit-logs.spec.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import MockAdapater from 'axios-mock-adapter';
+import MockAdapter from 'axios-mock-adapter';
 
 import { UnauthorizedException } from '../common/exceptions';
 import { BadRequestException } from '../common/exceptions/bad-request.exception';
@@ -8,7 +8,7 @@ import { CreateAuditLogEventOptions } from './interfaces';
 import { AuditLogExportOptions } from './interfaces/audit-log-export-options.interface';
 import { AuditLogExport } from './interfaces/audit-log-export.interface';
 
-const mock = new MockAdapater(axios);
+const mock = new MockAdapter(axios);
 const event: CreateAuditLogEventOptions = {
   action: 'document.updated',
   occurred_at: new Date(),

--- a/src/audit-trail/audit-trail.spec.ts
+++ b/src/audit-trail/audit-trail.spec.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
-import MockAdapater from 'axios-mock-adapter';
+import MockAdapter from 'axios-mock-adapter';
 
 import { EventOptions } from './interfaces/event-options.interface';
 import { UnauthorizedException } from '../common/exceptions';
 import { WorkOS } from '../workos';
 
-const mock = new MockAdapater(axios);
+const mock = new MockAdapter(axios);
 const event: EventOptions = {
   group: 'WorkOS',
   actor_name: 'WorkOS@example.com',

--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
-import MockAdapater from 'axios-mock-adapter';
+import MockAdapter from 'axios-mock-adapter';
 
 import { List } from '../common/interfaces/list.interface';
 import { WorkOS } from '../workos';
 import { Directory, Group, UserWithGroups } from './interfaces';
 
-const mock = new MockAdapater(axios);
+const mock = new MockAdapter(axios);
 
 describe('DirectorySync', () => {
   afterEach(() => mock.resetHistory());

--- a/src/events/events.spec.ts
+++ b/src/events/events.spec.ts
@@ -1,10 +1,10 @@
 import axios from 'axios';
-import MockAdapater from 'axios-mock-adapter';
+import MockAdapter from 'axios-mock-adapter';
 import { List } from '../common/interfaces/list.interface';
 import { WorkOS } from '../workos';
 import { Event } from './interfaces/event.interface';
 
-const mock = new MockAdapater(axios);
+const mock = new MockAdapter(axios);
 
 describe('Event', () => {
   afterEach(() => mock.resetHistory());

--- a/src/portal/portal.spec.ts
+++ b/src/portal/portal.spec.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
-import MockAdapater from 'axios-mock-adapter';
+import MockAdapter from 'axios-mock-adapter';
 import { WorkOS } from '../workos';
 import generateLinkInvalid from './fixtures/generate-link-invalid.json';
 import generateLink from './fixtures/generate-link.json';
 import { GeneratePortalLinkIntent } from './interfaces/generate-portal-link-intent.interface';
 
-const mock = new MockAdapater(axios);
+const mock = new MockAdapter(axios);
 const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
 describe('Portal', () => {

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import MockAdapater from 'axios-mock-adapter';
+import MockAdapter from 'axios-mock-adapter';
 
 import { WorkOS } from './workos';
 import {
@@ -9,7 +9,7 @@ import {
   OauthException,
 } from './common/exceptions';
 
-const mock = new MockAdapater(axios);
+const mock = new MockAdapter(axios);
 
 describe('WorkOS', () => {
   describe('constructor', () => {


### PR DESCRIPTION
## Description

This PR fixes a typo in the imported `MockAdapter` from `axios-mock-adapter`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
