### PR TITLE
Upgrade semaphore image

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6,8 +6,8 @@ execution_time_limit:
 
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
+    type: e2-standard-2
+    os_image: ubuntu2204
 
 global_job_config:
   env_vars:


### PR DESCRIPTION
## Description

Builds are now failing with a `ubuntu1804 is in brownout` error.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
