### PR TITLE
Migrate Passwordless to camelCased

### DIFF
--- a/src/passwordless/interfaces/create-passwordless-session-options.interface.ts
+++ b/src/passwordless/interfaces/create-passwordless-session-options.interface.ts
@@ -6,3 +6,12 @@ export interface CreatePasswordlessSessionOptions {
   connection?: string;
   expiresIn?: number;
 }
+
+export interface SerializedCreatePasswordlessSessionOptions {
+  type: 'MagicLink';
+  email: string;
+  redirect_uri?: string;
+  state?: string;
+  connection?: string;
+  expires_in?: number;
+}

--- a/src/passwordless/interfaces/index.ts
+++ b/src/passwordless/interfaces/index.ts
@@ -1,3 +1,3 @@
-export { PasswordlessSession } from './passwordless-session.interface';
-export { CreatePasswordlessSessionOptions } from './create-passwordless-session-options.interface';
-export { SendSessionResponse } from './send-session-response.interface';
+export * from './passwordless-session.interface';
+export * from './create-passwordless-session-options.interface';
+export * from './send-session-response.interface';

--- a/src/passwordless/interfaces/passwordless-session.interface.ts
+++ b/src/passwordless/interfaces/passwordless-session.interface.ts
@@ -1,6 +1,14 @@
 export interface PasswordlessSession {
   id: string;
   email: string;
+  expiresAt: Date;
+  link: string;
+  object: 'passwordless_session';
+}
+
+export interface PasswordlessSessionResponse {
+  id: string;
+  email: string;
   expires_at: Date;
   link: string;
   object: 'passwordless_session';

--- a/src/passwordless/passwordless.ts
+++ b/src/passwordless/passwordless.ts
@@ -1,7 +1,12 @@
 import { WorkOS } from '../workos';
-import { PasswordlessSession } from './interfaces/passwordless-session.interface';
-import { CreatePasswordlessSessionOptions } from './interfaces/create-passwordless-session-options.interface';
-import { SendSessionResponse } from './interfaces/send-session-response.interface';
+import {
+  CreatePasswordlessSessionOptions,
+  PasswordlessSession,
+  PasswordlessSessionResponse,
+  SendSessionResponse,
+  SerializedCreatePasswordlessSessionOptions,
+} from './interfaces';
+import { deserializePasswordlessSession } from './serializers/passwordless-session.serializer';
 
 export class Passwordless {
   constructor(private readonly workos: WorkOS) {}
@@ -11,12 +16,17 @@ export class Passwordless {
     expiresIn,
     ...options
   }: CreatePasswordlessSessionOptions): Promise<PasswordlessSession> {
-    const { data } = await this.workos.post('/passwordless/sessions', {
+    const { data } = await this.workos.post<
+      PasswordlessSessionResponse,
+      any,
+      SerializedCreatePasswordlessSessionOptions
+    >('/passwordless/sessions', {
       ...options,
       redirect_uri: redirectURI,
       expires_in: expiresIn,
     });
-    return data;
+
+    return deserializePasswordlessSession(data);
   }
 
   async sendSession(sessionId: string): Promise<SendSessionResponse> {

--- a/src/passwordless/serializers/passwordless-session.serializer.ts
+++ b/src/passwordless/serializers/passwordless-session.serializer.ts
@@ -1,0 +1,14 @@
+import {
+  PasswordlessSession,
+  PasswordlessSessionResponse,
+} from '../interfaces';
+
+export const deserializePasswordlessSession = (
+  passwordlessSession: PasswordlessSessionResponse,
+): PasswordlessSession => ({
+  id: passwordlessSession.id,
+  email: passwordlessSession.email,
+  expiresAt: passwordlessSession.expires_at,
+  link: passwordlessSession.link,
+  object: passwordlessSession.object,
+});


### PR DESCRIPTION
## Description

* Part of a wider initiative to migrate our Node SDK to camel case for the 3.0.0 release.
* Migrates the Passwordless module to camel case.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
