### PR TITLE
Rename ListUsersOptions to ListDirectoryUserOptions

### DIFF
--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -8,7 +8,7 @@ import {
 } from './interfaces/directory-user.interface';
 import { ListDirectoriesOptions } from './interfaces/list-directories-options.interface';
 import { ListGroupsOptions } from './interfaces/list-groups-options.interface';
-import { ListUsersOptions } from './interfaces/list-users-options.interface';
+import { ListDirectoryUsersOptions } from './interfaces/list-directory-users-options.interface';
 
 export class DirectorySync {
   constructor(private readonly workos: WorkOS) {}
@@ -39,7 +39,7 @@ export class DirectorySync {
   }
 
   async listUsers<TCustomAttributes extends object = DefaultCustomAttributes>(
-    options: ListUsersOptions,
+    options: ListDirectoryUsersOptions,
   ): Promise<List<DirectoryUserWithGroups<TCustomAttributes>>> {
     const { data } = await this.workos.get(`/directory_users`, {
       query: options,

--- a/src/directory-sync/interfaces/index.ts
+++ b/src/directory-sync/interfaces/index.ts
@@ -2,7 +2,7 @@ export { Directory } from './directory.interface';
 export { DirectoryGroup } from './directory-group.interface';
 export { ListDirectoriesOptions } from './list-directories-options.interface';
 export { ListGroupsOptions } from './list-groups-options.interface';
-export { ListUsersOptions } from './list-users-options.interface';
+export { ListDirectoryUsersOptions } from './list-directory-users-options.interface';
 export {
   DirectoryUser,
   DirectoryUserWithGroups,

--- a/src/directory-sync/interfaces/list-directory-users-options.interface.ts
+++ b/src/directory-sync/interfaces/list-directory-users-options.interface.ts
@@ -1,6 +1,6 @@
 import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
 
-export interface ListUsersOptions extends PaginationOptions {
+export interface ListDirectoryUsersOptions extends PaginationOptions {
   directory?: string;
   group?: string;
 }


### PR DESCRIPTION
## Description

This frees up the `ListUserOptions` name for user management.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
