### PR TITLE
Add status to organization membership and updated event

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -219,6 +219,17 @@ export interface OrganizationMembershipAddedResponse extends EventResponseBase {
   data: OrganizationMembershipResponse;
 }
 
+export interface OrganizationMembershipUpdated extends EventBase {
+  event: 'organization_membership.updated';
+  data: OrganizationMembership;
+}
+
+export interface OrganizationMembershipUpdatedResponse
+  extends EventResponseBase {
+  event: 'organization_membership.updated';
+  data: OrganizationMembershipResponse;
+}
+
 export interface OrganizationMembershipRemoved extends EventBase {
   event: 'organization_membership.removed';
   data: OrganizationMembership;
@@ -249,6 +260,7 @@ export type Event =
   | UserUpdatedEvent
   | UserDeletedEvent
   | OrganizationMembershipAdded
+  | OrganizationMembershipUpdated
   | OrganizationMembershipRemoved;
 
 export type EventResponse =
@@ -270,6 +282,7 @@ export type EventResponse =
   | UserUpdatedEventResponse
   | UserDeletedEventResponse
   | OrganizationMembershipAddedResponse
+  | OrganizationMembershipUpdatedResponse
   | OrganizationMembershipRemovedResponse;
 
 export type EventName =
@@ -291,4 +304,5 @@ export type EventName =
   | 'user.updated'
   | 'user.deleted'
   | 'organization_membership.added'
+  | 'organization_membership.updated'
   | 'organization_membership.removed';

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -85,6 +85,7 @@ export const deserializeEvent = (event: EventResponse): Event => {
         data: deserializeUser(event.data),
       };
     case 'organization_membership.added':
+    case 'organization_membership.updated':
     case 'organization_membership.removed':
       return {
         ...eventBase,

--- a/src/user-management/fixtures/list-organization-memberships.json
+++ b/src/user-management/fixtures/list-organization-memberships.json
@@ -6,6 +6,7 @@
       "id": "om_01H5JQDV7R7ATEYZDEG0W5PRYS",
       "user_id": "user_01H5JQDV7R7ATEYZDEG0W5PRYS",
       "organization_id": "organization_01H5JQDV7R7ATEYZDEG0W5PRYS",
+      "status": "active",
       "created_at": "2023-07-18T02:07:19.911Z",
       "updated_at": "2023-07-18T02:07:19.911Z"
     }

--- a/src/user-management/fixtures/organization-membership.json
+++ b/src/user-management/fixtures/organization-membership.json
@@ -3,6 +3,7 @@
   "id": "om_01H5JQDV7R7ATEYZDEG0W5PRYS",
   "user_id": "user_01H5JQDV7R7ATEYZDEG0W5PRYS",
   "organization_id": "organization_01H5JQDV7R7ATEYZDEG0W5PRYS",
+  "status": "active",
   "created_at": "2023-07-18T02:07:19.911Z",
   "updated_at": "2023-07-18T02:07:19.911Z"
 }

--- a/src/user-management/interfaces/organization-membership.interface.ts
+++ b/src/user-management/interfaces/organization-membership.interface.ts
@@ -2,6 +2,7 @@ export interface OrganizationMembership {
   object: 'organization_membership';
   id: string;
   organizationId: string;
+  status: 'active' | 'pending';
   userId: string;
   createdAt: string;
   updatedAt: string;
@@ -11,6 +12,7 @@ export interface OrganizationMembershipResponse {
   object: 'organization_membership';
   id: string;
   organization_id: string;
+  status: 'active' | 'pending';
   user_id: string;
   created_at: string;
   updated_at: string;

--- a/src/user-management/serializers/organization-membership.serializer.ts
+++ b/src/user-management/serializers/organization-membership.serializer.ts
@@ -10,6 +10,7 @@ export const deserializeOrganizationMembership = (
   id: organizationMembership.id,
   userId: organizationMembership.user_id,
   organizationId: organizationMembership.organization_id,
+  status: organizationMembership.status,
   createdAt: organizationMembership.created_at,
   updatedAt: organizationMembership.updated_at,
 });

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -509,6 +509,7 @@ describe('UserManagement', () => {
         id: 'om_01H5JQDV7R7ATEYZDEG0W5PRYS',
         userId: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
         organizationId: 'organization_01H5JQDV7R7ATEYZDEG0W5PRYS',
+        status: 'active',
       });
     });
   });
@@ -531,6 +532,7 @@ describe('UserManagement', () => {
             object: 'organization_membership',
             organizationId: 'organization_01H5JQDV7R7ATEYZDEG0W5PRYS',
             userId: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+            status: 'active',
           },
         ],
         listMetadata: {
@@ -577,6 +579,7 @@ describe('UserManagement', () => {
         object: 'organization_membership',
         organizationId: 'organization_01H5JQDV7R7ATEYZDEG0W5PRYS',
         userId: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+        status: 'active',
       });
     });
   });


### PR DESCRIPTION
## Description

Adds new `status` attribute to the organization membership object, and adds the `organization_membership.updated` event.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/25404
