### PR TITLE
Change magicAuthChallengedId to userId on authenticateUserWithMagicAuth

### DIFF
--- a/src/users/interfaces/authenticate-user-with-magic-auth-options.interface.ts
+++ b/src/users/interfaces/authenticate-user-with-magic-auth-options.interface.ts
@@ -1,7 +1,7 @@
 export interface AuthenticateUserWithMagicAuthOptions {
   clientId: string;
   code: string;
-  magicAuthChallengeId: string;
+  userId: string;
   ipAddress?: string;
   userAgent?: string;
 }
@@ -15,7 +15,7 @@ export interface SerializedAuthenticateUserWithMagicAuthOptions {
   client_id: string;
   client_secret: string | undefined;
   code: string;
-  magic_auth_challenge_id: string;
+  user_id: string;
   ip_address?: string;
   user_agent?: string;
 }

--- a/src/users/serializers/authenticate-user-with-magic-auth-options.serializer.ts
+++ b/src/users/serializers/authenticate-user-with-magic-auth-options.serializer.ts
@@ -12,7 +12,7 @@ export const serializeAuthenticateUserWithMagicAuthOptions = (
   client_id: options.clientId,
   client_secret: options.clientSecret,
   code: options.code,
-  magic_auth_challenge_id: options.magicAuthChallengeId,
+  user_id: options.userId,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
 });

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -99,7 +99,7 @@ describe('UserManagement', () => {
       const resp = await workos.users.authenticateUserWithMagicAuth({
         clientId: 'proj_whatever',
         code: '123456',
-        magicAuthChallengeId: 'auth_challenge_123',
+        userId: userFixture.id,
       });
 
       expect(mock.history.post[0].url).toEqual('/users/authenticate');


### PR DESCRIPTION
## Description

* Updates to the latest state of the API.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
