### PR TITLE
Remove `domains` and `allowProfilesOutsideOrganization` from `Organization` entity

### DIFF
--- a/src/organizations/fixtures/create-organization.json
+++ b/src/organizations/fixtures/create-organization.json
@@ -2,12 +2,5 @@
   "name": "Test Organization",
   "object": "organization",
   "id": "org_01EHT88Z8J8795GZNQ4ZP1J81T",
-  "allow_profiles_outside_organization": false,
-  "domains": [
-    {
-      "domain": "example.com",
-      "object": "organization_domain",
-      "id": "org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8"
-    }
-  ]
+  "allow_profiles_outside_organization": false
 }

--- a/src/organizations/fixtures/get-organization.json
+++ b/src/organizations/fixtures/get-organization.json
@@ -2,12 +2,5 @@
   "name": "Test Organization 3",
   "object": "organization",
   "id": "org_01EHT88Z8J8795GZNQ4ZP1J81T",
-  "allow_profiles_outside_organization": false,
-  "domains": [
-    {
-      "domain": "example.com",
-      "object": "organization_domain",
-      "id": "org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8"
-    }
-  ]
+  "allow_profiles_outside_organization": false
 }

--- a/src/organizations/fixtures/update-organization.json
+++ b/src/organizations/fixtures/update-organization.json
@@ -2,12 +2,5 @@
   "name": "Test Organization 2",
   "object": "organization",
   "id": "org_01EHT88Z8J8795GZNQ4ZP1J81T",
-  "allow_profiles_outside_organization": false,
-  "domains": [
-    {
-      "domain": "example.com",
-      "object": "organization_domain",
-      "id": "org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8"
-    }
-  ]
+  "allow_profiles_outside_organization": false
 }

--- a/src/organizations/interfaces/create-organization-options.interface.ts
+++ b/src/organizations/interfaces/create-organization-options.interface.ts
@@ -3,13 +3,11 @@ import { PostOptions } from '../../common/interfaces';
 export interface CreateOrganizationOptions {
   name: string;
   allowProfilesOutsideOrganization?: boolean;
-  domains?: string[];
 }
 
 export interface SerializedCreateOrganizationOptions {
   name: string;
   allow_profiles_outside_organization?: boolean;
-  domains?: string[];
 }
 
 export interface CreateOrganizationRequestOptions

--- a/src/organizations/interfaces/create-organization-options.interface.ts
+++ b/src/organizations/interfaces/create-organization-options.interface.ts
@@ -2,12 +2,10 @@ import { PostOptions } from '../../common/interfaces';
 
 export interface CreateOrganizationOptions {
   name: string;
-  allowProfilesOutsideOrganization?: boolean;
 }
 
 export interface SerializedCreateOrganizationOptions {
   name: string;
-  allow_profiles_outside_organization?: boolean;
 }
 
 export interface CreateOrganizationRequestOptions

--- a/src/organizations/interfaces/index.ts
+++ b/src/organizations/interfaces/index.ts
@@ -1,5 +1,4 @@
 export * from './create-organization-options.interface';
 export * from './list-organizations-options.interface';
-export * from './organization-domain.interface';
 export * from './organization.interface';
 export * from './update-organization-options.interface';

--- a/src/organizations/interfaces/organization-domain.interface.ts
+++ b/src/organizations/interfaces/organization-domain.interface.ts
@@ -1,5 +1,0 @@
-export interface OrganizationDomain {
-  object: 'organization_domain';
-  id: string;
-  domain: string;
-}

--- a/src/organizations/interfaces/organization.interface.ts
+++ b/src/organizations/interfaces/organization.interface.ts
@@ -1,11 +1,8 @@
-import { OrganizationDomain } from './organization-domain.interface';
-
 export interface Organization {
   object: 'organization';
   id: string;
   name: string;
   allowProfilesOutsideOrganization: boolean;
-  domains: OrganizationDomain[];
   createdAt: string;
   updatedAt: string;
 }
@@ -15,7 +12,6 @@ export interface OrganizationResponse {
   id: string;
   name: string;
   allow_profiles_outside_organization: boolean;
-  domains: OrganizationDomain[];
   created_at: string;
   updated_at: string;
 }

--- a/src/organizations/interfaces/organization.interface.ts
+++ b/src/organizations/interfaces/organization.interface.ts
@@ -2,7 +2,6 @@ export interface Organization {
   object: 'organization';
   id: string;
   name: string;
-  allowProfilesOutsideOrganization: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -11,7 +10,6 @@ export interface OrganizationResponse {
   object: 'organization';
   id: string;
   name: string;
-  allow_profiles_outside_organization: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/src/organizations/interfaces/update-organization-options.interface.ts
+++ b/src/organizations/interfaces/update-organization-options.interface.ts
@@ -1,10 +1,8 @@
 export interface UpdateOrganizationOptions {
   organization: string;
   name: string;
-  allowProfilesOutsideOrganization?: boolean;
 }
 
 export interface SerializedUpdateOrganizationOptions {
   name: string;
-  allow_profiles_outside_organization?: boolean;
 }

--- a/src/organizations/interfaces/update-organization-options.interface.ts
+++ b/src/organizations/interfaces/update-organization-options.interface.ts
@@ -2,11 +2,9 @@ export interface UpdateOrganizationOptions {
   organization: string;
   name: string;
   allowProfilesOutsideOrganization?: boolean;
-  domains?: string[];
 }
 
 export interface SerializedUpdateOrganizationOptions {
   name: string;
   allow_profiles_outside_organization?: boolean;
-  domains?: string[];
 }

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -184,7 +184,6 @@ describe('Organizations', () => {
       );
       expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
       expect(subject.name).toEqual('Test Organization 3');
-      expect(subject.allowProfilesOutsideOrganization).toEqual(false);
     });
   });
 

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -35,29 +35,6 @@ describe('Organizations', () => {
       });
     });
 
-    describe('with the domain option', () => {
-      it('forms the proper request to the API', async () => {
-        mock
-          .onGet('/organizations', {
-            domains: ['example.com'],
-          })
-          .replyOnce(200, listOrganizationsFixture);
-
-        const { data } = await workos.organizations.listOrganizations({
-          domains: ['example.com'],
-        });
-
-        expect(mock.history.get[0].params).toEqual({
-          domains: ['example.com'],
-          order: 'desc',
-        });
-
-        expect(mock.history.get[0].url).toEqual('/organizations');
-
-        expect(data).toHaveLength(7);
-      });
-    });
-
     describe('with the before option', () => {
       it('forms the proper request to the API', async () => {
         mock
@@ -133,14 +110,12 @@ describe('Organizations', () => {
       it('includes an idempotency key with request', async () => {
         mock
           .onPost('/organizations', {
-            domains: ['example.com'],
             name: 'Test Organization',
           })
           .replyOnce(201, createOrganization);
 
         await workos.organizations.createOrganization(
           {
-            domains: ['example.com'],
             name: 'Test Organization',
           },
           {
@@ -158,19 +133,16 @@ describe('Organizations', () => {
       it('creates an organization', async () => {
         mock
           .onPost('/organizations', {
-            domains: ['example.com'],
             name: 'Test Organization',
           })
           .replyOnce(201, createOrganization);
 
         const subject = await workos.organizations.createOrganization({
-          domains: ['example.com'],
           name: 'Test Organization',
         });
 
         expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
         expect(subject.name).toEqual('Test Organization');
-        expect(subject.domains).toHaveLength(1);
       });
     });
 
@@ -178,7 +150,6 @@ describe('Organizations', () => {
       it('returns an error', async () => {
         mock
           .onPost('/organizations', {
-            domains: ['example.com'],
             name: 'Test Organization',
           })
           .replyOnce(409, createOrganizationInvalid, {
@@ -187,7 +158,6 @@ describe('Organizations', () => {
 
         await expect(
           workos.organizations.createOrganization({
-            domains: ['example.com'],
             name: 'Test Organization',
           }),
         ).rejects.toThrowError(
@@ -215,7 +185,6 @@ describe('Organizations', () => {
       expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
       expect(subject.name).toEqual('Test Organization 3');
       expect(subject.allowProfilesOutsideOrganization).toEqual(false);
-      expect(subject.domains).toHaveLength(1);
     });
   });
 
@@ -242,20 +211,17 @@ describe('Organizations', () => {
       it('updates an organization', async () => {
         mock
           .onPut('/organizations/org_01EHT88Z8J8795GZNQ4ZP1J81T', {
-            domains: ['example.com'],
             name: 'Test Organization 2',
           })
           .replyOnce(201, updateOrganization);
 
         const subject = await workos.organizations.updateOrganization({
           organization: 'org_01EHT88Z8J8795GZNQ4ZP1J81T',
-          domains: ['example.com'],
           name: 'Test Organization 2',
         });
 
         expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
         expect(subject.name).toEqual('Test Organization 2');
-        expect(subject.domains).toHaveLength(1);
       });
     });
   });

--- a/src/organizations/serializers/create-organization-options.serializer.ts
+++ b/src/organizations/serializers/create-organization-options.serializer.ts
@@ -7,5 +7,4 @@ export const serializeCreateOrganizationOptions = (
   options: CreateOrganizationOptions,
 ): SerializedCreateOrganizationOptions => ({
   name: options.name,
-  allow_profiles_outside_organization: options.allowProfilesOutsideOrganization,
 });

--- a/src/organizations/serializers/create-organization-options.serializer.ts
+++ b/src/organizations/serializers/create-organization-options.serializer.ts
@@ -8,5 +8,4 @@ export const serializeCreateOrganizationOptions = (
 ): SerializedCreateOrganizationOptions => ({
   name: options.name,
   allow_profiles_outside_organization: options.allowProfilesOutsideOrganization,
-  domains: options.domains,
 });

--- a/src/organizations/serializers/organization.serializer.ts
+++ b/src/organizations/serializers/organization.serializer.ts
@@ -8,7 +8,6 @@ export const deserializeOrganization = (
   name: organization.name,
   allowProfilesOutsideOrganization:
     organization.allow_profiles_outside_organization,
-  domains: organization.domains,
   createdAt: organization.created_at,
   updatedAt: organization.updated_at,
 });

--- a/src/organizations/serializers/organization.serializer.ts
+++ b/src/organizations/serializers/organization.serializer.ts
@@ -6,8 +6,6 @@ export const deserializeOrganization = (
   object: organization.object,
   id: organization.id,
   name: organization.name,
-  allowProfilesOutsideOrganization:
-    organization.allow_profiles_outside_organization,
   createdAt: organization.created_at,
   updatedAt: organization.updated_at,
 });

--- a/src/organizations/serializers/update-organization-options.serializer.ts
+++ b/src/organizations/serializers/update-organization-options.serializer.ts
@@ -7,5 +7,4 @@ export const serializeUpdateOrganizationOptions = (
   options: Omit<UpdateOrganizationOptions, 'organization'>,
 ): SerializedUpdateOrganizationOptions => ({
   name: options.name,
-  allow_profiles_outside_organization: options.allowProfilesOutsideOrganization,
 });

--- a/src/organizations/serializers/update-organization-options.serializer.ts
+++ b/src/organizations/serializers/update-organization-options.serializer.ts
@@ -8,5 +8,4 @@ export const serializeUpdateOrganizationOptions = (
 ): SerializedUpdateOrganizationOptions => ({
   name: options.name,
   allow_profiles_outside_organization: options.allowProfilesOutsideOrganization,
-  domains: options.domains,
 });


### PR DESCRIPTION
## Description

Breaking change. Remove `domains` and `allowProfilesOutsideOrganization` properties from the `Organization` entity.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
