### PR TITLE
Migrate Webhooks to camelCased

### DIFF
--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -1,0 +1,82 @@
+import { deserializeDirectoryUser } from '../../directory-sync/serializers';
+import { deserializeConnection } from '../../sso/serializers';
+import {
+  Webhook,
+  WebhookBase,
+  WebhookResponse,
+} from '../../webhooks/interfaces';
+import {
+  deserializeDeletedWebhookDirectory,
+  deserializeUpdatedWebhookDirectoryGroup,
+  deserializeUpdatedWebhookDirectoryUser,
+  deserializeWebhookDirectory,
+  deserializeWebhookDirectoryGroup,
+} from '../../webhooks/serializers';
+
+export const deserializeEvent = (event: WebhookResponse): Webhook => {
+  const eventBase: WebhookBase = {
+    id: event.id,
+    createdAt: event.created_at,
+  };
+
+  switch (event.event) {
+    case 'connection.activated':
+    case 'connection.deactivated':
+    case 'connection.deleted':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeConnection(event.data),
+      };
+    case 'dsync.activated':
+    case 'dsync.deactivated':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeWebhookDirectory(event.data),
+      };
+    case 'dsync.deleted':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeDeletedWebhookDirectory(event.data),
+      };
+    case 'dsync.group.created':
+    case 'dsync.group.deleted':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeWebhookDirectoryGroup(event.data),
+      };
+    case 'dsync.group.updated':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeUpdatedWebhookDirectoryGroup(event.data),
+      };
+    case 'dsync.group.user_added':
+    case 'dsync.group.user_removed':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: {
+          directoryId: event.data.directory_id,
+          user: deserializeDirectoryUser(event.data.user),
+          group: event.data.group,
+        },
+      };
+    case 'dsync.user.created':
+    case 'dsync.user.deleted':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeDirectoryUser(event.data),
+      };
+    case 'dsync.user.updated':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeUpdatedWebhookDirectoryUser(event.data),
+      };
+  }
+};

--- a/src/common/serializers/index.ts
+++ b/src/common/serializers/index.ts
@@ -1,1 +1,2 @@
+export * from './event.serializer';
 export * from './list.serializer';

--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -72,6 +72,7 @@ describe('DirectorySync', () => {
   };
 
   const userWithGroup: DirectoryUserWithGroups = {
+    object: 'directory_user',
     id: 'user_123',
     customAttributes: {
       custom: true,
@@ -98,6 +99,7 @@ describe('DirectorySync', () => {
   };
 
   const userWithGroupResponse: DirectoryUserWithGroupsResponse = {
+    object: 'directory_user',
     id: 'user_123',
     custom_attributes: {
       custom: true,

--- a/src/directory-sync/interfaces/directory-user.interface.ts
+++ b/src/directory-sync/interfaces/directory-user.interface.ts
@@ -9,6 +9,7 @@ export interface DirectoryUser<
   TCustomAttributes extends object = DefaultCustomAttributes,
   TRawAttributes = any,
 > {
+  object: 'directory_user';
   id: string;
   directoryId: string;
   organizationId: string | null;
@@ -33,6 +34,7 @@ export interface DirectoryUserResponse<
   TCustomAttributes extends object = DefaultCustomAttributes,
   TRawAttributes = any,
 > {
+  object: 'directory_user';
   id: string;
   directory_id: string;
   organization_id: string | null;

--- a/src/directory-sync/serializers/directory-user.serializer.ts
+++ b/src/directory-sync/serializers/directory-user.serializer.ts
@@ -14,6 +14,7 @@ export const deserializeDirectoryUser = <
     | DirectoryUserResponse<TCustomAttributes>
     | DirectoryUserWithGroupsResponse<TCustomAttributes>,
 ): DirectoryUser<TCustomAttributes> => ({
+  object: directoryUser.object,
   id: directoryUser.id,
   directoryId: directoryUser.directory_id,
   organizationId: directoryUser.organization_id,

--- a/src/directory-sync/utils/get-primary-email.spec.ts
+++ b/src/directory-sync/utils/get-primary-email.spec.ts
@@ -3,6 +3,7 @@ import { DirectoryUser } from '../interfaces';
 
 describe('getPrimaryEmail', () => {
   const user: DirectoryUser = {
+    object: 'directory_user',
     id: 'user_123',
     customAttributes: {
       custom: true,

--- a/src/webhooks/fixtures/webhook.json
+++ b/src/webhooks/fixtures/webhook.json
@@ -1,1 +1,67 @@
-{"id": "wh_123","data":{"id":"directory_user_01FAEAJCR3ZBZ30D8BD1924TVG","state":"active","emails":[{"type":"work","value":"blair@foo-corp.com","primary":true}],"idp_id":"00u1e8mutl6wlH3lL4x7","object":"directory_user","username":"blair@foo-corp.com","last_name":"Lunchford","first_name":"Blair","job_title":"Software Engineer","directory_id":"directory_01F9M7F68PZP8QXP8G7X5QRHS7","raw_attributes":{"name":{"givenName":"Blair","familyName":"Lunchford","middleName":"Elizabeth","honorificPrefix":"Ms."},"title":"Software Engineer","active":true,"emails":[{"type":"work","value":"blair@foo-corp.com","primary":true}],"groups":[],"locale":"en-US","schemas":["urn:ietf:params:scim:schemas:core:2.0:User","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],"userName":"blair@foo-corp.com","addresses":[{"region":"CA","primary":true,"locality":"San Francisco","postalCode":"94016"}],"externalId":"00u1e8mutl6wlH3lL4x7","displayName":"Blair Lunchford","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User":{"manager":{"value":"2","displayName":"Kate Chapman"},"division":"Engineering","department":"Customer Success"}}},"event":"dsync.user.created","created_at":"2021-06-25T19:07:33.155Z"}
+{
+  "id": "wh_123",
+  "data": {
+    "id": "directory_user_01FAEAJCR3ZBZ30D8BD1924TVG",
+    "state": "active",
+    "emails": [
+      {
+        "type": "work",
+        "value": "blair@foo-corp.com",
+        "primary": true
+      }
+    ],
+    "idp_id": "00u1e8mutl6wlH3lL4x7",
+    "object": "directory_user",
+    "username": "blair@foo-corp.com",
+    "last_name": "Lunchford",
+    "first_name": "Blair",
+    "job_title": "Software Engineer",
+    "directory_id": "directory_01F9M7F68PZP8QXP8G7X5QRHS7",
+    "created_at": "2021-06-25T19:07:33.155Z",
+    "updated_at": "2021-06-25T19:07:33.155Z",
+    "raw_attributes": {
+      "name": {
+        "givenName": "Blair",
+        "familyName": "Lunchford",
+        "middleName": "Elizabeth",
+        "honorificPrefix": "Ms."
+      },
+      "title": "Software Engineer",
+      "active": true,
+      "emails": [
+        {
+          "type": "work",
+          "value": "blair@foo-corp.com",
+          "primary": true
+        }
+      ],
+      "groups": [],
+      "locale": "en-US",
+      "schemas": [
+        "urn:ietf:params:scim:schemas:core:2.0:User",
+        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+      ],
+      "userName": "blair@foo-corp.com",
+      "addresses": [
+        {
+          "region": "CA",
+          "primary": true,
+          "locality": "San Francisco",
+          "postalCode": "94016"
+        }
+      ],
+      "externalId": "00u1e8mutl6wlH3lL4x7",
+      "displayName": "Blair Lunchford",
+      "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+        "manager": {
+          "value": "2",
+          "displayName": "Kate Chapman"
+        },
+        "division": "Engineering",
+        "department": "Customer Success"
+      }
+    }
+  },
+  "event": "dsync.user.created",
+  "created_at": "2021-06-25T19:07:33.155Z"
+}

--- a/src/webhooks/interfaces/index.ts
+++ b/src/webhooks/interfaces/index.ts
@@ -1,4 +1,3 @@
 export * from './webhook.interface';
 export * from './webhook-directory.interface';
 export * from './webhook-directory-group.interface';
-export * from './webhook-directory-user.interface';

--- a/src/webhooks/interfaces/webhook-directory-group.interface.ts
+++ b/src/webhooks/interfaces/webhook-directory-group.interface.ts
@@ -1,5 +1,16 @@
 export interface WebhookDirectoryGroup<TRawAttributes = any> {
   id: string;
+  idpId: string;
+  directoryId: string;
+  organizationId: string | null;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  rawAttributes: TRawAttributes;
+}
+
+export interface WebhookDirectoryGroupResponse<TRawAttributes = any> {
+  id: string;
   idp_id: string;
   directory_id: string;
   organization_id: string | null;

--- a/src/webhooks/interfaces/webhook-directory-user.interface.ts
+++ b/src/webhooks/interfaces/webhook-directory-user.interface.ts
@@ -1,6 +1,0 @@
-import { DirectoryUser } from '../../directory-sync/interfaces';
-
-export interface WebhookDirectoryUser extends DirectoryUser {
-  created_at: string;
-  updated_at: string;
-}

--- a/src/webhooks/interfaces/webhook-directory.interface.ts
+++ b/src/webhooks/interfaces/webhook-directory.interface.ts
@@ -35,6 +35,19 @@ interface WebhookDirectoryDomain {
 export interface WebhookDirectory {
   object: 'directory';
   id: string;
+  externalKey: string;
+  type: WebhookDirectoryType;
+  state: WebhookDirectoryState;
+  name: string;
+  organizationId?: string;
+  domains: WebhookDirectoryDomain[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WebhookDirectoryResponse {
+  object: 'directory';
+  id: string;
   external_key: string;
   type: WebhookDirectoryType;
   state: WebhookDirectoryState;

--- a/src/webhooks/interfaces/webhook.interface.ts
+++ b/src/webhooks/interfaces/webhook.interface.ts
@@ -1,9 +1,23 @@
-import { Connection } from '../../sso/interfaces';
-import { WebhookDirectoryGroup as Group } from './webhook-directory-group.interface';
-import { WebhookDirectoryUser as User } from './webhook-directory-user.interface';
-import { WebhookDirectory as Directory } from './webhook-directory.interface';
+import {
+  DirectoryUser,
+  DirectoryUserResponse,
+} from '../../directory-sync/interfaces';
+import { Connection, ConnectionResponse } from '../../sso/interfaces';
+import {
+  WebhookDirectoryGroup as Group,
+  WebhookDirectoryGroupResponse as GroupResponse,
+} from './webhook-directory-group.interface';
+import {
+  WebhookDirectory as Directory,
+  WebhookDirectoryResponse as DirectoryResponse,
+} from './webhook-directory.interface';
 
-interface WebhookBase {
+export interface WebhookBase {
+  id: string;
+  createdAt: string;
+}
+
+interface WebhookResponseBase {
   id: string;
   created_at: string;
 }
@@ -13,9 +27,21 @@ export interface ConnectionActivatedWebhook extends WebhookBase {
   data: Connection;
 }
 
+export interface ConnectionActivatedWebhookResponse
+  extends WebhookResponseBase {
+  event: 'connection.activated';
+  data: ConnectionResponse;
+}
+
 export interface ConnectionDeactivatedWebhook extends WebhookBase {
   event: 'connection.deactivated';
   data: Connection;
+}
+
+export interface ConnectionDeactivatedWebhookResponse
+  extends WebhookResponseBase {
+  event: 'connection.deactivated';
+  data: ConnectionResponse;
 }
 
 export interface ConnectionDeletedWebhook extends WebhookBase {
@@ -23,9 +49,19 @@ export interface ConnectionDeletedWebhook extends WebhookBase {
   data: Connection;
 }
 
+export interface ConnectionDeletedWebhookResponse extends WebhookResponseBase {
+  event: 'connection.deleted';
+  data: ConnectionResponse;
+}
+
 export interface DsyncActivatedWebhook extends WebhookBase {
   event: 'dsync.activated';
   data: Directory;
+}
+
+export interface DsyncActivatedWebhookResponse extends WebhookResponseBase {
+  event: 'dsync.activated';
+  data: DirectoryResponse;
 }
 
 export interface DsyncDeactivatedWebhook extends WebhookBase {
@@ -33,9 +69,19 @@ export interface DsyncDeactivatedWebhook extends WebhookBase {
   data: Directory;
 }
 
+export interface DsyncDeactivatedWebhookResponse extends WebhookResponseBase {
+  event: 'dsync.deactivated';
+  data: DirectoryResponse;
+}
+
 export interface DsyncDeletedWebhook extends WebhookBase {
   event: 'dsync.deleted';
-  data: Omit<Directory, 'domains' | 'external_key'>;
+  data: Omit<Directory, 'domains' | 'externalKey'>;
+}
+
+export interface DsyncDeletedWebhookResponse extends WebhookResponseBase {
+  event: 'dsync.deleted';
+  data: Omit<DirectoryResponse, 'domains' | 'external_key'>;
 }
 
 export interface DsyncGroupCreatedWebhook extends WebhookBase {
@@ -43,47 +89,97 @@ export interface DsyncGroupCreatedWebhook extends WebhookBase {
   data: Group;
 }
 
+export interface DsyncGroupCreatedWebhookResponse extends WebhookResponseBase {
+  event: 'dsync.group.created';
+  data: GroupResponse;
+}
+
 export interface DsyncGroupDeletedWebhook extends WebhookBase {
   event: 'dsync.group.deleted';
   data: Group;
 }
 
+export interface DsyncGroupDeletedWebhookResponse extends WebhookResponseBase {
+  event: 'dsync.group.deleted';
+  data: GroupResponse;
+}
+
 export interface DsyncGroupUpdatedWebhook extends WebhookBase {
   event: 'dsync.group.updated';
-  data: Group & Record<'previous_attributes', any>;
+  data: Group & Record<'previousAttributes', any>;
+}
+
+export interface DsyncGroupUpdatedWebhookResponse extends WebhookResponseBase {
+  event: 'dsync.group.updated';
+  data: GroupResponse & Record<'previous_attributes', any>;
 }
 
 export interface DsyncGroupUserAddedWebhook extends WebhookBase {
   event: 'dsync.group.user_added';
   data: {
-    directory_id: string;
-    user: User;
+    directoryId: string;
+    user: DirectoryUser;
     group: Pick<Group, 'id' | 'name'>;
+  };
+}
+
+export interface DsyncGroupUserAddedWebhookResponse
+  extends WebhookResponseBase {
+  event: 'dsync.group.user_added';
+  data: {
+    directory_id: string;
+    user: DirectoryUserResponse;
+    group: Pick<GroupResponse, 'id' | 'name'>;
   };
 }
 
 export interface DsyncGroupUserRemovedWebhook extends WebhookBase {
   event: 'dsync.group.user_removed';
   data: {
-    directory_id: string;
-    user: User;
+    directoryId: string;
+    user: DirectoryUser;
     group: Pick<Group, 'id' | 'name'>;
+  };
+}
+
+export interface DsyncGroupUserRemovedWebhookResponse
+  extends WebhookResponseBase {
+  event: 'dsync.group.user_removed';
+  data: {
+    directory_id: string;
+    user: DirectoryUserResponse;
+    group: Pick<GroupResponse, 'id' | 'name'>;
   };
 }
 
 export interface DsyncUserCreatedWebhook extends WebhookBase {
   event: 'dsync.user.created';
-  data: User;
+  data: DirectoryUser;
+}
+
+export interface DsyncUserCreatedWebhookResponse extends WebhookResponseBase {
+  event: 'dsync.user.created';
+  data: DirectoryUserResponse;
 }
 
 export interface DsyncUserDeletedWebhook extends WebhookBase {
   event: 'dsync.user.deleted';
-  data: User;
+  data: DirectoryUser;
+}
+
+export interface DsyncUserDeletedWebhookResponse extends WebhookResponseBase {
+  event: 'dsync.user.deleted';
+  data: DirectoryUserResponse;
 }
 
 export interface DsyncUserUpdatedWebhook extends WebhookBase {
   event: 'dsync.user.updated';
-  data: User & Record<'previous_attributes', any>;
+  data: DirectoryUser & Record<'previousAttributes', any>;
+}
+
+export interface DsyncUserUpdatedWebhookResponse extends WebhookResponseBase {
+  event: 'dsync.user.updated';
+  data: DirectoryUserResponse & Record<'previous_attributes', any>;
 }
 
 export type Webhook =
@@ -101,3 +197,19 @@ export type Webhook =
   | DsyncUserCreatedWebhook
   | DsyncUserUpdatedWebhook
   | DsyncUserDeletedWebhook;
+
+export type WebhookResponse =
+  | ConnectionActivatedWebhookResponse
+  | ConnectionDeactivatedWebhookResponse
+  | ConnectionDeletedWebhookResponse
+  | DsyncActivatedWebhookResponse
+  | DsyncDeactivatedWebhookResponse
+  | DsyncDeletedWebhookResponse
+  | DsyncGroupCreatedWebhookResponse
+  | DsyncGroupUpdatedWebhookResponse
+  | DsyncGroupDeletedWebhookResponse
+  | DsyncGroupUserAddedWebhookResponse
+  | DsyncGroupUserRemovedWebhookResponse
+  | DsyncUserCreatedWebhookResponse
+  | DsyncUserUpdatedWebhookResponse
+  | DsyncUserDeletedWebhookResponse;

--- a/src/webhooks/serializers/index.ts
+++ b/src/webhooks/serializers/index.ts
@@ -1,0 +1,3 @@
+export * from './webhook-directory-group.serializer';
+export * from './webhook-directory-user.serializer';
+export * from './webhook-directory.serializer';

--- a/src/webhooks/serializers/webhook-directory-group.serializer.ts
+++ b/src/webhooks/serializers/webhook-directory-group.serializer.ts
@@ -1,0 +1,32 @@
+import {
+  WebhookDirectoryGroup,
+  WebhookDirectoryGroupResponse,
+} from '../interfaces';
+
+export const deserializeWebhookDirectoryGroup = (
+  directoryGroup: WebhookDirectoryGroupResponse,
+): WebhookDirectoryGroup => ({
+  id: directoryGroup.id,
+  idpId: directoryGroup.idp_id,
+  directoryId: directoryGroup.directory_id,
+  organizationId: directoryGroup.organization_id,
+  name: directoryGroup.name,
+  createdAt: directoryGroup.created_at,
+  updatedAt: directoryGroup.updated_at,
+  rawAttributes: directoryGroup.raw_attributes,
+});
+
+export const deserializeUpdatedWebhookDirectoryGroup = (
+  directoryGroup: WebhookDirectoryGroupResponse &
+    Record<'previous_attributes', any>,
+): WebhookDirectoryGroup & Record<'previousAttributes', any> => ({
+  id: directoryGroup.id,
+  idpId: directoryGroup.idp_id,
+  directoryId: directoryGroup.directory_id,
+  organizationId: directoryGroup.organization_id,
+  name: directoryGroup.name,
+  createdAt: directoryGroup.created_at,
+  updatedAt: directoryGroup.updated_at,
+  rawAttributes: directoryGroup.raw_attributes,
+  previousAttributes: directoryGroup.previous_attributes,
+});

--- a/src/webhooks/serializers/webhook-directory-user.serializer.ts
+++ b/src/webhooks/serializers/webhook-directory-user.serializer.ts
@@ -1,0 +1,25 @@
+import {
+  DirectoryUser,
+  DirectoryUserResponse,
+} from '../../directory-sync/interfaces';
+
+export const deserializeUpdatedWebhookDirectoryUser = (
+  directoryUser: DirectoryUserResponse & Record<'previous_attributes', any>,
+): DirectoryUser & Record<'previousAttributes', any> => ({
+  object: 'directory_user',
+  id: directoryUser.id,
+  directoryId: directoryUser.directory_id,
+  organizationId: directoryUser.organization_id,
+  rawAttributes: directoryUser.raw_attributes,
+  customAttributes: directoryUser.custom_attributes,
+  idpId: directoryUser.idp_id,
+  firstName: directoryUser.first_name,
+  emails: directoryUser.emails,
+  username: directoryUser.username,
+  lastName: directoryUser.last_name,
+  jobTitle: directoryUser.job_title,
+  state: directoryUser.state,
+  createdAt: directoryUser.created_at,
+  updatedAt: directoryUser.updated_at,
+  previousAttributes: directoryUser.previous_attributes,
+});

--- a/src/webhooks/serializers/webhook-directory.serializer.ts
+++ b/src/webhooks/serializers/webhook-directory.serializer.ts
@@ -1,0 +1,29 @@
+import { WebhookDirectory, WebhookDirectoryResponse } from '../interfaces';
+
+export const deserializeWebhookDirectory = (
+  directory: WebhookDirectoryResponse,
+): WebhookDirectory => ({
+  object: directory.object,
+  id: directory.id,
+  externalKey: directory.external_key,
+  type: directory.type,
+  state: directory.state,
+  name: directory.name,
+  organizationId: directory.organization_id,
+  domains: directory.domains,
+  createdAt: directory.created_at,
+  updatedAt: directory.updated_at,
+});
+
+export const deserializeDeletedWebhookDirectory = (
+  directory: Omit<WebhookDirectoryResponse, 'domains' | 'external_key'>,
+): Omit<WebhookDirectory, 'domains' | 'externalKey'> => ({
+  object: directory.object,
+  id: directory.id,
+  type: directory.type,
+  state: directory.state,
+  name: directory.name,
+  organizationId: directory.organization_id,
+  createdAt: directory.created_at,
+  updatedAt: directory.updated_at,
+});

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -31,14 +31,16 @@ describe('Webhooks', () => {
           primary: true,
         },
       ],
-      idp_id: '00u1e8mutl6wlH3lL4x7',
+      idpId: '00u1e8mutl6wlH3lL4x7',
       object: 'directory_user',
       username: 'blair@foo-corp.com',
-      last_name: 'Lunchford',
-      first_name: 'Blair',
-      job_title: 'Software Engineer',
-      directory_id: 'directory_01F9M7F68PZP8QXP8G7X5QRHS7',
-      raw_attributes: {
+      lastName: 'Lunchford',
+      firstName: 'Blair',
+      jobTitle: 'Software Engineer',
+      directoryId: 'directory_01F9M7F68PZP8QXP8G7X5QRHS7',
+      createdAt: '2021-06-25T19:07:33.155Z',
+      updatedAt: '2021-06-25T19:07:33.155Z',
+      rawAttributes: {
         name: {
           givenName: 'Blair',
           familyName: 'Lunchford',

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -1,6 +1,7 @@
-import { Webhook } from './interfaces/webhook.interface';
+import { Webhook, WebhookResponse } from './interfaces';
 import crypto from 'crypto';
 import { SignatureVerificationException } from '../common/exceptions';
+import { deserializeEvent } from '../common/serializers';
 
 export class Webhooks {
   constructEvent({
@@ -17,8 +18,9 @@ export class Webhooks {
     const options = { payload, sigHeader, secret, tolerance };
     this.verifyHeader(options);
 
-    const webhookPayload = payload as Webhook;
-    return webhookPayload;
+    const webhookPayload = payload as WebhookResponse;
+
+    return deserializeEvent(webhookPayload);
   }
 
   verifyHeader({


### PR DESCRIPTION
## Description

* Part of a wider initiative to migrate our Node SDK to camel case for the 3.0.0 release.
* Migrates the Webhooks module to camel case.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
