### PR TITLE
Remove Connection.status

### DIFF
--- a/src/sso/interfaces/connection.interface.ts
+++ b/src/sso/interfaces/connection.interface.ts
@@ -16,10 +16,6 @@ export interface Connection {
    */
   connectionType: ConnectionType;
   state: 'draft' | 'active' | 'inactive' | 'validating';
-  /**
-   * @deprecated The status parameter has been deprecated. Please use state.
-   */
-  status: 'linked' | 'unlinked';
   domains: ConnectionDomain[];
   type: ConnectionType;
   createdAt: string;
@@ -33,10 +29,6 @@ export interface ConnectionResponse {
   name: string;
   connection_type: ConnectionType;
   state: 'draft' | 'active' | 'inactive' | 'validating';
-  /**
-   * @deprecated The status parameter has been deprecated. Please use state.
-   */
-  status: 'linked' | 'unlinked';
   domains: ConnectionDomain[];
   created_at: string;
   updated_at: string;

--- a/src/sso/serializers/connection.serializer.ts
+++ b/src/sso/serializers/connection.serializer.ts
@@ -10,7 +10,6 @@ export const deserializeConnection = (
   connectionType: connection.connection_type,
   type: connection.connection_type,
   state: connection.state,
-  status: connection.status,
   domains: connection.domains,
   createdAt: connection.created_at,
   updatedAt: connection.updated_at,

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -12,7 +12,6 @@ describe('SSO', () => {
     name: 'Connection',
     connection_type: ConnectionType.OktaSAML,
     state: 'active',
-    status: 'linked',
     domains: [],
     created_at: '2023-07-17T20:07:20.055Z',
     updated_at: '2023-07-17T20:07:20.055Z',


### PR DESCRIPTION
## Description

* Previously deprecated in 0.10.2 and replaced with Connection.state.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
