### PR TITLE
Migrate Events to camelCased

### DIFF
--- a/src/events/events.spec.ts
+++ b/src/events/events.spec.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { List } from '../common/interfaces/list.interface';
+import { List } from '../common/interfaces';
 import { WorkOS } from '../workos';
-import { Event } from './interfaces/event.interface';
+import { Event, EventResponse } from './interfaces';
 
 const mock = new MockAdapter(axios);
 
@@ -11,7 +11,16 @@ describe('Event', () => {
 
   const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
-  const eventResponse: Event = {
+  const event: Event = {
+    id: 'event_01234ABCD',
+    createdAt: '2020-05-06 04:21:48.649164',
+    event: 'dsync.user.created',
+    data: {
+      id: 'event_01234ABCD',
+    },
+  };
+
+  const eventResponse: EventResponse = {
     id: 'event_01234ABCD',
     created_at: '2020-05-06 04:21:48.649164',
     event: 'dsync.user.created',
@@ -21,7 +30,7 @@ describe('Event', () => {
   };
 
   describe('listEvents', () => {
-    const eventsListResponse: List<Event> = {
+    const eventsListResponse: List<EventResponse> = {
       object: 'list',
       data: [eventResponse],
       list_metadata: {},
@@ -30,9 +39,13 @@ describe('Event', () => {
     it(`requests Events`, async () => {
       mock.onGet('/events', {}).replyOnce(200, eventsListResponse);
 
-      const list = await workos.events.listEvents({});
+      const subject = await workos.events.listEvents({});
 
-      expect(list).toEqual(eventsListResponse);
+      expect(subject).toEqual({
+        object: 'list',
+        data: [event],
+        listMetadata: {},
+      });
     });
 
     it(`requests Events with a valid event name`, async () => {
@@ -42,7 +55,11 @@ describe('Event', () => {
         events: ['connection.activated'],
       });
 
-      expect(list).toEqual(eventsListResponse);
+      expect(list).toEqual({
+        object: 'list',
+        data: [event],
+        listMetadata: {},
+      });
     });
   });
 });

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,15 +1,20 @@
 import { WorkOS } from '../workos';
-import { Event } from './interfaces/event.interface';
-import { List } from '../common/interfaces/list.interface';
+import { Event, EventResponse } from './interfaces';
 import { ListEventOptions } from './interfaces';
+import { deserializeList } from '../common/serializers';
+import { DeserializedList, List } from '../common/interfaces';
+import { deserializeEvent } from './serializers/event.serializer';
 
 export class Events {
   constructor(private readonly workos: WorkOS) {}
 
-  async listEvents(options: ListEventOptions): Promise<List<Event>> {
-    const { data } = await this.workos.get(`/events`, {
+  async listEvents(
+    options: ListEventOptions,
+  ): Promise<DeserializedList<Event>> {
+    const { data } = await this.workos.get<List<EventResponse>>(`/events`, {
       query: options,
     });
-    return data;
+
+    return deserializeList(data, deserializeEvent);
   }
 }

--- a/src/events/interfaces/event.interface.ts
+++ b/src/events/interfaces/event.interface.ts
@@ -1,6 +1,6 @@
 interface EventBase {
   id: string;
-  created_at: string;
+  createdAt: string;
 }
 
 export interface ConnectionActivatedEvent extends EventBase {
@@ -88,6 +88,8 @@ export type Event =
   | DsyncUserCreatedEvent
   | DsyncUserUpdatedEvent
   | DsyncUserDeletedEvent;
+
+export type EventResponse = Omit<Event, 'createdAt'> & { created_at: string };
 
 export type EventNames =
   | 'connection.activated'

--- a/src/events/interfaces/list-events-options.interface.ts
+++ b/src/events/interfaces/list-events-options.interface.ts
@@ -2,8 +2,8 @@ import { EventNames } from './event.interface';
 
 export interface ListEventOptions {
   events?: EventNames[];
-  range_start?: string;
-  range_end?: string;
+  rangeStart?: string;
+  rangeEnd?: string;
   limit?: number;
   after?: string;
 }

--- a/src/events/serializers/event.serializer.ts
+++ b/src/events/serializers/event.serializer.ts
@@ -1,0 +1,8 @@
+import { Event, EventResponse } from '../interfaces';
+
+export const deserializeEvent = (event: EventResponse): Event => ({
+  id: event.id,
+  createdAt: event.created_at,
+  data: event.data,
+  event: event.event,
+});


### PR DESCRIPTION
## Description

* Part of a wider initiative to migrate our Node SDK to camel case for the 3.0.0 release.
* Migrates the Events module to camel case.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
