### PR TITLE
Fix `updateUser` options

### DIFF
--- a/src/common/interfaces/at-least-one-property-of.interface.ts
+++ b/src/common/interfaces/at-least-one-property-of.interface.ts
@@ -1,0 +1,3 @@
+export type AtLeastOnePropertyOf<T> = {
+  [K in keyof T]: { [L in K]: T[L] } & { [L in Exclude<keyof T, K>]?: T[L] };
+}[keyof T];

--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -1,3 +1,4 @@
+export * from './at-least-one-property-of.interface';
 export * from './event.interface';
 export * from './get-options.interface';
 export * from './list.interface';

--- a/src/users/interfaces/update-user-options.interface.ts
+++ b/src/users/interfaces/update-user-options.interface.ts
@@ -12,7 +12,10 @@ interface UpdateUserOptionsProperties {
 export type UpdateUserOptions = BaseUpdateUserOptions &
   AtLeastOnePropertyOf<UpdateUserOptionsProperties>;
 
-export interface SerializedUpdateUserOptions {
-  first_name?: string;
-  last_name?: string;
+export interface SerializedUpdateUserOptionsProperties {
+  first_name: string;
+  last_name: string;
 }
+
+export type SerializedUpdateUserOptions =
+  AtLeastOnePropertyOf<SerializedUpdateUserOptionsProperties>;

--- a/src/users/interfaces/update-user-options.interface.ts
+++ b/src/users/interfaces/update-user-options.interface.ts
@@ -1,10 +1,18 @@
-export interface UpdateUserOptions {
+import { AtLeastOnePropertyOf } from '../../common/interfaces';
+
+interface BaseUpdateUserOptions {
   userId: string;
+}
+
+interface UpdateUserOptionsProperties {
   firstName: string;
   lastName: string;
 }
 
+export type UpdateUserOptions = BaseUpdateUserOptions &
+  AtLeastOnePropertyOf<UpdateUserOptionsProperties>;
+
 export interface SerializedUpdateUserOptions {
-  first_name: string;
-  last_name: string;
+  first_name?: string;
+  last_name?: string;
 }

--- a/src/users/interfaces/update-user-options.interface.ts
+++ b/src/users/interfaces/update-user-options.interface.ts
@@ -12,10 +12,7 @@ interface UpdateUserOptionsProperties {
 export type UpdateUserOptions = BaseUpdateUserOptions &
   AtLeastOnePropertyOf<UpdateUserOptionsProperties>;
 
-export interface SerializedUpdateUserOptionsProperties {
-  first_name: string;
-  last_name: string;
+export interface SerializedUpdateUserOptions {
+  first_name?: string;
+  last_name?: string;
 }
-
-export type SerializedUpdateUserOptions =
-  AtLeastOnePropertyOf<SerializedUpdateUserOptionsProperties>;

--- a/src/users/serializers/update-user-options.serializer.ts
+++ b/src/users/serializers/update-user-options.serializer.ts
@@ -2,7 +2,8 @@ import { SerializedUpdateUserOptions, UpdateUserOptions } from '../interfaces';
 
 export const serializeUpdateUserOptions = (
   options: UpdateUserOptions,
-): SerializedUpdateUserOptions => ({
-  first_name: options.firstName,
-  last_name: options.lastName,
-});
+): SerializedUpdateUserOptions =>
+  ({
+    first_name: options.firstName,
+    last_name: options.lastName,
+  } as SerializedUpdateUserOptions);

--- a/src/users/serializers/update-user-options.serializer.ts
+++ b/src/users/serializers/update-user-options.serializer.ts
@@ -3,12 +3,12 @@ import { SerializedUpdateUserOptions, UpdateUserOptions } from '../interfaces';
 export const serializeUpdateUserOptions = (
   options: UpdateUserOptions,
 ): SerializedUpdateUserOptions => {
-  if (!Object.keys(options).length) {
-    throw new Error('At least one property must be provided');
+  if (!options.firstName || !options.lastName) {
+    throw new Error('At least one of the properties must be provided');
   }
 
   return {
     first_name: options.firstName,
     last_name: options.lastName,
-  } as SerializedUpdateUserOptions;
+  };
 };

--- a/src/users/serializers/update-user-options.serializer.ts
+++ b/src/users/serializers/update-user-options.serializer.ts
@@ -2,13 +2,7 @@ import { SerializedUpdateUserOptions, UpdateUserOptions } from '../interfaces';
 
 export const serializeUpdateUserOptions = (
   options: UpdateUserOptions,
-): SerializedUpdateUserOptions => {
-  if (!Object.keys(options).length) {
-    throw new Error('At least one of the properties must be provided');
-  }
-
-  return {
-    first_name: options.firstName,
-    last_name: options.lastName,
-  } as SerializedUpdateUserOptions;
-};
+): SerializedUpdateUserOptions => ({
+  first_name: options.firstName,
+  last_name: options.lastName,
+});

--- a/src/users/serializers/update-user-options.serializer.ts
+++ b/src/users/serializers/update-user-options.serializer.ts
@@ -2,8 +2,13 @@ import { SerializedUpdateUserOptions, UpdateUserOptions } from '../interfaces';
 
 export const serializeUpdateUserOptions = (
   options: UpdateUserOptions,
-): SerializedUpdateUserOptions =>
-  ({
+): SerializedUpdateUserOptions => {
+  if (Object.keys(options).length === 0) {
+    throw new Error('At least one property must be provided');
+  }
+
+  return {
     first_name: options.firstName,
     last_name: options.lastName,
-  } as SerializedUpdateUserOptions);
+  } as SerializedUpdateUserOptions;
+};

--- a/src/users/serializers/update-user-options.serializer.ts
+++ b/src/users/serializers/update-user-options.serializer.ts
@@ -3,7 +3,7 @@ import { SerializedUpdateUserOptions, UpdateUserOptions } from '../interfaces';
 export const serializeUpdateUserOptions = (
   options: UpdateUserOptions,
 ): SerializedUpdateUserOptions => {
-  if (Object.keys(options).length === 0) {
+  if (!Object.keys(options).length) {
     throw new Error('At least one property must be provided');
   }
 

--- a/src/users/serializers/update-user-options.serializer.ts
+++ b/src/users/serializers/update-user-options.serializer.ts
@@ -3,12 +3,12 @@ import { SerializedUpdateUserOptions, UpdateUserOptions } from '../interfaces';
 export const serializeUpdateUserOptions = (
   options: UpdateUserOptions,
 ): SerializedUpdateUserOptions => {
-  if (!options.firstName || !options.lastName) {
+  if (!Object.keys(options).length) {
     throw new Error('At least one of the properties must be provided');
   }
 
   return {
     first_name: options.firstName,
     last_name: options.lastName,
-  };
+  } as SerializedUpdateUserOptions;
 };

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -337,8 +337,30 @@ describe('UserManagement', () => {
       });
 
       expect(mock.history.put[0].url).toEqual(`/users/${userId}`);
+      expect(JSON.parse(mock.history.put[0].data)).toEqual({
+        first_name: 'Dane',
+        last_name: 'Williams',
+      });
       expect(resp).toMatchObject({
         email: 'test01@example.com',
+      });
+    });
+
+    describe('when only one property is provided', () => {
+      it('sends a updateUser request', async () => {
+        mock.onPut(`/users/${userId}`).reply(200, userFixture);
+        const resp = await workos.users.updateUser({
+          userId,
+          firstName: 'Dane',
+        });
+
+        expect(mock.history.put[0].url).toEqual(`/users/${userId}`);
+        expect(JSON.parse(mock.history.put[0].data)).toEqual({
+          first_name: 'Dane',
+        });
+        expect(resp).toMatchObject({
+          email: 'test01@example.com',
+        });
       });
     });
   });


### PR DESCRIPTION
## Description

`updateUser` options should require at least one property, not all properties to be passed. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
