### PR TITLE
Update axios and change dependency constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
-    "axios": "^1.6.5",
+    "axios": "~1.6.5",
     "pluralize": "8.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
-    "axios": "1.6.0",
+    "axios": "^1.6.5",
     "pluralize": "8.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
This PR updates the axios version to address a security update and changes the dependency constraint to allow for only patch updates to be installed

Resolves #936 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
