### PR TITLE
`organizationId` should be optional in authentication responses

### DIFF
--- a/src/user-management/interfaces/authentication-response.interface.ts
+++ b/src/user-management/interfaces/authentication-response.interface.ts
@@ -2,10 +2,10 @@ import { User, UserResponse } from './user.interface';
 
 export interface AuthenticationResponse {
   user: User;
-  organizationId: string;
+  organizationId?: string;
 }
 
 export interface AuthenticationResponseResponse {
   user: UserResponse;
-  organization_id: string;
+  organization_id?: string;
 }


### PR DESCRIPTION
## Description

There was a mismatch here where `organizationId` was marked as non-optional, when in it is actually an optional field in the response. [See related docs](https://workos.com/docs/reference/user-management/authentication/code).

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
