### PR TITLE
Add update user method

### DIFF
--- a/src/users/interfaces/index.ts
+++ b/src/users/interfaces/index.ts
@@ -12,3 +12,4 @@ export * from './revoke-session-options.interface';
 export * from './user.interface';
 export * from './verify-session.interface';
 export * from './update-user-password-options.interface';
+export * from './update-user-options.interface';

--- a/src/users/interfaces/update-user-options.interface.ts
+++ b/src/users/interfaces/update-user-options.interface.ts
@@ -1,0 +1,10 @@
+export interface UpdateUserOptions {
+  userId: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface SerializedUpdateUserOptions {
+  first_name: string;
+  last_name: string;
+}

--- a/src/users/serializers/index.ts
+++ b/src/users/serializers/index.ts
@@ -8,5 +8,6 @@ export * from './create-user-options.serializer';
 export * from './revoke-session-options.serializer';
 export * from './session.serializer';
 export * from './update-user-password-options.serializer';
+export * from './update-user-options.serializer';
 export * from './user.serializer';
 export * from './verify-session.serializer';

--- a/src/users/serializers/update-user-options.serializer.ts
+++ b/src/users/serializers/update-user-options.serializer.ts
@@ -1,0 +1,8 @@
+import { SerializedUpdateUserOptions, UpdateUserOptions } from '../interfaces';
+
+export const serializeUpdateUserOptions = (
+  options: UpdateUserOptions,
+): SerializedUpdateUserOptions => ({
+  first_name: options.firstName,
+  last_name: options.lastName,
+});

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -329,6 +329,22 @@ describe('UserManagement', () => {
     });
   });
 
+  describe('updateUser', () => {
+    it('sends a updateUser request', async () => {
+      mock.onPut(`/users/${userId}`).reply(200, userFixture);
+      const resp = await workos.users.updateUser({
+        userId,
+        firstName: 'Dane',
+        lastName: 'Williams',
+      });
+
+      expect(mock.history.put[0].url).toEqual(`/users/${userId}`);
+      expect(resp).toMatchObject({
+        email: 'test01@example.com',
+      });
+    });
+  });
+
   describe('updateUserPassword', () => {
     it('sends a updateUserPassword request', async () => {
       mock.onPut(`/users/${userId}/password`).reply(200, userFixture);

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -25,6 +25,7 @@ import {
   SerializedCreateUserOptions,
   SerializedRevokeSessionOptions,
   SerializedVerifySessionOptions,
+  UpdateUserOptions,
   UpdateUserPasswordOptions,
   User,
   UserResponse,
@@ -215,6 +216,15 @@ export class Users {
   }: RemoveUserFromOrganizationOptions): Promise<User> {
     const { data } = await this.workos.delete<UserResponse>(
       `/users/${userId}/organizations/${organizationId}`,
+    );
+
+    return deserializeUser(data);
+  }
+
+  async updateUser(payload: UpdateUserOptions): Promise<User> {
+    const { data } = await this.workos.put<UserResponse>(
+      `/users/${payload.userId}`,
+      serializeUpdateUserOptions(payload),
     );
 
     return deserializeUser(data);

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -46,6 +46,7 @@ import {
   serializeCreatePasswordResetChallengeOptions,
   serializeCreateUserOptions,
   serializeRevokeSessionOptions,
+  serializeUpdateUserOptions,
   serializeUpdateUserPasswordOptions,
   serializeVerifySessionOptions,
 } from './serializers';


### PR DESCRIPTION
## Description

Adds an `updateUser` method for user management

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
