### PR TITLE
Rename Group interface to DirectoryGroup

### DIFF
--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -3,7 +3,11 @@ import MockAdapter from 'axios-mock-adapter';
 
 import { List } from '../common/interfaces/list.interface';
 import { WorkOS } from '../workos';
-import { Directory, Group, DirectoryUserWithGroups } from './interfaces';
+import {
+  Directory,
+  DirectoryGroup,
+  DirectoryUserWithGroups,
+} from './interfaces';
 
 const mock = new MockAdapter(axios);
 
@@ -25,7 +29,7 @@ describe('DirectorySync', () => {
     updated_at: '2021-10-27 15:21:50.640958',
   };
 
-  const groupResponse: Group = {
+  const groupResponse: DirectoryGroup = {
     id: 'dir_grp_123',
     idp_id: '123',
     directory_id: 'dir_123',
@@ -121,7 +125,7 @@ describe('DirectorySync', () => {
   });
 
   describe('listGroups', () => {
-    const groupListResponse: List<Group> = {
+    const groupListResponse: List<DirectoryGroup> = {
       object: 'list',
       data: [groupResponse],
       list_metadata: {},

--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '../workos';
 import { Directory } from './interfaces/directory.interface';
 import { List } from '../common/interfaces/list.interface';
-import { Group } from './interfaces/group.interface';
+import { DirectoryGroup } from './interfaces/directory-group.interface';
 import {
   DefaultCustomAttributes,
   DirectoryUserWithGroups,
@@ -31,7 +31,7 @@ export class DirectorySync {
     await this.workos.delete(`/directories/${id}`);
   }
 
-  async listGroups(options: ListGroupsOptions): Promise<List<Group>> {
+  async listGroups(options: ListGroupsOptions): Promise<List<DirectoryGroup>> {
     const { data } = await this.workos.get(`/directory_groups`, {
       query: options,
     });
@@ -54,7 +54,7 @@ export class DirectorySync {
     return data;
   }
 
-  async getGroup(group: string): Promise<Group> {
+  async getGroup(group: string): Promise<DirectoryGroup> {
     const { data } = await this.workos.get(`/directory_groups/${group}`);
     return data;
   }

--- a/src/directory-sync/interfaces/directory-group.interface.ts
+++ b/src/directory-sync/interfaces/directory-group.interface.ts
@@ -1,4 +1,4 @@
-export interface Group {
+export interface DirectoryGroup {
   id: string;
   idp_id: string;
   directory_id: string;

--- a/src/directory-sync/interfaces/directory-user.interface.ts
+++ b/src/directory-sync/interfaces/directory-user.interface.ts
@@ -1,4 +1,4 @@
-import { Group } from './group.interface';
+import { DirectoryGroup } from './directory-group.interface';
 
 export type DefaultCustomAttributes = Record<string, unknown>;
 
@@ -27,5 +27,5 @@ export interface DirectoryUser<
 export interface DirectoryUserWithGroups<
   TCustomAttributes extends object = DefaultCustomAttributes,
 > extends DirectoryUser<TCustomAttributes> {
-  groups: Group[];
+  groups: DirectoryGroup[];
 }

--- a/src/directory-sync/interfaces/index.ts
+++ b/src/directory-sync/interfaces/index.ts
@@ -1,5 +1,5 @@
 export { Directory } from './directory.interface';
-export { Group } from './group.interface';
+export { DirectoryGroup } from './directory-group.interface';
 export { ListDirectoriesOptions } from './list-directories-options.interface';
 export { ListGroupsOptions } from './list-groups-options.interface';
 export { ListUsersOptions } from './list-users-options.interface';


### PR DESCRIPTION
## Description

* This is a breaking change to rename the Group interface. While not strictly necessary as the User -> DirectoryUser rename was, this is done to keep consistency across the SDK and to closer align the Node SDK interfaces with other SDKs and with the rest of our platform.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
