### PR TITLE
Expose non-publicly documented properties in auth response

### DIFF
--- a/src/user-management/serializers/authentication-response.serializer.ts
+++ b/src/user-management/serializers/authentication-response.serializer.ts
@@ -6,7 +6,11 @@ import { deserializeUser } from './user.serializer';
 
 export const deserializeAuthenticationResponse = (
   authenticationResponse: AuthenticationResponseResponse,
-): AuthenticationResponse => ({
-  user: deserializeUser(authenticationResponse.user),
-  organizationId: authenticationResponse.organization_id,
-});
+): AuthenticationResponse => {
+  const { user, organization_id, ...rest } = authenticationResponse;
+  return {
+    user: deserializeUser(user),
+    organizationId: organization_id,
+    ...rest,
+  };
+};


### PR DESCRIPTION
## Description

Currently, only the specified `user` and `organization_id` are accessible in an authentication response. Non-publicly-documented properties are stripped from the response and inaccessible even if the caller type-casts the response. This exposes it so it's at least accessible before publicly releasing anything.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
