### PR TITLE
Fix typeError on global.crypto assignment

### DIFF
--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -3,4 +3,6 @@ import { Crypto } from '@peculiar/webcrypto';
 
 enableFetchMocks();
 
-global.crypto = new Crypto();
+if (!global.crypto) {
+    global.crypto = new Crypto();
+}

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -3,6 +3,7 @@ import { Crypto } from '@peculiar/webcrypto';
 
 enableFetchMocks();
 
+// Assign Node's Crypto to global.crypto if it is not already present
 if (!global.crypto) {
     global.crypto = new Crypto();
 }


### PR DESCRIPTION
## Description

This PR resolves an issue where a TypeError occurs when trying to assign the 'crypto' property to the global object in a Jest test environment. The error occurred due to trying to get a read-only property from the global object.

The original error:
`TypeError: Cannot assign read-only property 'crypto' of object '[global object]'`

![Captura de tela 2024-03-09 062108](https://github.com/workos/workos-node/assets/56550632/2febea9b-f2d9-413f-acfc-e6503e2f6e89)

This was because the 'crypto' property already existed on the global object and was read-only.

To solve this problem I added an `if (!global.crypto)` check before assigning the 'crypto' property to the global object. This ensures that the 'crypto' property will only be set if it is not already set on the global object, thus avoiding the TypeError error.

![Captura de tela 2024-03-09 062551](https://github.com/workos/workos-node/assets/56550632/477b1ccb-c88d-4442-ae91-a39766ac278e)


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ X ] No
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
