### PR TITLE
Make user management APIs camelCase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-user-management.2",
+  "version": "3.0.0-user-management.3",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -21,7 +21,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/3.0.0-user-management.2",
+  "User-Agent": "workos-node/3.0.0-user-management.3",
 }
 `;
 
@@ -58,7 +58,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/3.0.0-user-management.2",
+  "User-Agent": "workos-node/3.0.0-user-management.3",
 }
 `;
 

--- a/src/users/interfaces/add-user-to-organization-options.interface.ts
+++ b/src/users/interfaces/add-user-to-organization-options.interface.ts
@@ -1,4 +1,4 @@
 export interface AddUserToOrganizationOptions {
-  user_id: string;
-  organization_id: string;
+  userId: string;
+  organizationId: string;
 }

--- a/src/users/interfaces/authenticate-user-with-password-options.interface.ts
+++ b/src/users/interfaces/authenticate-user-with-password-options.interface.ts
@@ -1,8 +1,8 @@
 export interface AuthenticateUserWithPasswordOptions {
   email: string;
   password: string;
-  ip_address?: string;
-  user_agent?: string;
-  start_session?: boolean;
-  expires_in?: number;
+  ipAddress?: string;
+  userAgent?: string;
+  startSession?: boolean;
+  expiresIn?: number;
 }

--- a/src/users/interfaces/authenticate-user-with-token-options.interface.ts
+++ b/src/users/interfaces/authenticate-user-with-token-options.interface.ts
@@ -1,6 +1,6 @@
 export interface AuthenticateUserWithTokenOptions {
-  client_id: string;
+  clientId: string;
   code: string;
-  start_session?: boolean;
-  expires_in?: number;
+  startSession?: boolean;
+  expiresIn?: number;
 }

--- a/src/users/interfaces/complete-password-reset-options.interface.ts
+++ b/src/users/interfaces/complete-password-reset-options.interface.ts
@@ -1,4 +1,4 @@
 export interface CompletePasswordResetOptions {
   token: string;
-  new_password: string;
+  newPassword: string;
 }

--- a/src/users/interfaces/create-email-verification-challenge-options.interface.ts
+++ b/src/users/interfaces/create-email-verification-challenge-options.interface.ts
@@ -1,8 +1,8 @@
 import { User } from './user.interface';
 
 export interface CreateEmailVerificationChallengeOptions {
-  user_id: string;
-  verification_url: string;
+  userId: string;
+  verificationUrl: string;
 }
 
 export interface CreateEmailVerificationChallengeResponse {

--- a/src/users/interfaces/create-password-reset-challenge-options.interface.ts
+++ b/src/users/interfaces/create-password-reset-challenge-options.interface.ts
@@ -2,7 +2,7 @@ import { User } from './user.interface';
 
 export interface CreatePasswordResetChallengeOptions {
   email: string;
-  password_reset_url: string;
+  passwordResetUrl: string;
 }
 
 export interface CreatePasswordResetChallengeResponse {

--- a/src/users/interfaces/create-user-options.interface.ts
+++ b/src/users/interfaces/create-user-options.interface.ts
@@ -1,7 +1,7 @@
 export interface CreateUserOptions {
   email: string;
   password: string;
-  first_name?: string;
-  last_name?: string;
-  email_verified?: boolean;
+  firstName?: string;
+  lastName?: string;
+  emailVerified?: boolean;
 }

--- a/src/users/interfaces/remove-user-from-organization-options.interface.ts
+++ b/src/users/interfaces/remove-user-from-organization-options.interface.ts
@@ -1,4 +1,4 @@
 export interface RemoveUserFromOrganizationOptions {
-  user_id: string;
-  organization_id: string;
+  userId: string;
+  organizationId: string;
 }

--- a/src/users/interfaces/revoke-session-options.interface.ts
+++ b/src/users/interfaces/revoke-session-options.interface.ts
@@ -1,9 +1,9 @@
 export type RevokeSessionOptions = SessionId | SessionToken;
 
 interface SessionId {
-  session_id: string;
+  sessionId: string;
 }
 
 interface SessionToken {
-  session_token: string;
+  sessionToken: string;
 }

--- a/src/users/interfaces/verify-session.interface.ts
+++ b/src/users/interfaces/verify-session.interface.ts
@@ -3,7 +3,7 @@ import { Session } from './session.interface';
 
 export interface VerifySessionOptions {
   token: string;
-  client_id: string;
+  clientId: string;
 }
 
 export interface VerifySessionResponse {

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -76,9 +76,9 @@ describe('UserManagement', () => {
       const user = await workos.users.createUser({
         email: 'test01@example.com',
         password: 'extra-secure',
-        first_name: 'Test 01',
-        last_name: 'User',
-        email_verified: true,
+        firstName: 'Test 01',
+        lastName: 'User',
+        emailVerified: true,
       });
 
       expect(mock.history.post[0].url).toEqual('/users');
@@ -116,9 +116,9 @@ describe('UserManagement', () => {
         .onPost('/users/sessions/token')
         .reply(200, { user: userFixture, session: sessionFixture });
       const resp = await workos.users.authenticateUserWithToken({
-        client_id: 'proj_whatever',
+        clientId: 'proj_whatever',
         code: 'or this',
-        expires_in: 15,
+        expiresIn: 15,
       });
 
       expect(mock.history.post[0].url).toEqual('/users/sessions/token');
@@ -147,7 +147,7 @@ describe('UserManagement', () => {
       });
 
       const resp = await workos.users.verifySession({
-        client_id: 'proj_something',
+        clientId: 'proj_something',
         token: 'really-long-token',
       });
 
@@ -169,7 +169,7 @@ describe('UserManagement', () => {
       mock.onPost('/users/sessions/revocations').reply(200, true);
 
       const revoked = await workos.users.revokeSession({
-        session_id: 'session_01H5K05VP5CPCXJA5Z7G191GS4',
+        sessionId: 'session_01H5K05VP5CPCXJA5Z7G191GS4',
       });
 
       expect(mock.history.post[0].url).toEqual('/users/sessions/revocations');
@@ -180,7 +180,7 @@ describe('UserManagement', () => {
       mock.onPost('/users/sessions/revocations').reply(200, true);
 
       const revoked = await workos.users.revokeSession({
-        session_token: 'really-long-token',
+        sessionToken: 'really-long-token',
       });
 
       expect(mock.history.post[0].url).toEqual('/users/sessions/revocations');
@@ -205,8 +205,8 @@ describe('UserManagement', () => {
         user: userFixture,
       });
       const resp = await workos.users.createEmailVerificationChallenge({
-        user_id: userId,
-        verification_url: 'https://example.com/verify-email',
+        userId: userId,
+        verificationUrl: 'https://example.com/verify-email',
       });
 
       expect(mock.history.post[0].url).toEqual(
@@ -248,7 +248,7 @@ describe('UserManagement', () => {
       });
       const resp = await workos.users.createPasswordResetChallenge({
         email: 'test01@example.com',
-        password_reset_url: 'https://example.com/forgot-password',
+        passwordResetUrl: 'https://example.com/forgot-password',
       });
 
       expect(mock.history.post[0].url).toEqual(
@@ -271,7 +271,7 @@ describe('UserManagement', () => {
       });
       const resp = await workos.users.completePasswordReset({
         token: '',
-        new_password: 'correct horse battery staple',
+        newPassword: 'correct horse battery staple',
       });
 
       expect(mock.history.post[0].url).toEqual(`/users/password_reset`);
@@ -290,8 +290,8 @@ describe('UserManagement', () => {
         user: userFixture,
       });
       const resp = await workos.users.addUserToOrganization({
-        user_id: userId,
-        organization_id: 'org_coolorg',
+        userId: userId,
+        organizationId: 'org_coolorg',
       });
 
       expect(mock.history.post[0].url).toEqual(
@@ -313,8 +313,8 @@ describe('UserManagement', () => {
         user: userFixture,
       });
       const resp = await workos.users.removeUserFromOrganization({
-        user_id: userId,
-        organization_id: orgId,
+        userId: userId,
+        organizationId: orgId,
       });
 
       expect(mock.history.delete[0].url).toEqual(

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -79,13 +79,13 @@ export class Users {
   }
 
   async createEmailVerificationChallenge({
-    user_id,
-    verification_url,
+    userId,
+    verificationUrl,
   }: CreateEmailVerificationChallengeOptions): Promise<CreateEmailVerificationChallengeResponse> {
     const { data } = await this.workos.post(
-      `/users/${user_id}/email_verification_challenge`,
+      `/users/${userId}/email_verification_challenge`,
       {
-        verification_url,
+        verification_url: verificationUrl,
       },
     );
     return data;
@@ -116,21 +116,21 @@ export class Users {
   }
 
   async addUserToOrganization({
-    user_id,
-    organization_id,
+    userId,
+    organizationId,
   }: AddUserToOrganizationOptions): Promise<User> {
-    const { data } = await this.workos.post(`/users/${user_id}/organizations`, {
-      organization_id,
+    const { data } = await this.workos.post(`/users/${userId}/organizations`, {
+      organizationId,
     });
     return data;
   }
 
   async removeUserFromOrganization({
-    user_id,
-    organization_id,
+    userId,
+    organizationId,
   }: RemoveUserFromOrganizationOptions): Promise<User> {
     const { data } = await this.workos.delete(
-      `/users/${user_id}/organizations/${organization_id}`,
+      `/users/${userId}/organizations/${organizationId}`,
     );
     return data;
   }

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -26,7 +26,7 @@ import { AuditLogs } from './audit-logs/audit-logs';
 import { Users } from './users/users';
 import { BadRequestException } from './common/exceptions/bad-request.exception';
 
-const VERSION = '3.0.0-user-management.2';
+const VERSION = '3.0.0-user-management.3';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
 


### PR DESCRIPTION
## Description

- Bump version to 3.0.0-user-management.3
- Convert user API params to camelCase

NOTE: this doesn't affect the responses of the API. Do we want to transform
those to camelCase too?

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
