### PR TITLE
Remove domain param from directories list query

### DIFF
--- a/src/directory-sync/interfaces/list-directories-options.interface.ts
+++ b/src/directory-sync/interfaces/list-directories-options.interface.ts
@@ -1,13 +1,11 @@
 import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
 
 export interface ListDirectoriesOptions extends PaginationOptions {
-  domain?: string;
   organizationId?: string;
   search?: string;
 }
 
 export interface SerializedListDirectoriesOptions extends PaginationOptions {
-  domain?: string;
   organization_id?: string;
   search?: string;
 }

--- a/src/directory-sync/serializers/list-directories-options.serializer.ts
+++ b/src/directory-sync/serializers/list-directories-options.serializer.ts
@@ -6,7 +6,6 @@ import {
 export const serializeListDirectoriesOptions = (
   options: ListDirectoriesOptions,
 ): SerializedListDirectoriesOptions => ({
-  domain: options.domain,
   organization_id: options.organizationId,
   search: options.search,
   limit: options.limit,


### PR DESCRIPTION
## Description
We no longer allow filtering directories by domain.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
