### PR TITLE
Add `link_authorization_code` parameter to `authenticateWithMagicAuth`

### DIFF
--- a/src/user-management/interfaces/authenticate-with-magic-auth-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-magic-auth-options.interface.ts
@@ -2,6 +2,7 @@ export interface AuthenticateWithMagicAuthOptions {
   clientId: string;
   code: string;
   userId: string;
+  linkAuthorizationCode?: string;
   ipAddress?: string;
   userAgent?: string;
 }
@@ -16,6 +17,7 @@ export interface SerializedAuthenticateWithMagicAuthOptions {
   client_secret: string | undefined;
   code: string;
   user_id: string;
+  link_authorization_code?: string;
   ip_address?: string;
   user_agent?: string;
 }

--- a/src/user-management/serializers/authenticate-with-magic-auth-options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-magic-auth-options.serializer.ts
@@ -13,6 +13,7 @@ export const serializeAuthenticateWithMagicAuthOptions = (
   client_secret: options.clientSecret,
   code: options.code,
   user_id: options.userId,
+  link_authorization_code: options.linkAuthorizationCode,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
 });

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -287,6 +287,7 @@ describe('UserManagement', () => {
             first_name: 'Test 01',
             last_name: 'User',
             email_verified: true,
+            link_authorization_code: 'mySuperCoolCode',
             created_at: '2023-07-18T02:07:19.911Z',
             updated_at: '2023-07-18T02:07:19.911Z',
           },


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.



#### PR Dependency Tree


* **PR #910** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)