### PR TITLE
Refactor Buffer usage

### DIFF
--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -3,6 +3,8 @@ import { deserializeEvent } from '../common/serializers';
 import { Event, EventResponse } from '../common/interfaces';
 
 export class Webhooks {
+  private encoder = new TextEncoder();
+
   async constructEvent({
     payload,
     sigHeader,
@@ -78,11 +80,10 @@ export class Webhooks {
   ): Promise<string> {
     payload = JSON.stringify(payload);
     const signedPayload = `${timestamp}.${payload}`;
-    const encoder = new TextEncoder();
 
     const key = await crypto.subtle.importKey(
       'raw',
-      encoder.encode(secret),
+      this.encoder.encode(secret),
       { name: 'HMAC', hash: 'SHA-256' },
       false,
       ['sign'],
@@ -91,7 +92,7 @@ export class Webhooks {
     const signatureBuffer = await crypto.subtle.sign(
       'HMAC',
       key,
-      encoder.encode(signedPayload),
+      this.encoder.encode(signedPayload),
     );
 
     // crypto.subtle returns the signature in base64 format. This must be
@@ -108,9 +109,8 @@ export class Webhooks {
   }
 
   async secureCompare(stringA: string, stringB: string): Promise<boolean> {
-    const encoder = new TextEncoder();
-    const bufferA = encoder.encode(stringA);
-    const bufferB = encoder.encode(stringB);
+    const bufferA = this.encoder.encode(stringA);
+    const bufferB = this.encoder.encode(stringB);
 
     if (bufferA.length !== bufferB.length) {
       return false;

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -78,10 +78,11 @@ export class Webhooks {
   ): Promise<string> {
     payload = JSON.stringify(payload);
     const signedPayload = `${timestamp}.${payload}`;
+    const encoder = new TextEncoder();
 
     const key = await crypto.subtle.importKey(
       'raw',
-      new TextEncoder().encode(secret),
+      encoder.encode(secret),
       { name: 'HMAC', hash: 'SHA-256' },
       false,
       ['sign'],
@@ -90,7 +91,7 @@ export class Webhooks {
     const signatureBuffer = await crypto.subtle.sign(
       'HMAC',
       key,
-      new TextEncoder().encode(signedPayload),
+      encoder.encode(signedPayload),
     );
 
     // crypto.subtle returns the signature in base64 format. This must be
@@ -107,8 +108,9 @@ export class Webhooks {
   }
 
   async secureCompare(stringA: string, stringB: string): Promise<boolean> {
-    const bufferA = Buffer.from(stringA);
-    const bufferB = Buffer.from(stringB);
+    const encoder = new TextEncoder();
+    const bufferA = encoder.encode(stringA);
+    const bufferB = encoder.encode(stringB);
 
     if (bufferA.length !== bufferB.length) {
       return false;


### PR DESCRIPTION
## Description

Fixes #964

There was a leftover usage of Node's `Buffer` API.
I have converted it to use the web platform's `TextEncoder` APIs instead.

I wonder if there's an ESLint plugin that could be used to lint for usages of APIs incompatible with cloudflare workers/edge runtime as it seems easy to let something through without thoroughly testing every single API call. A quick google search didn't bring much up so far.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
