### PR TITLE
Add update user password method

### DIFF
--- a/src/users/interfaces/index.ts
+++ b/src/users/interfaces/index.ts
@@ -11,3 +11,4 @@ export * from './remove-user-from-organization-options.interface';
 export * from './revoke-session-options.interface';
 export * from './user.interface';
 export * from './verify-session.interface';
+export * from './update-user-password-options.interface';

--- a/src/users/interfaces/update-user-password-options.interface.ts
+++ b/src/users/interfaces/update-user-password-options.interface.ts
@@ -1,0 +1,4 @@
+export interface UpdateUserPasswordOptions {
+  userId: string;
+  password: string;
+}

--- a/src/users/interfaces/update-user-password-options.interface.ts
+++ b/src/users/interfaces/update-user-password-options.interface.ts
@@ -2,3 +2,7 @@ export interface UpdateUserPasswordOptions {
   userId: string;
   password: string;
 }
+
+export interface SerializedUpdateUserPasswordOptions {
+  password: string;
+}

--- a/src/users/serializers/index.ts
+++ b/src/users/serializers/index.ts
@@ -7,5 +7,6 @@ export * from './create-password-reset-challenge.serializer';
 export * from './create-user-options.serializer';
 export * from './revoke-session-options.serializer';
 export * from './session.serializer';
+export * from './update-user-password.serializer';
 export * from './user.serializer';
 export * from './verify-session.serializer';

--- a/src/users/serializers/index.ts
+++ b/src/users/serializers/index.ts
@@ -7,6 +7,6 @@ export * from './create-password-reset-challenge.serializer';
 export * from './create-user-options.serializer';
 export * from './revoke-session-options.serializer';
 export * from './session.serializer';
-export * from './update-user-password.serializer';
+export * from './update-user-password-options.serializer';
 export * from './user.serializer';
 export * from './verify-session.serializer';

--- a/src/users/serializers/update-user-password-options.serializer.ts
+++ b/src/users/serializers/update-user-password-options.serializer.ts
@@ -3,7 +3,7 @@ import {
   UpdateUserPasswordOptions,
 } from '../interfaces';
 
-export const serializeUpdateUserPassword = (
+export const serializeUpdateUserPasswordOptions = (
   options: UpdateUserPasswordOptions,
 ): SerializedUpdateUserPasswordOptions => ({
   password: options.password,

--- a/src/users/serializers/update-user-password.serializer.ts
+++ b/src/users/serializers/update-user-password.serializer.ts
@@ -1,0 +1,10 @@
+import {
+  SerializedUpdateUserPasswordOptions,
+  UpdateUserPasswordOptions,
+} from '../interfaces';
+
+export const serializeUpdateUserPassword = (
+  options: UpdateUserPasswordOptions,
+): SerializedUpdateUserPasswordOptions => ({
+  password: options.password,
+});

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -328,4 +328,21 @@ describe('UserManagement', () => {
       });
     });
   });
+
+  describe('updateUserPassword', () => {
+    it('sends a updateUserPassword request', async () => {
+      mock
+        .onPut(`/users/${userId}/password`)
+        .reply(200, userFixture);
+      const resp = await workos.users.updateUserPassword({
+        userId,
+        password: 'secure'
+      });
+
+      expect(mock.history.put[0].url).toEqual(`/users/${userId}/password`);
+      expect(resp).toMatchObject({
+        email: 'test01@example.com',
+      });
+    });
+  });
 });

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -331,12 +331,10 @@ describe('UserManagement', () => {
 
   describe('updateUserPassword', () => {
     it('sends a updateUserPassword request', async () => {
-      mock
-        .onPut(`/users/${userId}/password`)
-        .reply(200, userFixture);
+      mock.onPut(`/users/${userId}/password`).reply(200, userFixture);
       const resp = await workos.users.updateUserPassword({
         userId,
-        password: 'secure'
+        password: 'secure',
       });
 
       expect(mock.history.put[0].url).toEqual(`/users/${userId}/password`);

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -46,6 +46,7 @@ import {
   serializeCreatePasswordResetChallengeOptions,
   serializeCreateUserOptions,
   serializeRevokeSessionOptions,
+  serializeUpdateUserPassword,
   serializeVerifySessionOptions,
 } from './serializers';
 import { deserializeList } from '../common/serializers';
@@ -220,16 +221,14 @@ export class Users {
     return deserializeUser(data);
   }
 
-  async updateUserPassword({
-    userId,
-    password,
-  }: UpdateUserPasswordOptions): Promise<User> {
+  async updateUserPassword(payload: UpdateUserPasswordOptions): Promise<User> {
     const { data } = await this.workos.put<
       UserResponse,
       SerializedUpdateUserPasswordOptions
-    >(`/users/${userId}/password`, {
-      password,
-    });
+    >(
+      `/users/${payload.userId}/password`,
+      serializeUpdateUserPassword(payload),
+    );
 
     return deserializeUser(data);
   }

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -24,7 +24,6 @@ import {
   SerializedCreatePasswordResetChallengeOptions,
   SerializedCreateUserOptions,
   SerializedRevokeSessionOptions,
-  SerializedUpdateUserPasswordOptions,
   SerializedVerifySessionOptions,
   UpdateUserPasswordOptions,
   User,

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -46,7 +46,7 @@ import {
   serializeCreatePasswordResetChallengeOptions,
   serializeCreateUserOptions,
   serializeRevokeSessionOptions,
-  serializeUpdateUserPassword,
+  serializeUpdateUserPasswordOptions,
   serializeVerifySessionOptions,
 } from './serializers';
 import { deserializeList } from '../common/serializers';
@@ -227,7 +227,7 @@ export class Users {
       SerializedUpdateUserPasswordOptions
     >(
       `/users/${payload.userId}/password`,
-      serializeUpdateUserPassword(payload),
+      serializeUpdateUserPasswordOptions(payload),
     );
 
     return deserializeUser(data);

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -24,7 +24,9 @@ import {
   SerializedCreatePasswordResetChallengeOptions,
   SerializedCreateUserOptions,
   SerializedRevokeSessionOptions,
+  SerializedUpdateUserPasswordOptions,
   SerializedVerifySessionOptions,
+  UpdateUserPasswordOptions,
   User,
   UserResponse,
   VerifySessionOptions,
@@ -47,7 +49,6 @@ import {
   serializeVerifySessionOptions,
 } from './serializers';
 import { deserializeList } from '../common/serializers';
-import { UpdateUserPasswordOptions } from './interfaces/update-user-password-options.interface';
 
 export class Users {
   constructor(private readonly workos: WorkOS) {}
@@ -219,15 +220,16 @@ export class Users {
     return deserializeUser(data);
   }
 
-  async updateUserPassword(
-   {userId, password}: UpdateUserPasswordOptions
-  ): Promise<User> {
-    const { data } = await this.workos.put<UserResponse>(
-      `/users/${userId}/password`,
-      {
-        password,
-      },
-    );
+  async updateUserPassword({
+    userId,
+    password,
+  }: UpdateUserPasswordOptions): Promise<User> {
+    const { data } = await this.workos.put<
+      UserResponse,
+      SerializedUpdateUserPasswordOptions
+    >(`/users/${userId}/password`, {
+      password,
+    });
 
     return deserializeUser(data);
   }

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -222,10 +222,7 @@ export class Users {
   }
 
   async updateUserPassword(payload: UpdateUserPasswordOptions): Promise<User> {
-    const { data } = await this.workos.put<
-      UserResponse,
-      SerializedUpdateUserPasswordOptions
-    >(
+    const { data } = await this.workos.put<UserResponse>(
       `/users/${payload.userId}/password`,
       serializeUpdateUserPasswordOptions(payload),
     );

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -47,6 +47,7 @@ import {
   serializeVerifySessionOptions,
 } from './serializers';
 import { deserializeList } from '../common/serializers';
+import { UpdateUserPasswordOptions } from './interfaces/update-user-password-options.interface';
 
 export class Users {
   constructor(private readonly workos: WorkOS) {}
@@ -213,6 +214,19 @@ export class Users {
   }: RemoveUserFromOrganizationOptions): Promise<User> {
     const { data } = await this.workos.delete<UserResponse>(
       `/users/${userId}/organizations/${organizationId}`,
+    );
+
+    return deserializeUser(data);
+  }
+
+  async updateUserPassword(
+   {userId, password}: UpdateUserPasswordOptions
+  ): Promise<User> {
+    const { data } = await this.workos.put<UserResponse>(
+      `/users/${userId}/password`,
+      {
+        password,
+      },
     );
 
     return deserializeUser(data);


### PR DESCRIPTION
## Description

Adds the update user password method for the user management API

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
