### PR TITLE
Normalize DirectoryState to newer values

### DIFF
--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -27,7 +27,7 @@ describe('DirectorySync', () => {
     name: 'Foo',
     object: 'directory',
     organizationId: 'org_01EXSR7M9QTKCC5D531SMCWMYG',
-    state: 'linked',
+    state: 'active',
     type: 'okta scim v1.1',
     updatedAt: '2021-12-13 12:15:45.531847',
   };

--- a/src/directory-sync/interfaces/directory.interface.ts
+++ b/src/directory-sync/interfaces/directory.interface.ts
@@ -24,6 +24,20 @@ export type DirectoryType =
   | 's3'
   | 'workday';
 
+export type DirectoryState =
+  | 'active'
+  | 'deleting'
+  | 'inactive'
+  | 'invalid_credentials'
+  | 'validating';
+
+export type DirectoryStateResponse =
+  | 'deleting'
+  | 'invalid_credentials'
+  | 'linked'
+  | 'unlinked'
+  | 'validating';
+
 export interface Directory {
   object: 'directory';
   id: string;
@@ -31,7 +45,7 @@ export interface Directory {
   externalKey: string;
   name: string;
   organizationId?: string;
-  state: 'unlinked' | 'linked' | 'invalid_credentials';
+  state: DirectoryState;
   type: DirectoryType;
   createdAt: string;
   updatedAt: string;
@@ -44,19 +58,11 @@ export interface DirectoryResponse {
   external_key: string;
   name: string;
   organization_id?: string;
-  state: 'unlinked' | 'linked' | 'invalid_credentials';
+  state: DirectoryStateResponse;
   type: DirectoryType;
   created_at: string;
   updated_at: string;
 }
-
-export type EventDirectoryState =
-  | 'active'
-  | 'validating'
-  | 'invalid_credentials'
-  | 'inactive'
-  | 'deleting';
-
 interface EventDirectoryDomain {
   object: 'organization_domain';
   id: string;
@@ -68,7 +74,7 @@ export interface EventDirectory {
   id: string;
   externalKey: string;
   type: DirectoryType;
-  state: EventDirectoryState;
+  state: DirectoryState;
   name: string;
   organizationId?: string;
   domains: EventDirectoryDomain[];
@@ -81,7 +87,7 @@ export interface EventDirectoryResponse {
   id: string;
   external_key: string;
   type: DirectoryType;
-  state: EventDirectoryState;
+  state: DirectoryState;
   name: string;
   organization_id?: string;
   domains: EventDirectoryDomain[];

--- a/src/directory-sync/serializers/directory.serializer.ts
+++ b/src/directory-sync/serializers/directory.serializer.ts
@@ -1,6 +1,8 @@
 import {
   Directory,
   DirectoryResponse,
+  DirectoryState,
+  DirectoryStateResponse,
   EventDirectory,
   EventDirectoryResponse,
 } from '../interfaces';
@@ -14,11 +16,25 @@ export const deserializeDirectory = (
   externalKey: directory.external_key,
   name: directory.name,
   organizationId: directory.organization_id,
-  state: directory.state,
+  state: deserializeDirectoryState(directory.state),
   type: directory.type,
   createdAt: directory.created_at,
   updatedAt: directory.updated_at,
 });
+
+export const deserializeDirectoryState = (
+  state: DirectoryStateResponse,
+): DirectoryState => {
+  if (state === 'linked') {
+    return 'active';
+  }
+
+  if (state === 'unlinked') {
+    return 'inactive';
+  }
+
+  return state;
+};
 
 export const deserializeEventDirectory = (
   directory: EventDirectoryResponse,


### PR DESCRIPTION
## Description

* Now that we have a serialization layer in our Node SDK, we're able to start bypassing some of the legacy naming decisions that we've made. They key benefit here is that this will bring the API return types in line with our webhook return values.
* This is a breaking change our developers will need to handle when updating their SDKs.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
