### PR TITLE
Split out with and without secrets factors

### DIFF
--- a/src/mfa/interfaces/factor.interface.ts
+++ b/src/mfa/interfaces/factor.interface.ts
@@ -6,7 +6,7 @@ import {
   TotpWithSecretsResponse,
 } from './totp.interface';
 
-type FactorType = 'sms' | 'totp';
+type FactorType = 'sms' | 'totp' | 'generic_otp';
 
 export interface Factor {
   object: 'authentication_factor';

--- a/src/mfa/interfaces/factor.interface.ts
+++ b/src/mfa/interfaces/factor.interface.ts
@@ -1,7 +1,12 @@
 import { Sms, SmsResponse } from './sms.interface';
-import { Totp, TotpResponse } from './totp.interface';
+import {
+  Totp,
+  TotpResponse,
+  TotpWithSecrets,
+  TotpWithSecretsResponse,
+} from './totp.interface';
 
-type FactorType = 'sms' | 'totp' | 'generic_otp';
+type FactorType = 'sms' | 'totp';
 
 export interface Factor {
   object: 'authentication_factor';
@@ -13,6 +18,16 @@ export interface Factor {
   totp?: Totp;
 }
 
+export interface FactorWithSecrets {
+  object: 'authentication_factor';
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  type: FactorType;
+  sms?: Sms;
+  totp?: TotpWithSecrets;
+}
+
 export interface FactorResponse {
   object: 'authentication_factor';
   id: string;
@@ -21,4 +36,14 @@ export interface FactorResponse {
   type: FactorType;
   sms?: SmsResponse;
   totp?: TotpResponse;
+}
+
+export interface FactorWithSecretsResponse {
+  object: 'authentication_factor';
+  id: string;
+  created_at: string;
+  updated_at: string;
+  type: FactorType;
+  sms?: SmsResponse;
+  totp?: TotpWithSecretsResponse;
 }

--- a/src/mfa/interfaces/totp.interface.ts
+++ b/src/mfa/interfaces/totp.interface.ts
@@ -1,15 +1,21 @@
 export interface Totp {
   issuer: string;
   user: string;
-  qrCode?: string;
-  secret?: string;
-  uri?: string;
+}
+
+export interface TotpWithSecrets extends Totp {
+  qrCode: string;
+  secret: string;
+  uri: string;
 }
 
 export interface TotpResponse {
   issuer: string;
   user: string;
-  qr_code?: string;
-  secret?: string;
-  uri?: string;
+}
+
+export interface TotpWithSecretsResponse extends TotpResponse {
+  qr_code: string;
+  secret: string;
+  uri: string;
 }

--- a/src/mfa/mfa.spec.ts
+++ b/src/mfa/mfa.spec.ts
@@ -8,6 +8,8 @@ import {
   ChallengeResponse,
   Factor,
   FactorResponse,
+  FactorWithSecrets,
+  FactorWithSecretsResponse,
   VerifyResponse,
   VerifyResponseResponse,
 } from './interfaces';
@@ -25,9 +27,6 @@ describe('MFA', () => {
         type: 'totp',
         totp: {
           issuer: 'WorkOS',
-          qrCode: 'qr-code-test',
-          secret: 'secret-test',
-          uri: 'uri-test',
           user: 'some_user',
         },
       };
@@ -40,9 +39,6 @@ describe('MFA', () => {
         type: 'totp',
         totp: {
           issuer: 'WorkOS',
-          qr_code: 'qr-code-test',
-          secret: 'secret-test',
-          uri: 'uri-test',
           user: 'some_user',
         },
       };
@@ -102,7 +98,7 @@ describe('MFA', () => {
 
     describe('with totp', () => {
       it('enrolls a factor with totp type', async () => {
-        const factor: Factor = {
+        const factor: FactorWithSecrets = {
           object: 'authentication_factor',
           id: 'auth_factor_1234',
           createdAt: '2022-03-15T20:39:19.892Z',
@@ -117,7 +113,7 @@ describe('MFA', () => {
           },
         };
 
-        const factorResponse: FactorResponse = {
+        const factorResponse: FactorWithSecretsResponse = {
           object: 'authentication_factor',
           id: 'auth_factor_1234',
           created_at: '2022-03-15T20:39:19.892Z',

--- a/src/mfa/mfa.ts
+++ b/src/mfa/mfa.ts
@@ -10,10 +10,13 @@ import {
   FactorResponse,
   ChallengeResponse,
   VerifyResponseResponse,
+  FactorWithSecretsResponse,
+  FactorWithSecrets,
 } from './interfaces';
 import {
   deserializeChallenge,
   deserializeFactor,
+  deserializeFactorWithSecrets,
   deserializeVerifyResponse,
 } from './serializers';
 
@@ -32,8 +35,8 @@ export class Mfa {
     return deserializeFactor(data);
   }
 
-  async enrollFactor(options: EnrollFactorOptions): Promise<Factor> {
-    const { data } = await this.workos.post<FactorResponse>(
+  async enrollFactor(options: EnrollFactorOptions): Promise<FactorWithSecrets> {
+    const { data } = await this.workos.post<FactorWithSecretsResponse>(
       '/auth/factors/enroll',
       {
         type: options.type,
@@ -55,7 +58,7 @@ export class Mfa {
       },
     );
 
-    return deserializeFactor(data);
+    return deserializeFactorWithSecrets(data);
   }
 
   async challengeFactor(options: ChallengeFactorOptions): Promise<Challenge> {

--- a/src/mfa/serializers/factor.serializer.ts
+++ b/src/mfa/serializers/factor.serializer.ts
@@ -1,6 +1,11 @@
-import { Factor, FactorResponse } from '../interfaces';
+import {
+  Factor,
+  FactorResponse,
+  FactorWithSecrets,
+  FactorWithSecretsResponse,
+} from '../interfaces';
 import { deserializeSms } from './sms.serializer';
-import { deserializeTotp } from './totp.serializer';
+import { deserializeTotp, deserializeTotpWithSecrets } from './totp.serializer';
 
 export const deserializeFactor = (factor: FactorResponse): Factor => ({
   object: factor.object,
@@ -10,4 +15,16 @@ export const deserializeFactor = (factor: FactorResponse): Factor => ({
   type: factor.type,
   ...(factor.sms ? { sms: deserializeSms(factor.sms) } : {}),
   ...(factor.totp ? { totp: deserializeTotp(factor.totp) } : {}),
+});
+
+export const deserializeFactorWithSecrets = (
+  factor: FactorWithSecretsResponse,
+): FactorWithSecrets => ({
+  object: factor.object,
+  id: factor.id,
+  createdAt: factor.created_at,
+  updatedAt: factor.updated_at,
+  type: factor.type,
+  ...(factor.sms ? { sms: deserializeSms(factor.sms) } : {}),
+  ...(factor.totp ? { totp: deserializeTotpWithSecrets(factor.totp) } : {}),
 });

--- a/src/mfa/serializers/totp.serializer.ts
+++ b/src/mfa/serializers/totp.serializer.ts
@@ -1,6 +1,20 @@
-import { Totp, TotpResponse } from '../interfaces';
+import {
+  Totp,
+  TotpResponse,
+  TotpWithSecretsResponse,
+  TotpWithSecrets,
+} from '../interfaces';
 
 export const deserializeTotp = (totp: TotpResponse): Totp => {
+  return {
+    issuer: totp.issuer,
+    user: totp.user,
+  };
+};
+
+export const deserializeTotpWithSecrets = (
+  totp: TotpWithSecretsResponse,
+): TotpWithSecrets => {
   return {
     issuer: totp.issuer,
     user: totp.user,

--- a/src/user-management/fixtures/list-factors.json
+++ b/src/user-management/fixtures/list-factors.json
@@ -9,9 +9,6 @@
       "type": "totp",
       "totp": {
         "issuer": "WorkOS",
-        "qr_code": "qr-code-test",
-        "secret": "secret-test",
-        "uri": "uri-test",
         "user": "some_user"
       }
     }

--- a/src/user-management/interfaces/factor.interface.ts
+++ b/src/user-management/interfaces/factor.interface.ts
@@ -2,6 +2,7 @@ import {
   Totp,
   TotpResponse,
   TotpWithSecrets,
+  TotpWithSecretsResponse,
 } from '../../mfa/interfaces/totp.interface';
 
 export interface Factor {
@@ -40,6 +41,6 @@ export interface FactorWithSecretsResponse {
   created_at: string;
   updated_at: string;
   type: 'totp';
-  totp: TotpWithSecrets;
+  totp: TotpWithSecretsResponse;
   user_id: string;
 }

--- a/src/user-management/interfaces/factor.interface.ts
+++ b/src/user-management/interfaces/factor.interface.ts
@@ -1,4 +1,8 @@
-import { Totp, TotpResponse } from '../../mfa/interfaces/totp.interface';
+import {
+  Totp,
+  TotpResponse,
+  TotpWithSecrets,
+} from '../../mfa/interfaces/totp.interface';
 
 export interface Factor {
   object: 'authentication_factor';
@@ -10,6 +14,16 @@ export interface Factor {
   userId: string;
 }
 
+export interface FactorWithSecrets {
+  object: 'authentication_factor';
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  type: 'totp';
+  totp: TotpWithSecrets;
+  userId: string;
+}
+
 export interface FactorResponse {
   object: 'authentication_factor';
   id: string;
@@ -17,5 +31,15 @@ export interface FactorResponse {
   updated_at: string;
   type: 'totp';
   totp: TotpResponse;
+  user_id: string;
+}
+
+export interface FactorWithSecretsResponse {
+  object: 'authentication_factor';
+  id: string;
+  created_at: string;
+  updated_at: string;
+  type: 'totp';
+  totp: TotpWithSecrets;
   user_id: string;
 }

--- a/src/user-management/serializers/factor.serializer.ts
+++ b/src/user-management/serializers/factor.serializer.ts
@@ -1,5 +1,13 @@
-import { Factor, FactorResponse } from '../interfaces/factor.interface';
-import { deserializeTotp } from '../../mfa/serializers/totp.serializer';
+import {
+  Factor,
+  FactorResponse,
+  FactorWithSecrets,
+  FactorWithSecretsResponse,
+} from '../interfaces/factor.interface';
+import {
+  deserializeTotp,
+  deserializeTotpWithSecrets,
+} from '../../mfa/serializers/totp.serializer';
 
 export const deserializeFactor = (factor: FactorResponse): Factor => ({
   object: factor.object,
@@ -8,5 +16,17 @@ export const deserializeFactor = (factor: FactorResponse): Factor => ({
   updatedAt: factor.updated_at,
   type: factor.type,
   totp: deserializeTotp(factor.totp),
+  userId: factor.user_id,
+});
+
+export const deserializeFactorWithSecrets = (
+  factor: FactorWithSecretsResponse,
+): FactorWithSecrets => ({
+  object: factor.object,
+  id: factor.id,
+  createdAt: factor.created_at,
+  updatedAt: factor.updated_at,
+  type: factor.type,
+  totp: deserializeTotpWithSecrets(factor.totp),
   userId: factor.user_id,
 });

--- a/src/user-management/serializers/index.ts
+++ b/src/user-management/serializers/index.ts
@@ -4,6 +4,7 @@ export * from './authenticate-with-password-options.serializer';
 export * from './authenticate-with-totp-options.serializer';
 export * from './authentication-response.serializer';
 export * from './enroll-auth-factor-options.serializer';
+export * from './factor.serializer';
 export * from './reset-password-options.serializer';
 export * from './send-password-reset-email.serializer';
 export * from './create-user-options.serializer';

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -493,9 +493,6 @@ describe('UserManagement', () => {
             type: 'totp',
             totp: {
               issuer: 'WorkOS',
-              qrCode: 'qr-code-test',
-              secret: 'secret-test',
-              uri: 'uri-test',
               user: 'some_user',
             },
           },

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -31,6 +31,7 @@ import {
 } from './interfaces';
 import {
   deserializeAuthenticationResponse,
+  deserializeFactorWithSecrets,
   deserializeUser,
   serializeAuthenticateWithMagicAuthOptions,
   serializeAuthenticateWithPasswordOptions,
@@ -82,7 +83,12 @@ import {
   SerializedAuthenticateWithOrganizationSelectionOptions,
 } from './interfaces/authenticate-with-organization-selection.interface';
 import { serializeAuthenticateWithOrganizationSelectionOptions } from './serializers/authenticate-with-organization-selection-options.serializer';
-import { Factor, FactorResponse } from './interfaces/factor.interface';
+import {
+  Factor,
+  FactorResponse,
+  FactorWithSecrets,
+  FactorWithSecretsResponse,
+} from './interfaces/factor.interface';
 import { deserializeFactor } from './serializers/factor.serializer';
 
 const toQueryString = (options: Record<string, string | undefined>): string => {
@@ -313,11 +319,11 @@ export class UserManagement {
   }
 
   async enrollAuthFactor(payload: EnrollAuthFactorOptions): Promise<{
-    authenticationFactor: Factor;
+    authenticationFactor: FactorWithSecrets;
     authenticationChallenge: Challenge;
   }> {
     const { data } = await this.workos.post<{
-      authentication_factor: FactorResponse;
+      authentication_factor: FactorWithSecretsResponse;
       authentication_challenge: ChallengeResponse;
     }>(
       `/user_management/users/${payload.userId}/auth_factors`,
@@ -325,7 +331,9 @@ export class UserManagement {
     );
 
     return {
-      authenticationFactor: deserializeFactor(data.authentication_factor),
+      authenticationFactor: deserializeFactorWithSecrets(
+        data.authentication_factor,
+      ),
       authenticationChallenge: deserializeChallenge(
         data.authentication_challenge,
       ),


### PR DESCRIPTION
## Description
Enrolling a TOTP auth factor always returns the `qrCode`, `secret`, and `uri` in the response, but retrieving and listing auth factors do not.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.



#### PR Dependency Tree


* **PR #929** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)