### PR TITLE
Rename ListGroupsOptions to ListDirectoryGroupsOptions

### DIFF
--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -8,8 +8,8 @@ import {
   DirectoryUserWithGroups,
   DirectoryUserWithGroupsResponse,
   ListDirectoriesOptions,
+  ListDirectoryGroupsOptions,
   ListDirectoryUsersOptions,
-  ListGroupsOptions,
 } from './interfaces';
 import { List, ListResponse } from '../common/interfaces';
 import { deserializeList } from '../common/serializers';
@@ -47,7 +47,9 @@ export class DirectorySync {
     await this.workos.delete(`/directories/${id}`);
   }
 
-  async listGroups(options: ListGroupsOptions): Promise<List<DirectoryGroup>> {
+  async listGroups(
+    options: ListDirectoryGroupsOptions,
+  ): Promise<List<DirectoryGroup>> {
     const { data } = await this.workos.get<
       ListResponse<DirectoryGroupResponse>
     >(`/directory_groups`, {

--- a/src/directory-sync/interfaces/list-groups-options.interface.ts
+++ b/src/directory-sync/interfaces/list-groups-options.interface.ts
@@ -1,6 +1,6 @@
 import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
 
-export interface ListGroupsOptions extends PaginationOptions {
+export interface ListDirectoryGroupsOptions extends PaginationOptions {
   directory?: string;
   user?: string;
 }


### PR DESCRIPTION
## Description

* Part of an effort to move the naming of types from Group to the more specific DirectoryGroup.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
