### PR TITLE
Standardize API naming

### DIFF
--- a/src/common/interfaces/get-options.interface.ts
+++ b/src/common/interfaces/get-options.interface.ts
@@ -1,4 +1,4 @@
 export interface GetOptions {
   query?: Record<string, any>;
-  accessToken?: string;
+  access_token?: string;
 }

--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -3,7 +3,7 @@ import MockAdapater from 'axios-mock-adapter';
 
 import { List } from '../common/interfaces/list.interface';
 import { WorkOS } from '../workos';
-import { Directory, Group, UserWithGroups } from './interfaces';
+import { Directory, DirectoryUserWithGroups, Group } from './interfaces';
 
 const mock = new MockAdapater(axios);
 
@@ -38,7 +38,7 @@ describe('DirectorySync', () => {
     },
   };
 
-  const userWithGroupResponse: UserWithGroups = {
+  const userWithGroupResponse: DirectoryUserWithGroups = {
     id: 'user_123',
     custom_attributes: {
       custom: true,
@@ -161,7 +161,7 @@ describe('DirectorySync', () => {
   });
 
   describe('listUsers', () => {
-    const userWithGroupListResponse: List<UserWithGroups> = {
+    const userWithGroupListResponse: List<DirectoryUserWithGroups> = {
       object: 'list',
       data: [userWithGroupResponse],
       list_metadata: {},

--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -1,14 +1,14 @@
 import { WorkOS } from '../workos';
-import { Directory } from './interfaces/directory.interface';
 import { List } from '../common/interfaces/list.interface';
-import { Group } from './interfaces/group.interface';
 import {
-  DefaultCustomAttributes,
-  UserWithGroups,
-} from './interfaces/user.interface';
-import { ListDirectoriesOptions } from './interfaces/list-directories-options.interface';
-import { ListGroupsOptions } from './interfaces/list-groups-options.interface';
-import { ListUsersOptions } from './interfaces/list-users-options.interface';
+  Directory,
+  Group,
+  ListDirectoriesOptions,
+  ListGroupsOptions,
+  ListUsersOptions,
+  DirectoryUserWithGroups,
+} from './interfaces';
+import { DefaultCustomAttributes } from './interfaces/directory_user.interface';
 
 export class DirectorySync {
   constructor(private readonly workos: WorkOS) {}
@@ -40,7 +40,7 @@ export class DirectorySync {
 
   async listUsers<TCustomAttributes extends object = DefaultCustomAttributes>(
     options: ListUsersOptions,
-  ): Promise<List<UserWithGroups<TCustomAttributes>>> {
+  ): Promise<List<DirectoryUserWithGroups<TCustomAttributes>>> {
     const { data } = await this.workos.get(`/directory_users`, {
       query: options,
     });
@@ -49,7 +49,7 @@ export class DirectorySync {
 
   async getUser<TCustomAttributes extends object = DefaultCustomAttributes>(
     user: string,
-  ): Promise<UserWithGroups<TCustomAttributes>> {
+  ): Promise<DirectoryUserWithGroups<TCustomAttributes>> {
     const { data } = await this.workos.get(`/directory_users/${user}`);
     return data;
   }

--- a/src/directory-sync/interfaces/directory_user.interface.ts
+++ b/src/directory-sync/interfaces/directory_user.interface.ts
@@ -2,7 +2,7 @@ import { Group } from './group.interface';
 
 export type DefaultCustomAttributes = Record<string, unknown>;
 
-export interface User<
+export interface DirectoryUser<
   TCustomAttributes extends object = DefaultCustomAttributes,
   TRawAttributes = any,
 > {
@@ -24,8 +24,8 @@ export interface User<
   state: 'active' | 'inactive' | 'suspended';
 }
 
-export interface UserWithGroups<
+export interface DirectoryUserWithGroups<
   TCustomAttributes extends object = DefaultCustomAttributes,
-> extends User<TCustomAttributes> {
+> extends DirectoryUser<TCustomAttributes> {
   groups: Group[];
 }

--- a/src/directory-sync/interfaces/index.ts
+++ b/src/directory-sync/interfaces/index.ts
@@ -1,6 +1,9 @@
 export { Directory } from './directory.interface';
+export {
+  DirectoryUser,
+  DirectoryUserWithGroups,
+} from './directory_user.interface';
 export { Group } from './group.interface';
 export { ListDirectoriesOptions } from './list-directories-options.interface';
 export { ListGroupsOptions } from './list-groups-options.interface';
 export { ListUsersOptions } from './list-users-options.interface';
-export { User, UserWithGroups } from './user.interface';

--- a/src/directory-sync/utils/get-primary-email.spec.ts
+++ b/src/directory-sync/utils/get-primary-email.spec.ts
@@ -1,8 +1,8 @@
 import { getPrimaryEmail } from './get-primary-email';
-import { User } from '../interfaces';
+import { DirectoryUser } from '../interfaces';
 
 describe('getPrimaryEmail', () => {
-  const user: User = {
+  const user: DirectoryUser = {
     id: 'user_123',
     custom_attributes: {
       custom: true,

--- a/src/directory-sync/utils/get-primary-email.ts
+++ b/src/directory-sync/utils/get-primary-email.ts
@@ -1,6 +1,6 @@
-import { User } from '../interfaces/user.interface';
+import { DirectoryUser } from '../interfaces';
 
-export function getPrimaryEmail(user: User): string | undefined {
+export function getPrimaryEmail(user: DirectoryUser): string | undefined {
   const primaryEmail = user.emails?.find((email) => email.primary);
   return primaryEmail?.value;
 }

--- a/src/mfa/interfaces/challenge-factor-options.ts
+++ b/src/mfa/interfaces/challenge-factor-options.ts
@@ -1,8 +1,4 @@
-export type ChallengeFactorOptions =
-  | {
-      authenticationFactorId: string;
-    }
-  | {
-      authenticationFactorId: string;
-      smsTemplate: string;
-    };
+export interface ChallengeFactorOptions {
+  authentication_factor_id: string;
+  sms_template?: string;
+}

--- a/src/mfa/mfa.spec.ts
+++ b/src/mfa/mfa.spec.ts
@@ -190,7 +190,7 @@ describe('MFA', () => {
         });
 
         const challengeResponse = await workos.mfa.challengeFactor({
-          authenticationFactorId: 'auth_factor_1234',
+          authentication_factor_id: 'auth_factor_1234',
         });
 
         expect(challengeResponse).toMatchInlineSnapshot(`
@@ -228,8 +228,8 @@ describe('MFA', () => {
         });
 
         const challengeResponse = await workos.mfa.challengeFactor({
-          authenticationFactorId: 'auth_factor_1234',
-          smsTemplate: 'This is your code: 12345',
+          authentication_factor_id: 'auth_factor_1234',
+          sms_template: 'This is your code: 12345',
         });
 
         expect(challengeResponse).toMatchInlineSnapshot(`

--- a/src/mfa/mfa.ts
+++ b/src/mfa/mfa.ts
@@ -42,13 +42,13 @@ export class Mfa {
     return data;
   }
 
-  async challengeFactor(options: ChallengeFactorOptions): Promise<Challenge> {
+  async challengeFactor({
+    authentication_factor_id,
+    sms_template,
+  }: ChallengeFactorOptions): Promise<Challenge> {
     const { data } = await this.workos.post(
-      `/auth/factors/${options.authenticationFactorId}/challenge`,
-      {
-        sms_template:
-          'smsTemplate' in options ? options.smsTemplate : undefined,
-      },
+      `/auth/factors/${authentication_factor_id}/challenge`,
+      { sms_template },
     );
 
     return data;

--- a/src/passwordless/interfaces/create-passwordless-session-options.interface.ts
+++ b/src/passwordless/interfaces/create-passwordless-session-options.interface.ts
@@ -1,8 +1,8 @@
 export interface CreatePasswordlessSessionOptions {
   type: 'MagicLink';
   email: string;
-  redirectURI?: string;
+  redirect_uri?: string;
   state?: string;
   connection?: string;
-  expiresIn?: number;
+  expires_in?: number;
 }

--- a/src/passwordless/passwordless.spec.ts
+++ b/src/passwordless/passwordless.spec.ts
@@ -28,7 +28,7 @@ describe('Passwordless', () => {
         const session = await workos.passwordless.createSession({
           type: 'MagicLink',
           email,
-          redirectURI,
+          redirect_uri: redirectURI,
         });
 
         expect(session.email).toEqual(email);

--- a/src/passwordless/passwordless.ts
+++ b/src/passwordless/passwordless.ts
@@ -6,16 +6,10 @@ import { SendSessionResponse } from './interfaces/send-session-response.interfac
 export class Passwordless {
   constructor(private readonly workos: WorkOS) {}
 
-  async createSession({
-    redirectURI,
-    expiresIn,
-    ...options
-  }: CreatePasswordlessSessionOptions): Promise<PasswordlessSession> {
-    const { data } = await this.workos.post('/passwordless/sessions', {
-      ...options,
-      redirect_uri: redirectURI,
-      expires_in: expiresIn,
-    });
+  async createSession(
+    payload: CreatePasswordlessSessionOptions,
+  ): Promise<PasswordlessSession> {
+    const { data } = await this.workos.post('/passwordless/sessions', payload);
     return data;
   }
 

--- a/src/portal/portal.spec.ts
+++ b/src/portal/portal.spec.ts
@@ -26,7 +26,7 @@ describe('Portal', () => {
           const { link } = await workos.portal.generateLink({
             intent: GeneratePortalLinkIntent.SSO,
             organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
-            returnUrl: 'https://www.example.com',
+            return_url: 'https://www.example.com',
           });
 
           expect(link).toEqual(
@@ -48,7 +48,7 @@ describe('Portal', () => {
           const { link } = await workos.portal.generateLink({
             intent: GeneratePortalLinkIntent.DSync,
             organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
-            returnUrl: 'https://www.example.com',
+            return_url: 'https://www.example.com',
           });
 
           expect(link).toEqual(
@@ -70,7 +70,7 @@ describe('Portal', () => {
           const { link } = await workos.portal.generateLink({
             intent: GeneratePortalLinkIntent.AuditLogs,
             organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
-            returnUrl: 'https://www.example.com',
+            return_url: 'https://www.example.com',
           });
 
           expect(link).toEqual(
@@ -92,7 +92,7 @@ describe('Portal', () => {
           const { link } = await workos.portal.generateLink({
             intent: GeneratePortalLinkIntent.LogStreams,
             organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
-            returnUrl: 'https://www.example.com',
+            return_url: 'https://www.example.com',
           });
 
           expect(link).toEqual(
@@ -118,7 +118,7 @@ describe('Portal', () => {
           workos.portal.generateLink({
             intent: GeneratePortalLinkIntent.SSO,
             organization: 'bogus-id',
-            returnUrl: 'https://www.example.com',
+            return_url: 'https://www.example.com',
           }),
         ).rejects.toThrowError(
           'Could not find an organization with the id, bogus-id.',

--- a/src/portal/portal.ts
+++ b/src/portal/portal.ts
@@ -7,19 +7,19 @@ export class Portal {
   async generateLink({
     intent,
     organization,
-    returnUrl,
-    successUrl,
+    return_url,
+    success_url,
   }: {
     intent: GeneratePortalLinkIntent;
     organization: string;
-    returnUrl?: string;
-    successUrl?: string;
+    return_url?: string;
+    success_url?: string;
   }): Promise<{ link: string }> {
     const { data } = await this.workos.post('/portal/generate_link', {
       intent,
       organization,
-      return_url: returnUrl,
-      success_url: successUrl,
+      return_url,
+      success_url,
     });
 
     return data;

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SSO SSO getAuthorizationURL with a connection generates an authorize url with the connection 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&connection=connection_123&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
+exports[`SSO SSO getAuthorizationUrl with a connection generates an authorize url with the connection 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&connection=connection_123&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
 
-exports[`SSO SSO getAuthorizationURL with a custom api hostname generates an authorize url with the custom api hostname 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
+exports[`SSO SSO getAuthorizationUrl with a custom api hostname generates an authorize url with the custom api hostname 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
 
-exports[`SSO SSO getAuthorizationURL with a provider generates an authorize url with the provider 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&provider=Google&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
+exports[`SSO SSO getAuthorizationUrl with a provider generates an authorize url with the provider 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&provider=Google&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
 
-exports[`SSO SSO getAuthorizationURL with an \`organization\` generates an authorization URL with the organization 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&organization=organization_123&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
+exports[`SSO SSO getAuthorizationUrl with an \`organization\` generates an authorization URL with the organization 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&organization=organization_123&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
 
-exports[`SSO SSO getAuthorizationURL with no custom api hostname generates an authorize url with the default api hostname 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
+exports[`SSO SSO getAuthorizationUrl with no custom api hostname generates an authorize url with the default api hostname 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
 
-exports[`SSO SSO getAuthorizationURL with no domain or provider throws an error for incomplete arguments 1`] = `"Incomplete arguments. Need to specify either a 'connection', 'organization', 'domain', or 'provider'."`;
+exports[`SSO SSO getAuthorizationUrl with no domain or provider throws an error for incomplete arguments 1`] = `"Incomplete arguments. Need to specify either a 'connection', 'organization', 'domain', or 'provider'."`;
 
-exports[`SSO SSO getAuthorizationURL with state generates an authorize url with the provided state 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state"`;
+exports[`SSO SSO getAuthorizationUrl with state generates an authorize url with the provided state 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state"`;
 
 exports[`SSO SSO getProfileAndToken with all information provided sends a request to the WorkOS api for a profile 1`] = `"client_id=proj_123&client_secret=sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU&grant_type=authorization_code&code=authorization_code"`;
 

--- a/src/sso/interfaces/authorization-url-options.interface.ts
+++ b/src/sso/interfaces/authorization-url-options.interface.ts
@@ -1,5 +1,5 @@
 export interface AuthorizationURLOptions {
-  clientID: string;
+  client_id: string;
   connection?: string;
   organization?: string;
 
@@ -7,9 +7,9 @@ export interface AuthorizationURLOptions {
    * @deprecated Please use `organization` instead.
    */
   domain?: string;
-  domainHint?: string;
-  loginHint?: string;
+  domain_hint?: string;
+  login_hint?: string;
   provider?: string;
-  redirectURI: string;
+  redirect_uri: string;
   state?: string;
 }

--- a/src/sso/interfaces/authorization-url-options.interface.ts
+++ b/src/sso/interfaces/authorization-url-options.interface.ts
@@ -1,4 +1,4 @@
-export interface AuthorizationURLOptions {
+export interface AuthorizationUrlOptions {
   client_id: string;
   connection?: string;
   organization?: string;

--- a/src/sso/interfaces/get-profile-and-token-options.interface.ts
+++ b/src/sso/interfaces/get-profile-and-token-options.interface.ts
@@ -1,4 +1,4 @@
 export interface GetProfileAndTokenOptions {
-  clientID: string;
+  client_id: string;
   code: string;
 }

--- a/src/sso/interfaces/get-profile-options.interface.ts
+++ b/src/sso/interfaces/get-profile-options.interface.ts
@@ -1,3 +1,3 @@
 export interface GetProfileOptions {
-  accessToken: string;
+  access_token: string;
 }

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -5,12 +5,12 @@ import { WorkOS } from '../workos';
 
 describe('SSO', () => {
   describe('SSO', () => {
-    describe('getAuthorizationURL', () => {
+    describe('getAuthorizationUrl', () => {
       describe('with no custom api hostname', () => {
         it('generates an authorize url with the default api hostname', () => {
           const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
-          const url = workos.sso.getAuthorizationURL({
+          const url = workos.sso.getAuthorizationUrl({
             domain: 'lyft.com',
             client_id: 'proj_123',
             redirect_uri: 'example.com/sso/workos/callback',
@@ -25,7 +25,7 @@ describe('SSO', () => {
           const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
           const urlFn = () =>
-            workos.sso.getAuthorizationURL({
+            workos.sso.getAuthorizationUrl({
               client_id: 'proj_123',
               redirect_uri: 'example.com/sso/workos/callback',
             });
@@ -40,7 +40,7 @@ describe('SSO', () => {
             apiHostname: 'api.workos.dev',
           });
 
-          const url = workos.sso.getAuthorizationURL({
+          const url = workos.sso.getAuthorizationUrl({
             provider: 'Google',
             client_id: 'proj_123',
             redirect_uri: 'example.com/sso/workos/callback',
@@ -56,7 +56,7 @@ describe('SSO', () => {
             apiHostname: 'api.workos.dev',
           });
 
-          const url = workos.sso.getAuthorizationURL({
+          const url = workos.sso.getAuthorizationUrl({
             connection: 'connection_123',
             client_id: 'proj_123',
             redirect_uri: 'example.com/sso/workos/callback',
@@ -72,7 +72,7 @@ describe('SSO', () => {
             apiHostname: 'api.workos.dev',
           });
 
-          const url = workos.sso.getAuthorizationURL({
+          const url = workos.sso.getAuthorizationUrl({
             organization: 'organization_123',
             client_id: 'proj_123',
             redirect_uri: 'example.com/sso/workos/callback',
@@ -88,7 +88,7 @@ describe('SSO', () => {
             apiHostname: 'api.workos.dev',
           });
 
-          const url = workos.sso.getAuthorizationURL({
+          const url = workos.sso.getAuthorizationUrl({
             domain: 'lyft.com',
             client_id: 'proj_123',
             redirect_uri: 'example.com/sso/workos/callback',
@@ -102,7 +102,7 @@ describe('SSO', () => {
         it('generates an authorize url with the provided state', () => {
           const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
-          const url = workos.sso.getAuthorizationURL({
+          const url = workos.sso.getAuthorizationUrl({
             domain: 'lyft.com',
             client_id: 'proj_123',
             redirect_uri: 'example.com/sso/workos/callback',
@@ -117,7 +117,7 @@ describe('SSO', () => {
         it('generates an authorize url with the provided domain hint', () => {
           const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
-          const url = workos.sso.getAuthorizationURL({
+          const url = workos.sso.getAuthorizationUrl({
             domain_hint: 'lyft.com',
             connection: 'connection_123',
             client_id: 'proj_123',
@@ -135,7 +135,7 @@ describe('SSO', () => {
         it('generates an authorize url with the provided login hint', () => {
           const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
-          const url = workos.sso.getAuthorizationURL({
+          const url = workos.sso.getAuthorizationUrl({
             login_hint: 'foo@workos.com',
             connection: 'connection_123',
             client_id: 'proj_123',

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -280,7 +280,7 @@ describe('SSO', () => {
 
         mock
           .onGet('/sso/profile', {
-            accessToken: 'access_token',
+            access_token: 'access_token',
           })
           .replyOnce(200, {
             id: 'prof_123',
@@ -302,7 +302,7 @@ describe('SSO', () => {
 
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
         const profile = await workos.sso.getProfile({
-          accessToken: 'access_token',
+          access_token: 'access_token',
         });
 
         expect(mock.history.get.length).toBe(1);

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -12,8 +12,8 @@ describe('SSO', () => {
 
           const url = workos.sso.getAuthorizationURL({
             domain: 'lyft.com',
-            clientID: 'proj_123',
-            redirectURI: 'example.com/sso/workos/callback',
+            client_id: 'proj_123',
+            redirect_uri: 'example.com/sso/workos/callback',
           });
 
           expect(url).toMatchSnapshot();
@@ -26,8 +26,8 @@ describe('SSO', () => {
 
           const urlFn = () =>
             workos.sso.getAuthorizationURL({
-              clientID: 'proj_123',
-              redirectURI: 'example.com/sso/workos/callback',
+              client_id: 'proj_123',
+              redirect_uri: 'example.com/sso/workos/callback',
             });
 
           expect(urlFn).toThrowErrorMatchingSnapshot();
@@ -42,8 +42,8 @@ describe('SSO', () => {
 
           const url = workos.sso.getAuthorizationURL({
             provider: 'Google',
-            clientID: 'proj_123',
-            redirectURI: 'example.com/sso/workos/callback',
+            client_id: 'proj_123',
+            redirect_uri: 'example.com/sso/workos/callback',
           });
 
           expect(url).toMatchSnapshot();
@@ -58,8 +58,8 @@ describe('SSO', () => {
 
           const url = workos.sso.getAuthorizationURL({
             connection: 'connection_123',
-            clientID: 'proj_123',
-            redirectURI: 'example.com/sso/workos/callback',
+            client_id: 'proj_123',
+            redirect_uri: 'example.com/sso/workos/callback',
           });
 
           expect(url).toMatchSnapshot();
@@ -74,8 +74,8 @@ describe('SSO', () => {
 
           const url = workos.sso.getAuthorizationURL({
             organization: 'organization_123',
-            clientID: 'proj_123',
-            redirectURI: 'example.com/sso/workos/callback',
+            client_id: 'proj_123',
+            redirect_uri: 'example.com/sso/workos/callback',
           });
 
           expect(url).toMatchSnapshot();
@@ -90,8 +90,8 @@ describe('SSO', () => {
 
           const url = workos.sso.getAuthorizationURL({
             domain: 'lyft.com',
-            clientID: 'proj_123',
-            redirectURI: 'example.com/sso/workos/callback',
+            client_id: 'proj_123',
+            redirect_uri: 'example.com/sso/workos/callback',
           });
 
           expect(url).toMatchSnapshot();
@@ -104,8 +104,8 @@ describe('SSO', () => {
 
           const url = workos.sso.getAuthorizationURL({
             domain: 'lyft.com',
-            clientID: 'proj_123',
-            redirectURI: 'example.com/sso/workos/callback',
+            client_id: 'proj_123',
+            redirect_uri: 'example.com/sso/workos/callback',
             state: 'custom state',
           });
 
@@ -118,10 +118,10 @@ describe('SSO', () => {
           const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
           const url = workos.sso.getAuthorizationURL({
-            domainHint: 'lyft.com',
+            domain_hint: 'lyft.com',
             connection: 'connection_123',
-            clientID: 'proj_123',
-            redirectURI: 'example.com/sso/workos/callback',
+            client_id: 'proj_123',
+            redirect_uri: 'example.com/sso/workos/callback',
             state: 'custom state',
           });
 
@@ -136,10 +136,10 @@ describe('SSO', () => {
           const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
           const url = workos.sso.getAuthorizationURL({
-            loginHint: 'foo@workos.com',
+            login_hint: 'foo@workos.com',
             connection: 'connection_123',
-            clientID: 'proj_123',
-            redirectURI: 'example.com/sso/workos/callback',
+            client_id: 'proj_123',
+            redirect_uri: 'example.com/sso/workos/callback',
             state: 'custom state',
           });
 
@@ -200,7 +200,7 @@ describe('SSO', () => {
           const { access_token: accessToken, profile } =
             await workos.sso.getProfileAndToken({
               code: 'authorization_code',
-              clientID: 'proj_123',
+              client_id: 'proj_123',
             });
 
           expect(mock.history.post.length).toBe(1);
@@ -260,7 +260,7 @@ describe('SSO', () => {
           const { access_token: accessToken, profile } =
             await workos.sso.getProfileAndToken({
               code: 'authorization_code',
-              clientID: 'proj_123',
+              client_id: 'proj_123',
             });
 
           expect(mock.history.post.length).toBe(1);

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -89,9 +89,9 @@ export class SSO {
     return data;
   }
 
-  async getProfile({ accessToken }: GetProfileOptions): Promise<Profile> {
+  async getProfile({ access_token }: GetProfileOptions): Promise<Profile> {
     const { data } = await this.workos.get('/sso/profile', {
-      accessToken,
+      access_token,
     });
 
     return data;

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -32,13 +32,13 @@ export class SSO {
 
   getAuthorizationURL({
     connection,
-    clientID,
+    client_id,
     domain,
-    domainHint,
-    loginHint,
+    domain_hint,
+    login_hint,
     organization,
     provider,
-    redirectURI,
+    redirect_uri,
     state,
   }: AuthorizationURLOptions): string {
     if (!domain && !provider && !connection && !organization) {
@@ -57,11 +57,11 @@ export class SSO {
       connection,
       organization,
       domain,
-      domain_hint: domainHint,
-      login_hint: loginHint,
+      domain_hint,
+      login_hint,
       provider,
-      client_id: clientID,
-      redirect_uri: redirectURI,
+      client_id,
+      redirect_uri,
       response_type: 'code',
       state,
     });
@@ -76,10 +76,10 @@ export class SSO {
 
   async getProfileAndToken({
     code,
-    clientID,
+    client_id,
   }: GetProfileAndTokenOptions): Promise<ProfileAndToken> {
     const form = new URLSearchParams({
-      client_id: clientID,
+      client_id,
       client_secret: this.workos.key as string,
       grant_type: 'authorization_code',
       code,

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -1,6 +1,6 @@
 import { List } from '../common/interfaces/list.interface';
 import { WorkOS } from '../workos';
-import { AuthorizationURLOptions } from './interfaces/authorization-url-options.interface';
+import { AuthorizationUrlOptions } from './interfaces/authorization-url-options.interface';
 import { Connection } from './interfaces/connection.interface';
 import { GetProfileAndTokenOptions } from './interfaces/get-profile-and-token-options.interface';
 import { GetProfileOptions } from './interfaces/get-profile-options.interface';
@@ -30,7 +30,7 @@ export class SSO {
     await this.workos.delete(`/connections/${id}`);
   }
 
-  getAuthorizationURL({
+  getAuthorizationUrl({
     connection,
     client_id,
     domain,
@@ -40,7 +40,7 @@ export class SSO {
     provider,
     redirect_uri,
     state,
-  }: AuthorizationURLOptions): string {
+  }: AuthorizationUrlOptions): string {
     if (!domain && !provider && !connection && !organization) {
       throw new Error(
         `Incomplete arguments. Need to specify either a 'connection', 'organization', 'domain', or 'provider'.`,
@@ -49,7 +49,7 @@ export class SSO {
 
     if (domain) {
       this.workos.emitWarning(
-        'The `domain` parameter for `getAuthorizationURL` is deprecated. Please use `organization` instead.',
+        'The `domain` parameter for `getAuthorizationUrl` is deprecated. Please use `organization` instead.',
       );
     }
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -103,13 +103,13 @@ export class WorkOS {
 
   async get(path: string, options: GetOptions = {}): Promise<AxiosResponse> {
     try {
-      const { accessToken } = options;
+      const { access_token } = options;
 
       return await this.client.get(path, {
         params: options.query,
-        headers: accessToken
+        headers: access_token
           ? {
-              Authorization: `Bearer ${accessToken}`,
+              Authorization: `Bearer ${access_token}`,
             }
           : undefined,
       });


### PR DESCRIPTION
## Description

- rename `accessToken` to `access_token`
- Make SSO interface properties snake_case
- SSO.getAuthorizationURL -> SSO.getAuthorizationUrl
- Make MFA interfaces use snake_case
- Make admin portal interfaces use snake_case
- Make passwordless interfaces use snake_case
- Rename User to DirectoryUser

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
