### PR TITLE
Fix directory-sync options

### DIFF
--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -40,7 +40,7 @@ export class DirectorySync {
           deserializeDirectory,
           params,
         ),
-      options,
+      options ? serializeListDirectoriesOptions(options) : undefined,
     );
   }
 


### PR DESCRIPTION
## Description

Make sure that the options used when auto paginating use the correct options

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
