### PR TITLE
Add rate limiting to pagination

### DIFF
--- a/src/common/utils/pagination.ts
+++ b/src/common/utils/pagination.ts
@@ -31,6 +31,8 @@ export class AutoPaginatable<T> {
     yield result.data;
 
     if (result.listMetadata.after) {
+      // Delay of 4rps to respect list users rate limits
+      await new Promise(resolve => setTimeout(resolve, 250));
       yield* this.generatePages({ after: result.listMetadata.after });
     }
   }

--- a/src/common/utils/pagination.ts
+++ b/src/common/utils/pagination.ts
@@ -32,7 +32,7 @@ export class AutoPaginatable<T> {
 
     if (result.listMetadata.after) {
       // Delay of 4rps to respect list users rate limits
-      await new Promise(resolve => setTimeout(resolve, 250));
+      await new Promise((resolve) => setTimeout(resolve, 250));
       yield* this.generatePages({ after: result.listMetadata.after });
     }
   }


### PR DESCRIPTION
## Description

Our auto pagination doesn't currently respect a limit of 4 RPS (the limit on our `list_users` endpoint). This is a proposed fix, though it applies to all endpoints.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
