### PR TITLE
Remove `object` response property from Directory User response

### DIFF
--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -72,7 +72,6 @@ describe('DirectorySync', () => {
   };
 
   const userWithGroup: DirectoryUserWithGroups = {
-    object: 'directory_user',
     id: 'user_123',
     customAttributes: {
       custom: true,
@@ -99,7 +98,6 @@ describe('DirectorySync', () => {
   };
 
   const userWithGroupResponse: DirectoryUserWithGroupsResponse = {
-    object: 'directory_user',
     id: 'user_123',
     custom_attributes: {
       custom: true,
@@ -303,7 +301,6 @@ describe('DirectorySync', () => {
             .replyOnce(200, {
               data: [
                 {
-                  object: 'directory_user',
                   id: 'directory_user_01FBSYNGBVB4Q0GE4PJR328QB6',
                   directory_id: 'directory_01FBSYNGBN6R6WRMQM47PRCVMH',
                   idp_id: 'd899102f-86ad-4c14-9629-cd478b6a1971',
@@ -330,7 +327,6 @@ describe('DirectorySync', () => {
                   ],
                 },
                 {
-                  object: 'directory_user',
                   id: 'directory_user_01FBSYQPYWG0SMTGRFFDS5FRQ9',
                   directory_id: 'directory_01FBSYQPYN2XMDN7BQHP490M03',
                   idp_id: '044d1610-7b9f-47bf-8269-9a5774a7a0d7',

--- a/src/directory-sync/interfaces/directory-user.interface.ts
+++ b/src/directory-sync/interfaces/directory-user.interface.ts
@@ -9,7 +9,6 @@ export interface DirectoryUser<
   TCustomAttributes extends object = DefaultCustomAttributes,
   TRawAttributes = any,
 > {
-  object: 'directory_user';
   id: string;
   directoryId: string;
   organizationId: string | null;
@@ -34,7 +33,6 @@ export interface DirectoryUserResponse<
   TCustomAttributes extends object = DefaultCustomAttributes,
   TRawAttributes = any,
 > {
-  object: 'directory_user';
   id: string;
   directory_id: string;
   organization_id: string | null;

--- a/src/directory-sync/serializers/directory-user.serializer.ts
+++ b/src/directory-sync/serializers/directory-user.serializer.ts
@@ -14,7 +14,6 @@ export const deserializeDirectoryUser = <
     | DirectoryUserResponse<TCustomAttributes>
     | DirectoryUserWithGroupsResponse<TCustomAttributes>,
 ): DirectoryUser<TCustomAttributes> => ({
-  object: directoryUser.object,
   id: directoryUser.id,
   directoryId: directoryUser.directory_id,
   organizationId: directoryUser.organization_id,
@@ -43,7 +42,6 @@ export const deserializeDirectoryUserWithGroups = <
 export const deserializeUpdatedEventDirectoryUser = (
   directoryUser: DirectoryUserResponse & Record<'previous_attributes', any>,
 ): DirectoryUser & Record<'previousAttributes', any> => ({
-  object: 'directory_user',
   id: directoryUser.id,
   directoryId: directoryUser.directory_id,
   organizationId: directoryUser.organization_id,

--- a/src/directory-sync/utils/get-primary-email.spec.ts
+++ b/src/directory-sync/utils/get-primary-email.spec.ts
@@ -3,7 +3,6 @@ import { DirectoryUser } from '../interfaces';
 
 describe('getPrimaryEmail', () => {
   const user: DirectoryUser = {
-    object: 'directory_user',
     id: 'user_123',
     customAttributes: {
       custom: true,

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -32,7 +32,6 @@ describe('Webhooks', () => {
         },
       ],
       idpId: '00u1e8mutl6wlH3lL4x7',
-      object: 'directory_user',
       username: 'blair@foo-corp.com',
       lastName: 'Lunchford',
       firstName: 'Blair',


### PR DESCRIPTION
## Description

Remove `object` response property from Directory User response. It's not included in the API response, and also not listed in the [docs](https://workos.com/docs/reference/directory-sync/directory-user). 

![CleanShot 2023-11-13 at 10 21 09](https://github.com/workos/workos-node/assets/48022589/4e8f24ac-691f-4ee4-b59d-9b56c31dfa22)

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
