### PR TITLE
Update directory provider types

### DIFF
--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -28,7 +28,7 @@ describe('DirectorySync', () => {
     object: 'directory',
     organizationId: 'org_01EXSR7M9QTKCC5D531SMCWMYG',
     state: 'active',
-    type: 'okta scim v1.1',
+    type: 'okta scim v2.0',
     updatedAt: '2021-12-13 12:15:45.531847',
   };
 
@@ -41,7 +41,7 @@ describe('DirectorySync', () => {
     object: 'directory',
     organization_id: 'org_01EXSR7M9QTKCC5D531SMCWMYG',
     state: 'linked',
-    type: 'okta scim v1.1',
+    type: 'okta scim v2.0',
     updated_at: '2021-12-13 12:15:45.531847',
   };
 

--- a/src/directory-sync/interfaces/directory.interface.ts
+++ b/src/directory-sync/interfaces/directory.interface.ts
@@ -6,22 +6,17 @@ export type DirectoryType =
   | 'cyberark scim v2.0'
   | 'fourth hr'
   | 'gsuite directory'
-  | 'generic scim v1.1'
   | 'generic scim v2.0'
-  | 'gusto'
   | 'hibob'
   | 'jump cloud scim v2.0'
-  | 'okta scim v1.1'
   | 'okta scim v2.0'
   | 'onelogin scim v2.0'
   | 'people hr'
   | 'personio'
   | 'pingfederate scim v2.0'
-  | 'rippling'
   | 'rippling scim v2.0'
   | 'sftp'
   | 'sftp workday'
-  | 's3'
   | 'workday';
 
 export type DirectoryState =


### PR DESCRIPTION
## Description

Updates directory provider types to remove deprecated providers: Generic SCIM v1.1, Okta SCIM v1.1, Gusto, S3, Rippling

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
