### PR TITLE
Remove MagicAuthChallenge interface

### DIFF
--- a/src/users/interfaces/index.ts
+++ b/src/users/interfaces/index.ts
@@ -9,7 +9,6 @@ export * from './create-user-options.interface';
 export * from './delete-user-options.interface';
 export * from './enroll-user-in-mfa-factor.interface';
 export * from './list-users-options.interface';
-export * from './magic-auth-challenge.interface';
 export * from './remove-user-from-organization-options.interface';
 export * from './send-magic-auth-code-options.interface';
 export * from './send-verification-email-options';

--- a/src/users/interfaces/magic-auth-challenge.interface.ts
+++ b/src/users/interfaces/magic-auth-challenge.interface.ts
@@ -1,3 +1,0 @@
-export interface MagicAuthChallenge {
-  id: string;
-}


### PR DESCRIPTION
## Description

* This interface is no longer used after all related endpoints were migrated to returning a User object instead.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
