### PR TITLE
Fix: Properly serialize args for listConnections and listDirectories

### DIFF
--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -137,11 +137,13 @@ describe('DirectorySync', () => {
         mock
           .onGet('/directories', {
             domain: 'google.com',
+            organization_id: 'org_1234',
           })
           .replyOnce(200, directoryListResponse);
 
         const subject = await workos.directorySync.listDirectories({
           domain: 'google.com',
+          organizationId: 'org_1234',
         });
 
         expect(subject).toMatchObject({

--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -17,6 +17,7 @@ import {
   deserializeDirectory,
   deserializeDirectoryGroup,
   deserializeDirectoryUserWithGroups,
+  serializeListDirectoriesOptions,
 } from './serializers';
 import { fetchAndDeserialize } from '../common/utils/fetch-and-deserialize';
 
@@ -31,7 +32,7 @@ export class DirectorySync {
         this.workos,
         '/directories',
         deserializeDirectory,
-        options,
+        options ? serializeListDirectoriesOptions(options) : undefined,
       ),
       (params) =>
         fetchAndDeserialize<DirectoryResponse, Directory>(

--- a/src/directory-sync/interfaces/list-directories-options.interface.ts
+++ b/src/directory-sync/interfaces/list-directories-options.interface.ts
@@ -5,3 +5,9 @@ export interface ListDirectoriesOptions extends PaginationOptions {
   organizationId?: string;
   search?: string;
 }
+
+export interface SerializedListDirectoriesOptions extends PaginationOptions {
+  domain?: string;
+  organization_id?: string;
+  search?: string;
+}

--- a/src/directory-sync/serializers/index.ts
+++ b/src/directory-sync/serializers/index.ts
@@ -1,3 +1,4 @@
 export * from './directory-group.serializer';
 export * from './directory-user.serializer';
 export * from './directory.serializer';
+export * from './list-directories-options.serializer';

--- a/src/directory-sync/serializers/list-directories-options.serializer.ts
+++ b/src/directory-sync/serializers/list-directories-options.serializer.ts
@@ -1,0 +1,16 @@
+import {
+  ListDirectoriesOptions,
+  SerializedListDirectoriesOptions,
+} from '../interfaces';
+
+export const serializeListDirectoriesOptions = (
+  options: ListDirectoriesOptions,
+): SerializedListDirectoriesOptions => ({
+  domain: options.domain,
+  organization_id: options.organizationId,
+  search: options.search,
+  limit: options.limit,
+  before: options.before,
+  after: options.after,
+  order: options.order,
+});

--- a/src/sso/serializers/index.ts
+++ b/src/sso/serializers/index.ts
@@ -1,3 +1,4 @@
 export * from './connection.serializer';
+export * from './list-connections-options.serializer';
 export * from './profile-and-token.serializer';
 export * from './profile.serializer';

--- a/src/sso/serializers/list-connections-options.serializer.ts
+++ b/src/sso/serializers/list-connections-options.serializer.ts
@@ -1,0 +1,16 @@
+import {
+  ListConnectionsOptions,
+  SerializedListConnectionsOptions,
+} from '../interfaces';
+
+export const serializeListConnectionsOptions = (
+  options: ListConnectionsOptions,
+): SerializedListConnectionsOptions => ({
+  connection_type: options.connectionType,
+  domain: options.domain,
+  organization_id: options.organizationId,
+  limit: options.limit,
+  before: options.before,
+  after: options.after,
+  order: options.order,
+});

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -16,6 +16,7 @@ import {
   deserializeConnection,
   deserializeProfile,
   deserializeProfileAndToken,
+  serializeListConnectionsOptions,
 } from './serializers';
 import { fetchAndDeserialize } from '../common/utils/fetch-and-deserialize';
 
@@ -45,7 +46,7 @@ export class SSO {
         this.workos,
         '/connections',
         deserializeConnection,
-        options,
+        options ? serializeListConnectionsOptions(options) : undefined,
       ),
       (params) =>
         fetchAndDeserialize<ConnectionResponse, Connection>(


### PR DESCRIPTION
## Description

* When we added serialization, we introduced a bug for these two endpoints that did not properly pass through the serialization of arguments for these two endpoints. This resolves the issue and adds tests to check for regressions in the future.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
