### PR TITLE
Remove distinction between "Managed" and "Unmanaged" users

### DIFF
--- a/src/users/exceptions/index.ts
+++ b/src/users/exceptions/index.ts
@@ -1,8 +1,0 @@
-import { UserResponse } from '../interfaces';
-
-export class UnexpectedUserTypeException extends Error {
-  constructor(user: UserResponse) {
-    super();
-    this.message = `Unsupported user type: ${user.user_type} received from API.`;
-  }
-}

--- a/src/users/fixtures/list-users.json
+++ b/src/users/fixtures/list-users.json
@@ -9,7 +9,6 @@
       "last_name": "User",
       "created_at": "2023-07-18T02:07:19.911Z",
       "updated_at": "2023-07-18T02:07:19.911Z",
-      "user_type": "unmanaged",
       "email_verified_at": "2023-07-17T20:07:20.055Z"
     }
   ],

--- a/src/users/fixtures/user.json
+++ b/src/users/fixtures/user.json
@@ -6,6 +6,5 @@
   "last_name": "User",
   "created_at": "2023-07-18T02:07:19.911Z",
   "updated_at": "2023-07-18T02:07:19.911Z",
-  "user_type": "unmanaged",
   "email_verified_at": "2023-07-17T20:07:20.055Z"
 }

--- a/src/users/interfaces/user.interface.ts
+++ b/src/users/interfaces/user.interface.ts
@@ -1,43 +1,19 @@
-export type User = ManagedUser | UnmanagedUser;
-export type UserResponse = ManagedUserResponse | UnmanagedUserResponse;
-
-interface ManagedUser extends BaseUser {
-  userType: 'managed';
-  ssoProfileId: string | null;
-}
-
-interface ManagedUserResponse extends BaseUserResponse {
-  user_type: 'managed';
-  sso_profile_id: string | null;
-}
-interface UnmanagedUser extends BaseUser {
-  userType: 'unmanaged';
-  emailVerifiedAt: string | null;
-  googleOauthProfileId: string | null;
-  microsoftOauthProfileId: string | null;
-}
-
-interface UnmanagedUserResponse extends BaseUserResponse {
-  user_type: 'unmanaged';
-  email_verified_at: string | null;
-  google_oauth_profile_id: string | null;
-  microsoft_oauth_profile_id: string | null;
-}
-
-export interface BaseUser {
+export interface User {
   object: 'user';
   id: string;
   email: string;
+  emailVerifiedAt: string | null;
   firstName: string | null;
   lastName: string | null;
   createdAt: string;
   updatedAt: string;
 }
 
-interface BaseUserResponse {
+export interface UserResponse {
   object: 'user';
   id: string;
   email: string;
+  email_verified_at: string | null;
   first_name: string | null;
   last_name: string | null;
   created_at: string;

--- a/src/users/serializers/user.serializer.ts
+++ b/src/users/serializers/user.serializer.ts
@@ -1,33 +1,12 @@
-import { UnexpectedUserTypeException } from '../exceptions';
-import { BaseUser, User, UserResponse } from '../interfaces';
+import { User, UserResponse } from '../interfaces';
 
-export const deserializeUser = (user: UserResponse): User => {
-  const baseUser: BaseUser = {
-    object: user.object,
-    id: user.id,
-    email: user.email,
-    firstName: user.first_name,
-    lastName: user.last_name,
-    createdAt: user.created_at,
-    updatedAt: user.updated_at,
-  };
-
-  switch (user.user_type) {
-    case 'managed':
-      return {
-        ...baseUser,
-        userType: user.user_type,
-        ssoProfileId: user.sso_profile_id,
-      };
-    case 'unmanaged':
-      return {
-        ...baseUser,
-        userType: user.user_type,
-        emailVerifiedAt: user.email_verified_at,
-        googleOauthProfileId: user.google_oauth_profile_id,
-        microsoftOauthProfileId: user.microsoft_oauth_profile_id,
-      };
-    default:
-      throw new UnexpectedUserTypeException(user);
-  }
-};
+export const deserializeUser = (user: UserResponse): User => ({
+  object: user.object,
+  id: user.id,
+  email: user.email,
+  emailVerifiedAt: user.email_verified_at,
+  firstName: user.first_name,
+  lastName: user.last_name,
+  createdAt: user.created_at,
+  updatedAt: user.updated_at,
+});

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -23,7 +23,6 @@ describe('UserManagement', () => {
         email: 'test01@example.com',
         firstName: 'Test 01',
         lastName: 'User',
-        userType: 'unmanaged',
         emailVerifiedAt: '2023-07-17T20:07:20.055Z',
       });
     });
@@ -87,7 +86,6 @@ describe('UserManagement', () => {
         email: 'test01@example.com',
         firstName: 'Test 01',
         lastName: 'User',
-        userType: 'unmanaged',
         emailVerifiedAt: '2023-07-17T20:07:20.055Z',
         createdAt: '2023-07-18T02:07:19.911Z',
         updatedAt: '2023-07-18T02:07:19.911Z',


### PR DESCRIPTION
## Description

This PR removes the distinction between "Managed" and "Unmanaged" users from the SDK.

This concept is being removed from the API in the near future.

This is a breaking change to the User Management portion of the SDK.

Resolves USRLD-843.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
