### PR TITLE
All authentication methods should pass `ipAddress` and `userAgent`

### DIFF
--- a/src/users/interfaces/authenticate-with-code-options.interface.ts
+++ b/src/users/interfaces/authenticate-with-code-options.interface.ts
@@ -1,6 +1,8 @@
 export interface AuthenticateWithCodeOptions {
   clientId: string;
   code: string;
+  ipAddress?: string;
+  userAgent?: string;
 }
 
 export interface AuthenticateUserWithCodeCredentials {
@@ -12,4 +14,6 @@ export interface SerializedAuthenticateWithCodeOptions {
   client_id: string;
   client_secret: string | undefined;
   code: string;
+  ip_address?: string;
+  user_agent?: string;
 }

--- a/src/users/interfaces/authenticate-with-totp-options.interface.ts
+++ b/src/users/interfaces/authenticate-with-totp-options.interface.ts
@@ -3,6 +3,8 @@ export interface AuthenticateWithTotpOptions {
   code: string;
   pendingAuthenticationToken: string;
   authenticationChallengeId: string;
+  ipAddress?: string;
+  userAgent?: string;
 }
 
 export interface AuthenticateUserWithTotpCredentials {
@@ -16,4 +18,6 @@ export interface SerializedAuthenticateWithTotpOptions {
   code: string;
   pending_authentication_token: string;
   authentication_challenge_id: string;
+  ip_address?: string;
+  user_agent?: string;
 }

--- a/src/users/serializers/authenticate-with-code-options.serializer.ts
+++ b/src/users/serializers/authenticate-with-code-options.serializer.ts
@@ -11,4 +11,6 @@ export const serializeAuthenticateWithCodeOptions = (
   client_id: options.clientId,
   client_secret: options.clientSecret,
   code: options.code,
+  ip_address: options.ipAddress,
+  user_agent: options.userAgent,
 });

--- a/src/users/serializers/authenticate-with-totp-options.serializer.ts
+++ b/src/users/serializers/authenticate-with-totp-options.serializer.ts
@@ -1,9 +1,8 @@
-import {} from '../interfaces';
 import {
   AuthenticateUserWithTotpCredentials,
   AuthenticateWithTotpOptions,
   SerializedAuthenticateWithTotpOptions,
-} from '../interfaces/authenticate-with-totp-options.interface';
+} from '../interfaces';
 
 export const serializeAuthenticateWithTotpOptions = (
   options: AuthenticateWithTotpOptions & AuthenticateUserWithTotpCredentials,
@@ -14,4 +13,6 @@ export const serializeAuthenticateWithTotpOptions = (
   code: options.code,
   authentication_challenge_id: options.authenticationChallengeId,
   pending_authentication_token: options.pendingAuthenticationToken,
+  ip_address: options.ipAddress,
+  user_agent: options.userAgent,
 });


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
