### PR TITLE
Fix return types for directory sync paginated methods

### DIFF
--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -12,7 +12,6 @@ import {
   ListDirectoryGroupsOptions,
   ListDirectoryUsersOptions,
 } from './interfaces';
-import { List } from '../common/interfaces';
 import {
   deserializeDirectory,
   deserializeDirectoryGroup,
@@ -59,7 +58,7 @@ export class DirectorySync {
 
   async listGroups(
     options: ListDirectoryGroupsOptions,
-  ): Promise<List<DirectoryGroup>> {
+  ): Promise<AutoPaginatable<DirectoryGroup>> {
     return new AutoPaginatable(
       await fetchAndDeserialize<DirectoryGroupResponse, DirectoryGroup>(
         this.workos,
@@ -80,7 +79,7 @@ export class DirectorySync {
 
   async listUsers<TCustomAttributes extends object = DefaultCustomAttributes>(
     options: ListDirectoryUsersOptions,
-  ): Promise<List<DirectoryUserWithGroups<TCustomAttributes>>> {
+  ): Promise<AutoPaginatable<DirectoryUserWithGroups<TCustomAttributes>>> {
     return new AutoPaginatable(
       await fetchAndDeserialize<
         DirectoryUserWithGroupsResponse<TCustomAttributes>,


### PR DESCRIPTION
## Description
This PR fixes the return types for directory sync paginated methods that were using `List` to use `AutoPaginatable`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
