### PR TITLE
fix: Prevent JSON.stringify on null entity

### DIFF
--- a/src/common/utils/fetch-client.ts
+++ b/src/common/utils/fetch-client.ts
@@ -24,7 +24,12 @@ export class FetchClient {
     const contentTypeHeader = bodyIsSearchParams
       ? { 'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8' }
       : undefined;
-    const body = bodyIsSearchParams ? entity : JSON.stringify(entity);
+    const body =
+      entity !== null
+        ? bodyIsSearchParams
+          ? entity
+          : JSON.stringify(entity)
+        : null;
     const response = await this.fetch(resourceURL, {
       method: 'POST',
       headers: { ...contentTypeHeader, ...options.headers },


### PR DESCRIPTION
## Description

Working on a WorkOS integration and I discovered I can't successfully use invitation revoke in v6.0.0. This looks to have appeared with the introduction of FetchClient to replace Axios.

The revoke method passes `null` as an entity to the FetchClient: https://github.com/workos/workos-node/blob/main/src/user-management/user-management.ts#L465-L469

However, the client then calls `JSON.stringify` on `null` and sends the string `'null'` to the API endpoint, which somewhat confusingly returns a 400 and a JSON parse error.

Probably, the client should allow not sending an entity at all, given that one isn't required for the revokeInvitation endpoint but that's a bigger task.

This PR just checks if the entity is null and allows it to be sent as is (since the `fetch` interface supports this) -- but it's not the prettiest code in the world.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
