### PR TITLE
Ensure the SDK version in code matches `package.json`

### DIFF
--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-
+import fs from 'fs/promises';
 import { WorkOS } from './workos';
 import {
   NoApiKeyProvidedException,
@@ -88,6 +88,16 @@ describe('WorkOS', () => {
           'X-My-Custom-Header': 'Hey there!',
         });
       });
+    });
+  });
+
+  describe('version', () => {
+    it('matches the version in `package.json`', async () => {
+      const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+      const packageJson = JSON.parse(await fs.readFile('package.json', 'utf8'));
+
+      expect(workos.version).toBe(packageJson.version);
     });
   });
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -80,6 +80,10 @@ export class WorkOS {
     });
   }
 
+  get version() {
+    return VERSION;
+  }
+
   async post<T = any, D = any, P = any>(
     path: string,
     entity: P,


### PR DESCRIPTION
## Description

This PR adds a test that ensures that the SDK version number defined in the code is the same as the one in `package.json`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
