### PR TITLE
Add `invitation_token` to authenticate endpoints

### DIFF
--- a/src/user-management/interfaces/authenticate-with-code-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-code-options.interface.ts
@@ -6,6 +6,7 @@ import {
 export interface AuthenticateWithCodeOptions
   extends AuthenticateWithOptionsBase {
   code: string;
+  invitationToken?: string;
 }
 
 export interface AuthenticateUserWithCodeCredentials {
@@ -16,4 +17,5 @@ export interface SerializedAuthenticateWithCodeOptions
   extends SerializedAuthenticateWithOptionsBase {
   grant_type: 'authorization_code';
   code: string;
+  invitation_token?: string;
 }

--- a/src/user-management/interfaces/authenticate-with-magic-auth-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-magic-auth-options.interface.ts
@@ -7,6 +7,7 @@ export interface AuthenticateWithMagicAuthOptions
   extends AuthenticateWithOptionsBase {
   code: string;
   email: string;
+  invitationToken?: string;
   linkAuthorizationCode?: string;
 }
 
@@ -19,5 +20,6 @@ export interface SerializedAuthenticateWithMagicAuthOptions
   grant_type: 'urn:workos:oauth:grant-type:magic-auth:code';
   code: string;
   email: string;
+  invitation_token?: string;
   link_authorization_code?: string;
 }

--- a/src/user-management/interfaces/authenticate-with-password-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-password-options.interface.ts
@@ -7,6 +7,7 @@ export interface AuthenticateWithPasswordOptions
   extends AuthenticateWithOptionsBase {
   email: string;
   password: string;
+  invitationToken?: string;
 }
 
 export interface AuthenticateUserWithPasswordCredentials {
@@ -18,4 +19,5 @@ export interface SerializedAuthenticateWithPasswordOptions
   grant_type: 'password';
   email: string;
   password: string;
+  invitation_token?: string;
 }

--- a/src/user-management/serializers/authenticate-with-code-options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-code-options.serializer.ts
@@ -11,6 +11,7 @@ export const serializeAuthenticateWithCodeOptions = (
   client_id: options.clientId,
   client_secret: options.clientSecret,
   code: options.code,
+  invitation_token: options.invitationToken,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
 });

--- a/src/user-management/serializers/authenticate-with-magic-auth-options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-magic-auth-options.serializer.ts
@@ -13,6 +13,7 @@ export const serializeAuthenticateWithMagicAuthOptions = (
   client_secret: options.clientSecret,
   code: options.code,
   email: options.email,
+  invitation_token: options.invitationToken,
   link_authorization_code: options.linkAuthorizationCode,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,

--- a/src/user-management/serializers/authenticate-with-password-options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-password-options.serializer.ts
@@ -13,6 +13,7 @@ export const serializeAuthenticateWithPasswordOptions = (
   client_secret: options.clientSecret,
   email: options.email,
   password: options.password,
+  invitation_token: options.invitationToken,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
 });


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

I'll add the documentation for these params on the API and for the Node SDK all at once shortly.

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
