### PR TITLE
Add default order

### DIFF
--- a/src/audit-trail/audit-trail.ts
+++ b/src/audit-trail/audit-trail.ts
@@ -4,6 +4,7 @@ import { EventOptions } from './interfaces/event-options.interface';
 import { ListResponse } from '../common/interfaces';
 import { ListEventsOptions } from './interfaces/list-events-options.interface';
 import { WorkOS } from '../workos';
+import { withDefaultOrder } from '../common/utils/default-order';
 
 export class AuditTrail {
   constructor(private readonly workos: WorkOS) {}
@@ -19,7 +20,7 @@ export class AuditTrail {
     options?: ListEventsOptions,
   ): Promise<ListResponse<AuditTrailEvent>> {
     const { data } = await this.workos.get('/events', {
-      query: options,
+      query: withDefaultOrder(options),
     });
     return data;
   }

--- a/src/common/utils/default-order.ts
+++ b/src/common/utils/default-order.ts
@@ -1,0 +1,5 @@
+import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
+
+export function withDefaultOrder(options?: PaginationOptions): PaginationOptions {
+    return { ...options, order: options?.order ?? 'desc' };
+  }

--- a/src/common/utils/default-order.ts
+++ b/src/common/utils/default-order.ts
@@ -1,5 +1,7 @@
 import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
 
-export function withDefaultOrder(options?: PaginationOptions): PaginationOptions {
-    return { ...options, order: options?.order ?? 'desc' };
-  }
+export function withDefaultOrder(
+  options?: PaginationOptions,
+): PaginationOptions {
+  return { ...options, order: options?.order ?? 'desc' };
+}

--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -18,6 +18,7 @@ import {
   deserializeDirectoryGroup,
   deserializeDirectoryUserWithGroups,
 } from './serializers';
+import { withDefaultOrder } from '../common/utils/default-order';
 
 export class DirectorySync {
   constructor(private readonly workos: WorkOS) {}
@@ -28,7 +29,7 @@ export class DirectorySync {
     const { data } = await this.workos.get<ListResponse<DirectoryResponse>>(
       '/directories',
       {
-        query: options,
+        query: withDefaultOrder(options),
       },
     );
 
@@ -53,7 +54,7 @@ export class DirectorySync {
     const { data } = await this.workos.get<
       ListResponse<DirectoryGroupResponse>
     >(`/directory_groups`, {
-      query: options,
+      query: withDefaultOrder(options),
     });
 
     return deserializeList(data, deserializeDirectoryGroup);
@@ -65,7 +66,7 @@ export class DirectorySync {
     const { data } = await this.workos.get<
       ListResponse<DirectoryUserWithGroupsResponse<TCustomAttributes>>
     >(`/directory_users`, {
-      query: options,
+      query: withDefaultOrder(options),
     });
 
     return deserializeList(data, deserializeDirectoryUserWithGroups);

--- a/src/organizations/fixtures/list-organizations.json
+++ b/src/organizations/fixtures/list-organizations.json
@@ -93,5 +93,5 @@
       ]
     }
   ],
-  "list_metadata": { "before": "before-id", "after": null }
+  "list_metadata": { "before": null, "after": "after-id" }
 }

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -21,14 +21,14 @@ describe('Organizations', () => {
         const { data, listMetadata } =
           await workos.organizations.listOrganizations();
 
-        expect(mock.history.get[0].params).toBeUndefined();
+        expect(mock.history.get[0].params).toEqual({ order: 'desc' });
         expect(mock.history.get[0].url).toEqual('/organizations');
 
         expect(data).toHaveLength(7);
 
         expect(listMetadata).toEqual({
-          after: null,
-          before: 'before-id',
+          after: 'after-id',
+          before: null,
         });
       });
     });
@@ -43,10 +43,12 @@ describe('Organizations', () => {
 
         const { data } = await workos.organizations.listOrganizations({
           domains: ['example.com'],
+          order: 'desc',
         });
 
         expect(mock.history.get[0].params).toEqual({
           domains: ['example.com'],
+          order: "desc",
         });
 
         expect(mock.history.get[0].url).toEqual('/organizations');
@@ -69,6 +71,7 @@ describe('Organizations', () => {
 
         expect(mock.history.get[0].params).toEqual({
           before: 'before-id',
+          order: "desc",
         });
 
         expect(mock.history.get[0].url).toEqual('/organizations');
@@ -91,6 +94,7 @@ describe('Organizations', () => {
 
         expect(mock.history.get[0].params).toEqual({
           after: 'after-id',
+          order: "desc",
         });
 
         expect(mock.history.get[0].url).toEqual('/organizations');
@@ -113,6 +117,7 @@ describe('Organizations', () => {
 
         expect(mock.history.get[0].params).toEqual({
           limit: 10,
+          order: "desc",
         });
 
         expect(mock.history.get[0].url).toEqual('/organizations');

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -48,7 +48,7 @@ describe('Organizations', () => {
 
         expect(mock.history.get[0].params).toEqual({
           domains: ['example.com'],
-          order: "desc",
+          order: 'desc',
         });
 
         expect(mock.history.get[0].url).toEqual('/organizations');
@@ -71,7 +71,7 @@ describe('Organizations', () => {
 
         expect(mock.history.get[0].params).toEqual({
           before: 'before-id',
-          order: "desc",
+          order: 'desc',
         });
 
         expect(mock.history.get[0].url).toEqual('/organizations');
@@ -94,7 +94,7 @@ describe('Organizations', () => {
 
         expect(mock.history.get[0].params).toEqual({
           after: 'after-id',
-          order: "desc",
+          order: 'desc',
         });
 
         expect(mock.history.get[0].url).toEqual('/organizations');
@@ -117,7 +117,7 @@ describe('Organizations', () => {
 
         expect(mock.history.get[0].params).toEqual({
           limit: 10,
-          order: "desc",
+          order: 'desc',
         });
 
         expect(mock.history.get[0].url).toEqual('/organizations');

--- a/src/organizations/organizations.ts
+++ b/src/organizations/organizations.ts
@@ -1,6 +1,7 @@
 import { List, ListResponse } from '../common/interfaces';
 import { deserializeList } from '../common/serializers';
 import { WorkOS } from '../workos';
+import { withDefaultOrder } from '../common/utils/default-order';
 import {
   CreateOrganizationOptions,
   CreateOrganizationRequestOptions,
@@ -24,7 +25,7 @@ export class Organizations {
     const { data } = await this.workos.get<ListResponse<OrganizationResponse>>(
       '/organizations',
       {
-        query: options,
+        query: withDefaultOrder(options),
       },
     );
 

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -1,5 +1,6 @@
 import { List, ListResponse } from '../common/interfaces';
 import { deserializeList } from '../common/serializers';
+import { withDefaultOrder } from '../common/utils/default-order';
 import { WorkOS } from '../workos';
 import {
   AuthorizationURLOptions,
@@ -121,7 +122,7 @@ export class SSO {
     const { data } = await this.workos.get<ListResponse<ConnectionResponse>>(
       `/connections`,
       {
-        query: options,
+        query: withDefaultOrder(options),
       },
     );
 


### PR DESCRIPTION
## Description

Passes in 'desc' as the default order when none is provided. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
