### PR TITLE
Add domain verification intent enum and test

### DIFF
--- a/src/portal/interfaces/generate-portal-link-intent.interface.ts
+++ b/src/portal/interfaces/generate-portal-link-intent.interface.ts
@@ -1,5 +1,6 @@
 export enum GeneratePortalLinkIntent {
   AuditLogs = 'audit_logs',
+  DomainVerification = 'domain_verification',
   DSync = 'dsync',
   LogStreams = 'log_streams',
   SSO = 'sso',

--- a/src/portal/portal.spec.ts
+++ b/src/portal/portal.spec.ts
@@ -35,6 +35,28 @@ describe('Portal', () => {
         });
       });
 
+      describe('with the domain_verification intent', () => {
+        it('returns an Admin Portal link', async () => {
+          mock
+            .onPost('/portal/generate_link', {
+              intent: GeneratePortalLinkIntent.DomainVerification,
+              organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
+              return_url: 'https://www.example.com',
+            })
+            .replyOnce(201, generateLink);
+
+          const { link } = await workos.portal.generateLink({
+            intent: GeneratePortalLinkIntent.DomainVerification,
+            organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
+            returnUrl: 'https://www.example.com',
+          });
+
+          expect(link).toEqual(
+            'https://id.workos.com/portal/launch?secret=secret',
+          );
+        });
+      });
+
       describe('with the dsync intent', () => {
         it('returns an Admin Portal link', async () => {
           mock


### PR DESCRIPTION
## Description
Add domain verification intent enum and test

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
