### PR TITLE
Remove `--tag=next` in npm publish

### DIFF
--- a/.semaphore/npm.yml
+++ b/.semaphore/npm.yml
@@ -21,5 +21,4 @@ blocks:
         - name: yarn publish
           commands:
             - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-            # TODO: Remove the `--tag=next` specifier when we're ready to release v3.0.0.
-            - yarn publish --access=public --tag=next
+            - yarn publish --access=public


### PR DESCRIPTION
## Description

This PR removes the `--tag=next` so that we can publish to the `latest` tag.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
