### PR TITLE
Update `sendMagicAuthCode` to take email rather than email_address

### DIFF
--- a/src/users/interfaces/send-magic-auth-code-options.interface.ts
+++ b/src/users/interfaces/send-magic-auth-code-options.interface.ts
@@ -1,7 +1,7 @@
 export interface SendMagicAuthCodeOptions {
-  emailAddress: string;
+  email: string;
 }
 
 export interface SerializedSendMagicAuthCodeOptions {
-  email_address: string;
+  email: string;
 }

--- a/src/users/serializers/send-magic-auth-code-options.serializer.ts
+++ b/src/users/serializers/send-magic-auth-code-options.serializer.ts
@@ -6,5 +6,5 @@ import {
 export const serializeSendMagicAuthCodeOptions = (
   options: SendMagicAuthCodeOptions,
 ): SerializedSendMagicAuthCodeOptions => ({
-  email_address: options.emailAddress,
+  email: options.email,
 });

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -237,7 +237,7 @@ describe('UserManagement', () => {
     it('sends a Send Magic Auth Code request', async () => {
       mock
         .onPost('/users/magic_auth/send', {
-          email_address: 'bob.loblaw@example.com',
+          email: 'bob.loblaw@example.com',
         })
         .reply(200, {
           user: {
@@ -252,7 +252,7 @@ describe('UserManagement', () => {
         });
 
       const response = await workos.users.sendMagicAuthCode({
-        emailAddress: 'bob.loblaw@example.com',
+        email: 'bob.loblaw@example.com',
       });
 
       expect(mock.history.post[0].url).toEqual('/users/magic_auth/send');


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
