### PR TITLE
Modify `updateUser` to use `email_verified` rather than `email_verified_at`

### DIFF
--- a/src/users/interfaces/update-user-options.interface.ts
+++ b/src/users/interfaces/update-user-options.interface.ts
@@ -2,11 +2,11 @@ export interface UpdateUserOptions {
   userId: string;
   firstName?: string;
   lastName?: string;
-  emailVerifiedAt?: string;
+  emailVerified?: boolean;
 }
 
 export interface SerializedUpdateUserOptions {
   first_name?: string;
   last_name?: string;
-  email_verified_at?: string;
+  email_verified?: boolean;
 }

--- a/src/users/serializers/update-user-options.serializer.ts
+++ b/src/users/serializers/update-user-options.serializer.ts
@@ -5,5 +5,5 @@ export const serializeUpdateUserOptions = (
 ): SerializedUpdateUserOptions => ({
   first_name: options.firstName,
   last_name: options.lastName,
-  email_verified_at: options.emailVerifiedAt,
+  email_verified: options.emailVerified,
 });

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -320,14 +320,14 @@ describe('UserManagement', () => {
         userId,
         firstName: 'Dane',
         lastName: 'Williams',
-        emailVerifiedAt: '2023-07-17T20:07:20.055Z',
+        emailVerified: true,
       });
 
       expect(mock.history.put[0].url).toEqual(`/users/${userId}`);
       expect(JSON.parse(mock.history.put[0].data)).toEqual({
         first_name: 'Dane',
         last_name: 'Williams',
-        email_verified_at: '2023-07-17T20:07:20.055Z',
+        email_verified: true,
       });
       expect(resp).toMatchObject({
         email: 'test01@example.com',


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
