### PR TITLE
Migrate completeEmailVerification to verifyEmail

### DIFF
--- a/src/users/interfaces/index.ts
+++ b/src/users/interfaces/index.ts
@@ -16,3 +16,4 @@ export * from './session.interface';
 export * from './update-user-options.interface';
 export * from './update-user-password-options.interface';
 export * from './user.interface';
+export * from './verify-email-options.interface';

--- a/src/users/interfaces/verify-email-options.interface.ts
+++ b/src/users/interfaces/verify-email-options.interface.ts
@@ -1,0 +1,8 @@
+export interface VerifyEmailOptions {
+  code: string;
+  userId: string;
+}
+
+export interface SerializedVerifyEmailOptions {
+  code: string;
+}

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -193,15 +193,18 @@ describe('UserManagement', () => {
       });
     });
 
-    describe('completeEmailVerification', () => {
+    describe('verifyEmail', () => {
       it('sends a Complete Email Verification request', async () => {
-        mock.onPost(`/users/email_verification`).reply(200, userFixture);
+        mock.onPost(`/users/user-123/verify_email`).reply(200, userFixture);
 
-        const resp = await workos.users.completeEmailVerification(
-          'email-verification-token',
+        const resp = await workos.users.verifyEmail({
+          userId: 'user-123',
+          code: '123456',
+        });
+
+        expect(mock.history.post[0].url).toEqual(
+          `/users/user-123/verify_email`,
         );
-
-        expect(mock.history.post[0].url).toEqual(`/users/email_verification`);
 
         expect(resp).toMatchObject({
           email: 'test01@example.com',

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -195,15 +195,15 @@ describe('UserManagement', () => {
 
     describe('verifyEmail', () => {
       it('sends a Complete Email Verification request', async () => {
-        mock.onPost(`/users/user-123/verify_email`).reply(200, userFixture);
+        mock.onPost(`/users/user_123/verify_email`).reply(200, userFixture);
 
         const resp = await workos.users.verifyEmail({
-          userId: 'user-123',
+          userId: 'user_123',
           code: '123456',
         });
 
         expect(mock.history.post[0].url).toEqual(
-          `/users/user-123/verify_email`,
+          `/users/user_123/verify_email`,
         );
 
         expect(resp).toMatchObject({

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -33,6 +33,8 @@ import {
   User,
   UserResponse,
   EnrollUserInMfaFactorOptions,
+  VerifyEmailOptions,
+  SerializedVerifyEmailOptions,
 } from './interfaces';
 import {
   deserializeAuthenticationResponse,
@@ -178,13 +180,14 @@ export class Users {
     return data;
   }
 
-  async completeEmailVerification(token: string): Promise<User> {
-    const { data } = await this.workos.post<UserResponse>(
-      '/users/email_verification',
-      {
-        token,
-      },
-    );
+  async verifyEmail({ code, userId }: VerifyEmailOptions): Promise<User> {
+    const { data } = await this.workos.post<
+      UserResponse,
+      any,
+      SerializedVerifyEmailOptions
+    >(`/users/${userId}/verify_email`, {
+      code,
+    });
 
     return deserializeUser(data);
   }


### PR DESCRIPTION
## Description

* Changes the completeEmailVerification path and body to match the latest updates from the API. It now not only takes a token (now renamed to code) as an argument, but also requires the userId of the user.
* Fixes USRLD-849, USRLD-934

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
