### PR TITLE
Make password optional when creating users

### DIFF
--- a/src/users/interfaces/create-user-options.interface.ts
+++ b/src/users/interfaces/create-user-options.interface.ts
@@ -1,6 +1,6 @@
 export interface CreateUserOptions {
   email: string;
-  password: string;
+  password?: string;
   firstName?: string;
   lastName?: string;
   emailVerified?: boolean;
@@ -8,7 +8,7 @@ export interface CreateUserOptions {
 
 export interface SerializedCreateUserOptions {
   email: string;
-  password: string;
+  password?: string;
   first_name?: string;
   last_name?: string;
   email_verified?: boolean;


### PR DESCRIPTION
## Description

Password is now optional when creating users in the API as of workos/workos#22384. This matches it.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
