### PR TITLE
Migrate Audit Logs to camelCased

### DIFF
--- a/src/audit-logs/audit-logs.spec.ts
+++ b/src/audit-logs/audit-logs.spec.ts
@@ -1,17 +1,22 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-
+import { AxiosError } from 'axios';
 import { UnauthorizedException } from '../common/exceptions';
 import { BadRequestException } from '../common/exceptions/bad-request.exception';
+import { mockWorkOsResponse } from '../common/utils/workos-mock-response';
 import { WorkOS } from '../workos';
-import { CreateAuditLogEventOptions } from './interfaces';
-import { AuditLogExportOptions } from './interfaces/audit-log-export-options.interface';
-import { AuditLogExport } from './interfaces/audit-log-export.interface';
+import {
+  AuditLogExport,
+  AuditLogExportOptions,
+  AuditLogExportResponse,
+  CreateAuditLogEventOptions,
+} from './interfaces';
+import {
+  serializeAuditLogExportOptions,
+  serializeCreateAuditLogEventOptions,
+} from './serializers';
 
-const mock = new MockAdapter(axios);
 const event: CreateAuditLogEventOptions = {
   action: 'document.updated',
-  occurred_at: new Date(),
+  occurredAt: new Date(),
   actor: {
     id: 'user_1',
     name: 'Jon Smith',
@@ -24,29 +29,23 @@ const event: CreateAuditLogEventOptions = {
     },
   ],
   context: {
-    location: ' 192.0.0.8',
-    user_agent: 'Firefox',
+    location: '192.0.0.8',
+    userAgent: 'Firefox',
   },
   metadata: {
     successful: true,
   },
 };
 
-const serializeEventOptions = (options: CreateAuditLogEventOptions) => ({
-  ...options,
-  occurred_at: options.occurred_at.toISOString(),
-});
-
 describe('AuditLogs', () => {
   describe('createEvent', () => {
     describe('with an idempotency key', () => {
       it('includes an idempotency key with request', async () => {
-        mock
-          .onPost('/audit_logs/events', {
-            event: serializeEventOptions(event),
-            organization_id: 'org_123',
-          })
-          .replyOnce(201, { success: true });
+        const workosSpy = jest.spyOn(WorkOS.prototype, 'post');
+
+        workosSpy.mockResolvedValueOnce(
+          mockWorkOsResponse(201, { success: true }),
+        );
 
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
@@ -56,54 +55,65 @@ describe('AuditLogs', () => {
           }),
         ).resolves.toBeUndefined();
 
-        expect(mock.history.post[0].headers?.['Idempotency-Key']).toEqual(
-          'the-idempotency-key',
+        expect(workosSpy).toHaveBeenCalledWith(
+          '/audit_logs/events',
+          {
+            event: serializeCreateAuditLogEventOptions(event),
+            organization_id: 'org_123',
+          },
+          { idempotencyKey: 'the-idempotency-key' },
         );
       });
     });
 
     describe('when the api responds with a 200', () => {
       it('returns void', async () => {
-        mock
-          .onPost('/audit_logs/events', {
-            organization_id: 'org_123',
-            event: serializeEventOptions(event),
-          })
-          .replyOnce(201, { success: true });
+        const workosSpy = jest.spyOn(WorkOS.prototype, 'post');
+
+        workosSpy.mockResolvedValueOnce(
+          mockWorkOsResponse(201, { success: true }),
+        );
 
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
         await expect(
           workos.auditLogs.createEvent('org_123', event),
         ).resolves.toBeUndefined();
+
+        expect(workosSpy).toHaveBeenCalledWith(
+          '/audit_logs/events',
+          {
+            event: serializeCreateAuditLogEventOptions(event),
+            organization_id: 'org_123',
+          },
+          {},
+        );
       });
     });
 
     describe('when the api responds with a 401', () => {
       it('throws an UnauthorizedException', async () => {
-        mock
-          .onPost('/audit_logs/events', {
-            organization_id: 'org_123',
-            event: serializeEventOptions(event),
-          })
-          .replyOnce(
-            401,
-            {
-              message: 'Unauthorized',
-            },
-            { 'X-Request-ID': 'a-request-id' },
+        const workosSpy = jest.spyOn(WorkOS.prototype, 'post');
+
+        workosSpy.mockImplementationOnce(() => {
+          throw new AxiosError(
+            'Could not authorize the request. Maybe your API key is invalid?',
+            '401',
           );
+        });
 
         const workos = new WorkOS('invalid apikey');
 
         await expect(
           workos.auditLogs.createEvent('org_123', event),
-        ).rejects.toStrictEqual(new UnauthorizedException('a-request-id'));
+        ).rejects.toThrowError(new UnauthorizedException('a-request-id'));
       });
     });
 
     describe('when the api responds with a 400', () => {
       it('throws an BadRequestException', async () => {
+        const workosSpy = jest.spyOn(WorkOS.prototype, 'post');
+
         const errors = [
           {
             field: 'occurred_at',
@@ -111,21 +121,15 @@ describe('AuditLogs', () => {
           },
         ];
 
-        mock
-          .onPost('/audit_logs/events', {
-            organization_id: 'org_123',
-            event: serializeEventOptions(event),
-          })
-          .replyOnce(
-            400,
-            {
-              message:
-                'Audit Log could not be processed due to missing or incorrect data.',
-              code: 'invalid_audit_log',
-              errors,
-            },
-            { 'X-Request-ID': 'a-request-id' },
-          );
+        workosSpy.mockImplementationOnce(() => {
+          throw new BadRequestException({
+            code: '400',
+            errors,
+            message:
+              'Audit Log could not be processed due to missing or incorrect data.',
+            requestID: 'a-request-id',
+          });
+        });
 
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
@@ -137,25 +141,26 @@ describe('AuditLogs', () => {
   });
 
   describe('createExport', () => {
-    const serializeExportOptions = ({
-      range_end,
-      range_start,
-      ...options
-    }: AuditLogExportOptions) => ({
-      range_start: range_start.toISOString(),
-      range_end: range_end.toISOString(),
-      ...options,
-    });
-
     describe('when the api responds with a 201', () => {
       it('returns `audit_log_export`', async () => {
+        const workosSpy = jest.spyOn(WorkOS.prototype, 'post');
+
         const options: AuditLogExportOptions = {
-          organization_id: 'org_123',
-          range_start: new Date(),
-          range_end: new Date(),
+          organizationId: 'org_123',
+          rangeStart: new Date(),
+          rangeEnd: new Date(),
         };
 
         const auditLogExport: AuditLogExport = {
+          object: 'audit_log_export',
+          id: 'audit_log_export_1234',
+          state: 'pending',
+          url: undefined,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        };
+
+        const auditLogExportResponse: AuditLogExportResponse = {
           object: 'audit_log_export',
           id: 'audit_log_export_1234',
           state: 'pending',
@@ -164,28 +169,35 @@ describe('AuditLogs', () => {
           updated_at: new Date().toISOString(),
         };
 
-        mock
-          .onPost('/audit_logs/exports', serializeExportOptions(options))
-          .replyOnce(201, auditLogExport);
+        workosSpy.mockResolvedValueOnce(
+          mockWorkOsResponse(201, auditLogExportResponse),
+        );
 
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
         await expect(workos.auditLogs.createExport(options)).resolves.toEqual(
           auditLogExport,
         );
+
+        expect(workosSpy).toHaveBeenCalledWith(
+          '/audit_logs/exports',
+          serializeAuditLogExportOptions(options),
+        );
       });
     });
 
     describe('when additional filters are defined', () => {
       it('returns `audit_log_export`', async () => {
+        const workosSpy = jest.spyOn(WorkOS.prototype, 'post');
+
         const options: AuditLogExportOptions = {
           actions: ['foo', 'bar'],
           actors: ['Jon', 'Smith'],
-          actor_names: ['Jon', 'Smith'],
-          actor_ids: ['user_foo', 'user_bar'],
-          organization_id: 'org_123',
-          range_end: new Date(),
-          range_start: new Date(),
+          actorNames: ['Jon', 'Smith'],
+          actorIds: ['user_foo', 'user_bar'],
+          organizationId: 'org_123',
+          rangeEnd: new Date(),
+          rangeStart: new Date(),
           targets: ['user', 'team'],
         };
 
@@ -194,53 +206,11 @@ describe('AuditLogs', () => {
           id: 'audit_log_export_1234',
           state: 'pending',
           url: undefined,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
         };
 
-        mock
-          .onPost('/audit_logs/exports', serializeExportOptions(options))
-          .replyOnce(201, auditLogExport);
-
-        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
-
-        await expect(workos.auditLogs.createExport(options)).resolves.toEqual(
-          auditLogExport,
-        );
-      });
-    });
-
-    describe('when the api responds with a 401', () => {
-      it('throws an UnauthorizedException', async () => {
-        const options: AuditLogExportOptions = {
-          organization_id: 'org_123',
-          range_start: new Date(),
-          range_end: new Date(),
-        };
-
-        mock
-          .onPost('/audit_logs/exports', serializeExportOptions(options))
-          .replyOnce(
-            401,
-            {
-              message: 'Unauthorized',
-            },
-            { 'X-Request-ID': 'a-request-id' },
-          );
-
-        const workos = new WorkOS('invalid apikey');
-
-        await expect(
-          workos.auditLogs.createExport(options),
-        ).rejects.toStrictEqual(new UnauthorizedException('a-request-id'));
-      });
-    });
-  });
-
-  describe('getExport', () => {
-    describe('when the api responds with a 201', () => {
-      it('returns `audit_log_export`', async () => {
-        const auditLogExport: AuditLogExport = {
+        const auditLogExportResponse: AuditLogExportResponse = {
           object: 'audit_log_export',
           id: 'audit_log_export_1234',
           state: 'pending',
@@ -249,33 +219,108 @@ describe('AuditLogs', () => {
           updated_at: new Date().toISOString(),
         };
 
-        mock
-          .onGet(`/audit_logs/exports/${auditLogExport.id}`)
-          .replyOnce(200, auditLogExport);
+        workosSpy.mockResolvedValueOnce(
+          mockWorkOsResponse(201, auditLogExportResponse),
+        );
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        await expect(workos.auditLogs.createExport(options)).resolves.toEqual(
+          auditLogExport,
+        );
+
+        expect(workosSpy).toHaveBeenCalledWith(
+          '/audit_logs/exports',
+          serializeAuditLogExportOptions(options),
+        );
+      });
+    });
+
+    describe('when the api responds with a 401', () => {
+      it('throws an UnauthorizedException', async () => {
+        const workosSpy = jest.spyOn(WorkOS.prototype, 'post');
+
+        const options: AuditLogExportOptions = {
+          organizationId: 'org_123',
+          rangeStart: new Date(),
+          rangeEnd: new Date(),
+        };
+
+        workosSpy.mockImplementationOnce(() => {
+          throw new AxiosError(
+            'Could not authorize the request. Maybe your API key is invalid?',
+            '401',
+          );
+        });
+
+        const workos = new WorkOS('invalid apikey');
+
+        await expect(
+          workos.auditLogs.createExport(options),
+        ).rejects.toThrowError(new UnauthorizedException('a-request-id'));
+      });
+    });
+  });
+
+  describe('getExport', () => {
+    describe('when the api responds with a 201', () => {
+      it('returns `audit_log_export`', async () => {
+        const workosSpy = jest.spyOn(WorkOS.prototype, 'get');
+
+        const auditLogExport: AuditLogExport = {
+          object: 'audit_log_export',
+          id: 'audit_log_export_1234',
+          state: 'pending',
+          url: undefined,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        };
+
+        const auditLogExportResponse: AuditLogExportResponse = {
+          object: 'audit_log_export',
+          id: 'audit_log_export_1234',
+          state: 'pending',
+          url: undefined,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        };
+
+        workosSpy.mockResolvedValueOnce(
+          mockWorkOsResponse(201, auditLogExportResponse),
+        );
 
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
         await expect(
           workos.auditLogs.getExport(auditLogExport.id),
         ).resolves.toEqual(auditLogExport);
+
+        expect(workosSpy).toHaveBeenCalledWith(
+          `/audit_logs/exports/${auditLogExport.id}`,
+        );
       });
     });
 
     describe('when the api responds with a 401', () => {
       it('throws an UnauthorizedException', async () => {
-        mock.onGet('/audit_logs/exports/audit_log_export_1234').replyOnce(
-          401,
-          {
-            message: 'Unauthorized',
-          },
-          { 'X-Request-ID': 'a-request-id' },
-        );
+        const workosSpy = jest.spyOn(WorkOS.prototype, 'get');
+
+        workosSpy.mockImplementationOnce(() => {
+          throw new AxiosError(
+            'Could not authorize the request. Maybe your API key is invalid?',
+            '401',
+          );
+        });
 
         const workos = new WorkOS('invalid apikey');
 
         await expect(
           workos.auditLogs.getExport('audit_log_export_1234'),
-        ).rejects.toStrictEqual(new UnauthorizedException('a-request-id'));
+        ).rejects.toThrowError(new UnauthorizedException('a-request-id'));
+
+        expect(workosSpy).toHaveBeenCalledWith(
+          `/audit_logs/exports/audit_log_export_1234`,
+        );
       });
     });
   });

--- a/src/audit-logs/audit-logs.ts
+++ b/src/audit-logs/audit-logs.ts
@@ -4,7 +4,15 @@ import {
   CreateAuditLogEventRequestOptions,
 } from './interfaces';
 import { AuditLogExportOptions } from './interfaces/audit-log-export-options.interface';
-import { AuditLogExport } from './interfaces/audit-log-export.interface';
+import {
+  AuditLogExport,
+  AuditLogExportResponse,
+} from './interfaces/audit-log-export.interface';
+import {
+  deserializeAuditLogExport,
+  serializeAuditLogExportOptions,
+  serializeCreateAuditLogEventOptions,
+} from './serializers';
 
 export class AuditLogs {
   constructor(private readonly workos: WorkOS) {}
@@ -17,7 +25,7 @@ export class AuditLogs {
     await this.workos.post(
       '/audit_logs/events',
       {
-        event,
+        event: serializeCreateAuditLogEventOptions(event),
         organization_id: organization,
       },
       options,
@@ -25,16 +33,19 @@ export class AuditLogs {
   }
 
   async createExport(options: AuditLogExportOptions): Promise<AuditLogExport> {
-    const { data } = await this.workos.post('/audit_logs/exports', options);
+    const { data } = await this.workos.post<AuditLogExportResponse>(
+      '/audit_logs/exports',
+      serializeAuditLogExportOptions(options),
+    );
 
-    return data;
+    return deserializeAuditLogExport(data);
   }
 
   async getExport(auditLogExportId: string): Promise<AuditLogExport> {
-    const { data } = await this.workos.get(
+    const { data } = await this.workos.get<AuditLogExportResponse>(
       `/audit_logs/exports/${auditLogExportId}`,
     );
 
-    return data;
+    return deserializeAuditLogExport(data);
   }
 }

--- a/src/audit-logs/interfaces/audit-log-export-options.interface.ts
+++ b/src/audit-logs/interfaces/audit-log-export-options.interface.ts
@@ -1,13 +1,24 @@
 export interface AuditLogExportOptions {
   actions?: string[];
   /**
-   * @deprecated Please use `actor_names` instead.
+   * @deprecated Please use `actorNames` instead.
    */
+  actors?: string[];
+  actorNames?: string[];
+  actorIds?: string[];
+  organizationId: string;
+  rangeEnd: Date;
+  rangeStart: Date;
+  targets?: string[];
+}
+
+export interface SerializedAuditLogExportOptions {
+  actions?: string[];
   actors?: string[];
   actor_names?: string[];
   actor_ids?: string[];
   organization_id: string;
-  range_end: Date;
-  range_start: Date;
+  range_end: string;
+  range_start: string;
   targets?: string[];
 }

--- a/src/audit-logs/interfaces/audit-log-export.interface.ts
+++ b/src/audit-logs/interfaces/audit-log-export.interface.ts
@@ -3,6 +3,15 @@ export interface AuditLogExport {
   id: string;
   state: 'pending' | 'ready' | 'error';
   url?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AuditLogExportResponse {
+  object: 'audit_log_export';
+  id: string;
+  state: 'pending' | 'ready' | 'error';
+  url?: string;
   created_at: string;
   updated_at: string;
 }

--- a/src/audit-logs/interfaces/create-audit-log-event-options.interface.ts
+++ b/src/audit-logs/interfaces/create-audit-log-event-options.interface.ts
@@ -17,7 +17,20 @@ export interface AuditLogTarget {
 export interface CreateAuditLogEventOptions {
   action: string;
   version?: number;
-  occurred_at: Date;
+  occurredAt: Date;
+  actor: AuditLogActor;
+  targets: AuditLogTarget[];
+  context: {
+    location: string;
+    userAgent?: string;
+  };
+  metadata?: Record<string, string | number | boolean>;
+}
+
+export interface SerializedCreateAuditLogEventOptions {
+  action: string;
+  version?: number;
+  occurred_at: string;
   actor: AuditLogActor;
   targets: AuditLogTarget[];
   context: {

--- a/src/audit-logs/serializers/audit-log-export-options.serializer.ts
+++ b/src/audit-logs/serializers/audit-log-export-options.serializer.ts
@@ -1,0 +1,17 @@
+import {
+  AuditLogExportOptions,
+  SerializedAuditLogExportOptions,
+} from '../interfaces';
+
+export const serializeAuditLogExportOptions = (
+  options: AuditLogExportOptions,
+): SerializedAuditLogExportOptions => ({
+  actions: options.actions,
+  actors: options.actors,
+  actor_names: options.actorNames,
+  actor_ids: options.actorIds,
+  organization_id: options.organizationId,
+  range_end: options.rangeEnd.toISOString(),
+  range_start: options.rangeStart.toISOString(),
+  targets: options.targets,
+});

--- a/src/audit-logs/serializers/audit-log-export.serializer.ts
+++ b/src/audit-logs/serializers/audit-log-export.serializer.ts
@@ -1,0 +1,12 @@
+import { AuditLogExport, AuditLogExportResponse } from '../interfaces';
+
+export const deserializeAuditLogExport = (
+  auditLogExport: AuditLogExportResponse,
+): AuditLogExport => ({
+  object: auditLogExport.object,
+  id: auditLogExport.id,
+  state: auditLogExport.state,
+  url: auditLogExport.url,
+  createdAt: auditLogExport.created_at,
+  updatedAt: auditLogExport.updated_at,
+});

--- a/src/audit-logs/serializers/create-audit-log-event-options.serializer.ts
+++ b/src/audit-logs/serializers/create-audit-log-event-options.serializer.ts
@@ -1,0 +1,19 @@
+import {
+  CreateAuditLogEventOptions,
+  SerializedCreateAuditLogEventOptions,
+} from '../interfaces';
+
+export const serializeCreateAuditLogEventOptions = (
+  event: CreateAuditLogEventOptions,
+): SerializedCreateAuditLogEventOptions => ({
+  action: event.action,
+  version: event.version,
+  occurred_at: event.occurredAt.toISOString(),
+  actor: event.actor,
+  targets: event.targets,
+  context: {
+    location: event.context.location,
+    user_agent: event.context.userAgent,
+  },
+  metadata: event.metadata,
+});

--- a/src/audit-logs/serializers/index.ts
+++ b/src/audit-logs/serializers/index.ts
@@ -1,0 +1,3 @@
+export * from './audit-log-export.serializer';
+export * from './audit-log-export-options.serializer';
+export * from './create-audit-log-event-options.serializer';

--- a/src/common/utils/workos-mock-response.ts
+++ b/src/common/utils/workos-mock-response.ts
@@ -1,0 +1,7 @@
+export const mockWorkOsResponse = (status: number, data: unknown) => ({
+  data,
+  status,
+  headers: {},
+  statusText: '',
+  config: {} as any,
+});

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -78,11 +78,11 @@ export class WorkOS {
     });
   }
 
-  async post(
+  async post<T = any, D = any>(
     path: string,
     entity: any,
     options: PostOptions = {},
-  ): Promise<AxiosResponse> {
+  ): Promise<AxiosResponse<T, D>> {
     const requestHeaders: any = {};
 
     if (options.idempotencyKey) {
@@ -101,7 +101,10 @@ export class WorkOS {
     }
   }
 
-  async get(path: string, options: GetOptions = {}): Promise<AxiosResponse> {
+  async get<T = any, D = any>(
+    path: string,
+    options: GetOptions = {},
+  ): Promise<AxiosResponse<T, D>> {
     try {
       const { accessToken } = options;
 


### PR DESCRIPTION
## Description

* Part of a wider initiative to migrate our Node SDK to camel case for the 3.0.0 release.
* Migrates the Audit Log module to camel case.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
