### PR TITLE
Rename emailVerifiedAt to emailVerified and remove type arg from listUsers

### DIFF
--- a/src/users/fixtures/user.json
+++ b/src/users/fixtures/user.json
@@ -6,5 +6,5 @@
   "last_name": "User",
   "created_at": "2023-07-18T02:07:19.911Z",
   "updated_at": "2023-07-18T02:07:19.911Z",
-  "email_verified_at": "2023-07-17T20:07:20.055Z"
+  "email_verified": true
 }

--- a/src/users/interfaces/list-users-options.interface.ts
+++ b/src/users/interfaces/list-users-options.interface.ts
@@ -1,7 +1,6 @@
 import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
 
 export interface ListUsersOptions extends PaginationOptions {
-  type?: 'managed' | 'unmanaged';
   email?: string;
   organization?: string;
 }

--- a/src/users/interfaces/user.interface.ts
+++ b/src/users/interfaces/user.interface.ts
@@ -2,7 +2,7 @@ export interface User {
   object: 'user';
   id: string;
   email: string;
-  emailVerifiedAt: string | null;
+  emailVerified: boolean;
   firstName: string | null;
   lastName: string | null;
   createdAt: string;
@@ -13,7 +13,7 @@ export interface UserResponse {
   object: 'user';
   id: string;
   email: string;
-  email_verified_at: string | null;
+  email_verified: boolean;
   first_name: string | null;
   last_name: string | null;
   created_at: string;

--- a/src/users/serializers/user.serializer.ts
+++ b/src/users/serializers/user.serializer.ts
@@ -4,7 +4,7 @@ export const deserializeUser = (user: UserResponse): User => ({
   object: user.object,
   id: user.id,
   email: user.email,
-  emailVerifiedAt: user.email_verified_at,
+  emailVerified: user.email_verified,
   firstName: user.first_name,
   lastName: user.last_name,
   createdAt: user.created_at,

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -23,7 +23,7 @@ describe('UserManagement', () => {
         email: 'test01@example.com',
         firstName: 'Test 01',
         lastName: 'User',
-        emailVerifiedAt: '2023-07-17T20:07:20.055Z',
+        emailVerified: true,
       });
     });
   });
@@ -53,7 +53,6 @@ describe('UserManagement', () => {
       await workos.users.listUsers({
         email: 'foo@example.com',
         organization: 'org_someorg',
-        type: 'managed',
         after: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
         limit: 10,
       });
@@ -61,7 +60,6 @@ describe('UserManagement', () => {
       expect(mock.history.get[0].params).toEqual({
         email: 'foo@example.com',
         organization: 'org_someorg',
-        type: 'managed',
         after: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
         limit: 10,
         order: 'desc',
@@ -86,7 +84,7 @@ describe('UserManagement', () => {
         email: 'test01@example.com',
         firstName: 'Test 01',
         lastName: 'User',
-        emailVerifiedAt: '2023-07-17T20:07:20.055Z',
+        emailVerified: true,
         createdAt: '2023-07-18T02:07:19.911Z',
         updatedAt: '2023-07-18T02:07:19.911Z',
       });


### PR DESCRIPTION
## Description

* The API has changed and we now send email_verified instead of email_verified_at in our User response. This is also now a boolean instead of a timestamp.
* The type was previously removed from Users and this change removes the now defunct type argument from listUsers.
* Fixes USRLD-900

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
