### PR TITLE
Use `email` rather than `userId` on `authenticateWithMagicAuth` method

### DIFF
--- a/src/user-management/interfaces/authenticate-with-magic-auth-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-magic-auth-options.interface.ts
@@ -1,7 +1,7 @@
 export interface AuthenticateWithMagicAuthOptions {
   clientId: string;
   code: string;
-  userId: string;
+  email: string;
   linkAuthorizationCode?: string;
   ipAddress?: string;
   userAgent?: string;
@@ -16,7 +16,7 @@ export interface SerializedAuthenticateWithMagicAuthOptions {
   client_id: string;
   client_secret: string | undefined;
   code: string;
-  user_id: string;
+  email: string;
   link_authorization_code?: string;
   ip_address?: string;
   user_agent?: string;

--- a/src/user-management/serializers/authenticate-with-magic-auth-options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-magic-auth-options.serializer.ts
@@ -12,7 +12,7 @@ export const serializeAuthenticateWithMagicAuthOptions = (
   client_id: options.clientId,
   client_secret: options.clientSecret,
   code: options.code,
-  user_id: options.userId,
+  email: options.email,
   link_authorization_code: options.linkAuthorizationCode,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -108,7 +108,7 @@ describe('UserManagement', () => {
       const resp = await workos.userManagement.authenticateWithMagicAuth({
         clientId: 'proj_whatever',
         code: '123456',
-        userId: userFixture.id,
+        email: userFixture.email,
       });
 
       expect(mock.history.post[0].url).toEqual('/user_management/authenticate');


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.



#### PR Dependency Tree


* **PR #915** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)