### PR TITLE
Simplify `UpdateUserOptions`

### DIFF
--- a/src/common/interfaces/at-least-one-property-of.interface.ts
+++ b/src/common/interfaces/at-least-one-property-of.interface.ts
@@ -1,3 +1,0 @@
-export type AtLeastOnePropertyOf<T> = {
-  [K in keyof T]: { [L in K]: T[L] } & { [L in Exclude<keyof T, K>]?: T[L] };
-}[keyof T];

--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -1,4 +1,3 @@
-export * from './at-least-one-property-of.interface';
 export * from './event.interface';
 export * from './get-options.interface';
 export * from './list.interface';

--- a/src/users/interfaces/update-user-options.interface.ts
+++ b/src/users/interfaces/update-user-options.interface.ts
@@ -1,16 +1,8 @@
-import { AtLeastOnePropertyOf } from '../../common/interfaces';
-
-interface BaseUpdateUserOptions {
+export interface UpdateUserOptions {
   userId: string;
+  firstName?: string;
+  lastName?: string;
 }
-
-interface UpdateUserOptionsProperties {
-  firstName: string;
-  lastName: string;
-}
-
-export type UpdateUserOptions = BaseUpdateUserOptions &
-  AtLeastOnePropertyOf<UpdateUserOptionsProperties>;
 
 export interface SerializedUpdateUserOptions {
   first_name?: string;


### PR DESCRIPTION
## Description

This PR simplifies the `UpdateUserOptions` type.

### Motivation

The current type is too hard to type with non-static data, which severely limits its usability in real-world scenarios.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
