### PR TITLE
Remove "suspended" state on Directory Sync user object

### DIFF
--- a/src/directory-sync/interfaces/directory-user.interface.ts
+++ b/src/directory-sync/interfaces/directory-user.interface.ts
@@ -25,7 +25,7 @@ export interface DirectoryUser<
   username: string | null;
   lastName: string | null;
   jobTitle: string | null;
-  state: 'active' | 'inactive' | 'suspended';
+  state: 'active' | 'inactive';
   createdAt: string;
   updatedAt: string;
 }
@@ -50,7 +50,7 @@ export interface DirectoryUserResponse<
   username: string | null;
   last_name: string | null;
   job_title: string | null;
-  state: 'active' | 'inactive' | 'suspended';
+  state: 'active' | 'inactive';
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Description
"suspended" state is now deprecated and consolidated into the "inactive" state

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
