### PR TITLE
Fix `code` on `Challenge` which is incorrectly set as required

### DIFF
--- a/src/mfa/interfaces/challenge.interface.ts
+++ b/src/mfa/interfaces/challenge.interface.ts
@@ -4,7 +4,7 @@ export interface Challenge {
   createdAt: string;
   updatedAt: string;
   expiresAt?: string;
-  code: string;
+  code?: string;
   authenticationFactorId: string;
 }
 
@@ -14,6 +14,6 @@ export interface ChallengeResponse {
   created_at: string;
   updated_at: string;
   expires_at?: string;
-  code: string;
+  code?: string;
   authentication_factor_id: string;
 }


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.



#### PR Dependency Tree


* **PR #911** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)