### PR TITLE
Rename DeserializedList to List

### DIFF
--- a/src/audit-trail/audit-trail.ts
+++ b/src/audit-trail/audit-trail.ts
@@ -1,7 +1,7 @@
 import { CreateEventOptions } from './interfaces/create-event-options.interface';
 import { AuditTrailEvent } from './interfaces/event.interface';
 import { EventOptions } from './interfaces/event-options.interface';
-import { List } from '../common/interfaces/list.interface';
+import { ListResponse } from '../common/interfaces';
 import { ListEventsOptions } from './interfaces/list-events-options.interface';
 import { WorkOS } from '../workos';
 
@@ -17,7 +17,7 @@ export class AuditTrail {
 
   async listEvents(
     options?: ListEventsOptions,
-  ): Promise<List<AuditTrailEvent>> {
+  ): Promise<ListResponse<AuditTrailEvent>> {
     const { data } = await this.workos.get('/events', {
       query: options,
     });

--- a/src/common/interfaces/list.interface.ts
+++ b/src/common/interfaces/list.interface.ts
@@ -1,4 +1,4 @@
-export interface List<T> {
+export interface ListResponse<T> {
   readonly object: 'list';
   data: T[];
   list_metadata: {
@@ -7,7 +7,7 @@ export interface List<T> {
   };
 }
 
-export interface DeserializedList<T> {
+export interface List<T> {
   readonly object: 'list';
   data: T[];
   listMetadata: {

--- a/src/common/serializers/list.serializer.ts
+++ b/src/common/serializers/list.serializer.ts
@@ -1,9 +1,9 @@
-import { DeserializedList, List } from '../interfaces';
+import { List, ListResponse } from '../interfaces';
 
 export const deserializeList = <TSerialized, TDeserialized>(
-  list: List<TSerialized>,
+  list: ListResponse<TSerialized>,
   deserializer: (serialized: TSerialized) => TDeserialized,
-): DeserializedList<TDeserialized> => ({
+): List<TDeserialized> => ({
   object: 'list',
   data: list.data.map(deserializer),
   listMetadata: list.list_metadata,

--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
-import { List } from '../common/interfaces/list.interface';
+import { ListResponse } from '../common/interfaces/list.interface';
 import { WorkOS } from '../workos';
 import {
   Directory,
@@ -126,7 +126,7 @@ describe('DirectorySync', () => {
   describe('listDirectories', () => {
     describe('with options', () => {
       it('requests Directories with query parameters', async () => {
-        const directoryListResponse: List<DirectoryResponse> = {
+        const directoryListResponse: ListResponse<DirectoryResponse> = {
           object: 'list',
           data: [directoryResponse],
           list_metadata: {},
@@ -184,7 +184,7 @@ describe('DirectorySync', () => {
   });
 
   describe('listGroups', () => {
-    const groupListResponse: List<DirectoryGroupResponse> = {
+    const groupListResponse: ListResponse<DirectoryGroupResponse> = {
       object: 'list',
       data: [groupResponse],
       list_metadata: {},
@@ -232,11 +232,12 @@ describe('DirectorySync', () => {
   });
 
   describe('listUsers', () => {
-    const userWithGroupListResponse: List<DirectoryUserWithGroupsResponse> = {
-      object: 'list',
-      data: [userWithGroupResponse],
-      list_metadata: {},
-    };
+    const userWithGroupListResponse: ListResponse<DirectoryUserWithGroupsResponse> =
+      {
+        object: 'list',
+        data: [userWithGroupResponse],
+        list_metadata: {},
+      };
 
     describe('with a Directory', () => {
       it(`requests a Directory's Users`, async () => {

--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -11,7 +11,7 @@ import {
   ListDirectoryUsersOptions,
   ListGroupsOptions,
 } from './interfaces';
-import { DeserializedList, List } from '../common/interfaces';
+import { List, ListResponse } from '../common/interfaces';
 import { deserializeList } from '../common/serializers';
 import {
   deserializeDirectory,
@@ -24,8 +24,8 @@ export class DirectorySync {
 
   async listDirectories(
     options?: ListDirectoriesOptions,
-  ): Promise<DeserializedList<Directory>> {
-    const { data } = await this.workos.get<List<DirectoryResponse>>(
+  ): Promise<List<Directory>> {
+    const { data } = await this.workos.get<ListResponse<DirectoryResponse>>(
       '/directories',
       {
         query: options,
@@ -47,24 +47,21 @@ export class DirectorySync {
     await this.workos.delete(`/directories/${id}`);
   }
 
-  async listGroups(
-    options: ListGroupsOptions,
-  ): Promise<DeserializedList<DirectoryGroup>> {
-    const { data } = await this.workos.get<List<DirectoryGroupResponse>>(
-      `/directory_groups`,
-      {
-        query: options,
-      },
-    );
+  async listGroups(options: ListGroupsOptions): Promise<List<DirectoryGroup>> {
+    const { data } = await this.workos.get<
+      ListResponse<DirectoryGroupResponse>
+    >(`/directory_groups`, {
+      query: options,
+    });
 
     return deserializeList(data, deserializeDirectoryGroup);
   }
 
   async listUsers<TCustomAttributes extends object = DefaultCustomAttributes>(
     options: ListDirectoryUsersOptions,
-  ): Promise<DeserializedList<DirectoryUserWithGroups<TCustomAttributes>>> {
+  ): Promise<List<DirectoryUserWithGroups<TCustomAttributes>>> {
     const { data } = await this.workos.get<
-      List<DirectoryUserWithGroupsResponse<TCustomAttributes>>
+      ListResponse<DirectoryUserWithGroupsResponse<TCustomAttributes>>
     >(`/directory_users`, {
       query: options,
     });

--- a/src/events/events.spec.ts
+++ b/src/events/events.spec.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { List } from '../common/interfaces';
+import { ListResponse } from '../common/interfaces';
 import { WorkOS } from '../workos';
 import { Event, EventResponse } from './interfaces';
 
@@ -30,7 +30,7 @@ describe('Event', () => {
   };
 
   describe('listEvents', () => {
-    const eventsListResponse: List<EventResponse> = {
+    const eventsListResponse: ListResponse<EventResponse> = {
       object: 'list',
       data: [eventResponse],
       list_metadata: {},

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -2,18 +2,19 @@ import { WorkOS } from '../workos';
 import { Event, EventResponse } from './interfaces';
 import { ListEventOptions } from './interfaces';
 import { deserializeList } from '../common/serializers';
-import { DeserializedList, List } from '../common/interfaces';
+import { List, ListResponse } from '../common/interfaces';
 import { deserializeEvent } from './serializers/event.serializer';
 
 export class Events {
   constructor(private readonly workos: WorkOS) {}
 
-  async listEvents(
-    options: ListEventOptions,
-  ): Promise<DeserializedList<Event>> {
-    const { data } = await this.workos.get<List<EventResponse>>(`/events`, {
-      query: options,
-    });
+  async listEvents(options: ListEventOptions): Promise<List<Event>> {
+    const { data } = await this.workos.get<ListResponse<EventResponse>>(
+      `/events`,
+      {
+        query: options,
+      },
+    );
 
     return deserializeList(data, deserializeEvent);
   }

--- a/src/organizations/organizations.ts
+++ b/src/organizations/organizations.ts
@@ -1,4 +1,4 @@
-import { DeserializedList, List } from '../common/interfaces';
+import { List, ListResponse } from '../common/interfaces';
 import { deserializeList } from '../common/serializers';
 import { WorkOS } from '../workos';
 import {
@@ -20,8 +20,8 @@ export class Organizations {
 
   async listOrganizations(
     options?: ListOrganizationsOptions,
-  ): Promise<DeserializedList<Organization>> {
-    const { data } = await this.workos.get<List<OrganizationResponse>>(
+  ): Promise<List<Organization>> {
+    const { data } = await this.workos.get<ListResponse<OrganizationResponse>>(
       '/organizations',
       {
         query: options,

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -1,4 +1,4 @@
-import { DeserializedList, List } from '../common/interfaces';
+import { List, ListResponse } from '../common/interfaces';
 import { deserializeList } from '../common/serializers';
 import { WorkOS } from '../workos';
 import {
@@ -117,8 +117,8 @@ export class SSO {
 
   async listConnections(
     options?: ListConnectionsOptions,
-  ): Promise<DeserializedList<Connection>> {
-    const { data } = await this.workos.get<List<ConnectionResponse>>(
+  ): Promise<List<Connection>> {
+    const { data } = await this.workos.get<ListResponse<ConnectionResponse>>(
       `/connections`,
       {
         query: options,

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -33,7 +33,7 @@ import {
   VerifySessionResponse,
   VerifySessionResponseResponse,
 } from './interfaces';
-import { DeserializedList, List } from '../common/interfaces';
+import { List, ListResponse } from '../common/interfaces';
 import {
   deserializeAuthenticationResponse,
   deserializeCreateEmailVerificationChallengeResponse,
@@ -61,10 +61,13 @@ export class Users {
     return deserializeUser(data);
   }
 
-  async listUsers(options?: ListUsersOptions): Promise<DeserializedList<User>> {
-    const { data } = await this.workos.get<List<UserResponse>>('/users', {
-      query: options,
-    });
+  async listUsers(options?: ListUsersOptions): Promise<List<User>> {
+    const { data } = await this.workos.get<ListResponse<UserResponse>>(
+      '/users',
+      {
+        query: options,
+      },
+    );
 
     return deserializeList(data, deserializeUser);
   }


### PR DESCRIPTION
## Description

* Had previously inverted the naming structure of the serialization of List to help make an easier migration. Now that the bulk of the work of migrating to camelCase is complete we're making the swap to keep the naming in line with the rest of the types.
* DeseralizedList is becoming List and List is becoming ListResponse.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
