### PR TITLE
Switch Directory.type to DirectoryType instead of string

### DIFF
--- a/src/directory-sync/interfaces/directory.interface.ts
+++ b/src/directory-sync/interfaces/directory.interface.ts
@@ -1,9 +1,8 @@
 export type DirectoryType =
-  | 'okta scim v1.1'
-  | 'okta scim v2.0'
   | 'azure scim v2.0'
   | 'bamboohr'
   | 'breathe hr'
+  | 'cezanne hr'
   | 'cyberark scim v2.0'
   | 'fourth hr'
   | 'gsuite directory'
@@ -12,10 +11,16 @@ export type DirectoryType =
   | 'gusto'
   | 'hibob'
   | 'jump cloud scim v2.0'
+  | 'okta scim v1.1'
+  | 'okta scim v2.0'
   | 'onelogin scim v2.0'
   | 'people hr'
+  | 'personio'
   | 'pingfederate scim v2.0'
   | 'rippling'
+  | 'rippling scim v2.0'
+  | 'sftp'
+  | 'sftp workday'
   | 's3'
   | 'workday';
 
@@ -27,7 +32,7 @@ export interface Directory {
   name: string;
   organizationId?: string;
   state: 'unlinked' | 'linked' | 'invalid_credentials';
-  type: string;
+  type: DirectoryType;
   createdAt: string;
   updatedAt: string;
 }
@@ -40,7 +45,7 @@ export interface DirectoryResponse {
   name: string;
   organization_id?: string;
   state: 'unlinked' | 'linked' | 'invalid_credentials';
-  type: string;
+  type: DirectoryType;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Description

* Additionally adds some missing types to DirectoryType.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
