### PR TITLE
Add `microsoft_oauth_profile_id` to `UnmanagedUser`

### DIFF
--- a/src/users/interfaces/user.interface.ts
+++ b/src/users/interfaces/user.interface.ts
@@ -11,6 +11,7 @@ interface UnmanangedUser extends BaseUser {
   organization_memberships: OrganizationMembership[];
   email_verified_at: string | null;
   google_oauth_profile_id: string | null;
+  microsoft_oauth_profile_id: string | null;
 }
 
 interface BaseUser {


### PR DESCRIPTION
## Description

Similar to the existing `google_oauth_profile_id`, this also adds `microsoft_oauth_profile_id` which we support.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
