### PR TITLE
Set maximium limit when auto paginating

### DIFF
--- a/src/common/utils/pagination.ts
+++ b/src/common/utils/pagination.ts
@@ -25,6 +25,7 @@ export class AutoPaginatable<T> {
   private async *generatePages(params: PaginationOptions): AsyncGenerator<T[]> {
     const result = await this.apiCall({
       ...this.options,
+      limit: 100,
       after: params.after,
     });
 
@@ -38,20 +39,20 @@ export class AutoPaginatable<T> {
   }
 
   async autoPagination(): Promise<T[]> {
-    if (!this.options.limit) {
-      const generatePages = this.generatePages({
-        after: this.options.after,
-      });
-
-      const results: T[] = [];
-
-      for await (const page of generatePages) {
-        results.push(...page);
-      }
-
-      return results;
-    } else {
+    // assume user only wants the exact number of records
+    // they requested with the limit option
+    if (this.options.limit) {
       return this.data;
     }
+
+    const results: T[] = [];
+
+    for await (const page of this.generatePages({
+      after: this.options.after,
+    })) {
+      results.push(...page);
+    }
+
+    return results;
   }
 }

--- a/src/common/utils/pagination.ts
+++ b/src/common/utils/pagination.ts
@@ -38,9 +38,11 @@ export class AutoPaginatable<T> {
     }
   }
 
+  /**
+   * Automatically paginates over the list of results, returning the complete data set.
+   * Returns the first result if `options.limit` is passed to the first request.
+   */
   async autoPagination(): Promise<T[]> {
-    // assume user only wants the exact number of records
-    // they requested with the limit option
     if (this.options.limit) {
       return this.data;
     }


### PR DESCRIPTION
## Description
This PR sets maximium limit of 100 records when auto paginating.

Right now, without the explicit limit being used in the auto pagination, we are paginating for every 10 records, making the pagination process too slow, discouraging our users to use this feature and implement their own instead. So we should use the maximum allowed and make this feature faster ourselves

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
