### PR TITLE
Rename User interface to DirectoryUser

### DIFF
--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -3,7 +3,7 @@ import MockAdapter from 'axios-mock-adapter';
 
 import { List } from '../common/interfaces/list.interface';
 import { WorkOS } from '../workos';
-import { Directory, Group, UserWithGroups } from './interfaces';
+import { Directory, Group, DirectoryUserWithGroups } from './interfaces';
 
 const mock = new MockAdapter(axios);
 
@@ -38,7 +38,7 @@ describe('DirectorySync', () => {
     },
   };
 
-  const userWithGroupResponse: UserWithGroups = {
+  const userWithGroupResponse: DirectoryUserWithGroups = {
     id: 'user_123',
     custom_attributes: {
       custom: true,
@@ -161,7 +161,7 @@ describe('DirectorySync', () => {
   });
 
   describe('listUsers', () => {
-    const userWithGroupListResponse: List<UserWithGroups> = {
+    const userWithGroupListResponse: List<DirectoryUserWithGroups> = {
       object: 'list',
       data: [userWithGroupResponse],
       list_metadata: {},

--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -4,8 +4,8 @@ import { List } from '../common/interfaces/list.interface';
 import { Group } from './interfaces/group.interface';
 import {
   DefaultCustomAttributes,
-  UserWithGroups,
-} from './interfaces/user.interface';
+  DirectoryUserWithGroups,
+} from './interfaces/directory-user.interface';
 import { ListDirectoriesOptions } from './interfaces/list-directories-options.interface';
 import { ListGroupsOptions } from './interfaces/list-groups-options.interface';
 import { ListUsersOptions } from './interfaces/list-users-options.interface';
@@ -40,7 +40,7 @@ export class DirectorySync {
 
   async listUsers<TCustomAttributes extends object = DefaultCustomAttributes>(
     options: ListUsersOptions,
-  ): Promise<List<UserWithGroups<TCustomAttributes>>> {
+  ): Promise<List<DirectoryUserWithGroups<TCustomAttributes>>> {
     const { data } = await this.workos.get(`/directory_users`, {
       query: options,
     });
@@ -49,7 +49,7 @@ export class DirectorySync {
 
   async getUser<TCustomAttributes extends object = DefaultCustomAttributes>(
     user: string,
-  ): Promise<UserWithGroups<TCustomAttributes>> {
+  ): Promise<DirectoryUserWithGroups<TCustomAttributes>> {
     const { data } = await this.workos.get(`/directory_users/${user}`);
     return data;
   }

--- a/src/directory-sync/interfaces/directory-user.interface.ts
+++ b/src/directory-sync/interfaces/directory-user.interface.ts
@@ -2,7 +2,7 @@ import { Group } from './group.interface';
 
 export type DefaultCustomAttributes = Record<string, unknown>;
 
-export interface User<
+export interface DirectoryUser<
   TCustomAttributes extends object = DefaultCustomAttributes,
   TRawAttributes = any,
 > {
@@ -24,8 +24,8 @@ export interface User<
   state: 'active' | 'inactive' | 'suspended';
 }
 
-export interface UserWithGroups<
+export interface DirectoryUserWithGroups<
   TCustomAttributes extends object = DefaultCustomAttributes,
-> extends User<TCustomAttributes> {
+> extends DirectoryUser<TCustomAttributes> {
   groups: Group[];
 }

--- a/src/directory-sync/interfaces/index.ts
+++ b/src/directory-sync/interfaces/index.ts
@@ -3,4 +3,7 @@ export { Group } from './group.interface';
 export { ListDirectoriesOptions } from './list-directories-options.interface';
 export { ListGroupsOptions } from './list-groups-options.interface';
 export { ListUsersOptions } from './list-users-options.interface';
-export { User, UserWithGroups } from './user.interface';
+export {
+  DirectoryUser,
+  DirectoryUserWithGroups,
+} from './directory-user.interface';

--- a/src/directory-sync/utils/get-primary-email.spec.ts
+++ b/src/directory-sync/utils/get-primary-email.spec.ts
@@ -1,8 +1,8 @@
 import { getPrimaryEmail } from './get-primary-email';
-import { User } from '../interfaces';
+import { DirectoryUser } from '../interfaces';
 
 describe('getPrimaryEmail', () => {
-  const user: User = {
+  const user: DirectoryUser = {
     id: 'user_123',
     custom_attributes: {
       custom: true,

--- a/src/directory-sync/utils/get-primary-email.ts
+++ b/src/directory-sync/utils/get-primary-email.ts
@@ -1,6 +1,6 @@
-import { User } from '../interfaces/user.interface';
+import { DirectoryUser } from '../interfaces/directory-user.interface';
 
-export function getPrimaryEmail(user: User): string | undefined {
+export function getPrimaryEmail(user: DirectoryUser): string | undefined {
   const primaryEmail = user.emails?.find((email) => email.primary);
   return primaryEmail?.value;
 }

--- a/src/webhooks/interfaces/webhook-directory-user.interface.ts
+++ b/src/webhooks/interfaces/webhook-directory-user.interface.ts
@@ -1,6 +1,6 @@
-import { User } from '../../directory-sync/interfaces';
+import { DirectoryUser } from '../../directory-sync/interfaces';
 
-export interface WebhookDirectoryUser extends User {
+export interface WebhookDirectoryUser extends DirectoryUser {
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Description

* This is a breaking change to rename the User interface, which is taking up a namespace that we would otherwise like to use, to DirectoryUser. This aligns the interface with the naming used elsewhere across the WorkOS platform.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
