### PR TITLE
Add impersonation fields and event

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -302,25 +302,4 @@ export type EventResponse =
   | OrganizationMembershipUpdatedResponse
   | OrganizationMembershipRemovedResponse;
 
-export type EventName =
-  | 'connection.activated'
-  | 'connection.deactivated'
-  | 'connection.deleted'
-  | 'dsync.activated'
-  | 'dsync.deactivated'
-  | 'dsync.deleted'
-  | 'dsync.group.created'
-  | 'dsync.group.deleted'
-  | 'dsync.group.updated'
-  | 'dsync.group.user_added'
-  | 'dsync.group.user_removed'
-  | 'dsync.user.created'
-  | 'dsync.user.deleted'
-  | 'dsync.user.updated'
-  | 'user.created'
-  | 'user.updated'
-  | 'user.deleted'
-  | 'user.impersonated'
-  | 'organization_membership.added'
-  | 'organization_membership.updated'
-  | 'organization_membership.removed';
+export type EventName = Event['event'];

--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -7,7 +7,12 @@ import {
   EventDirectoryResponse,
 } from '../../directory-sync/interfaces';
 import { Connection, ConnectionResponse } from '../../sso/interfaces';
-import { User, UserResponse } from '../../user-management/interfaces';
+import {
+  Session,
+  SessionResponse,
+  User,
+  UserResponse,
+} from '../../user-management/interfaces';
 import {
   OrganizationMembership,
   OrganizationMembershipResponse,
@@ -209,6 +214,16 @@ export interface UserDeletedEventResponse extends EventResponseBase {
   data: UserResponse;
 }
 
+export interface UserImpersonatedEvent extends EventBase {
+  event: 'user.impersonated';
+  data: Session;
+}
+
+export interface UserImpersonatedEventResponse extends EventResponseBase {
+  event: 'user.impersonated';
+  data: SessionResponse;
+}
+
 export interface OrganizationMembershipAdded extends EventBase {
   event: 'organization_membership.added';
   data: OrganizationMembership;
@@ -259,6 +274,7 @@ export type Event =
   | UserCreatedEvent
   | UserUpdatedEvent
   | UserDeletedEvent
+  | UserImpersonatedEvent
   | OrganizationMembershipAdded
   | OrganizationMembershipUpdated
   | OrganizationMembershipRemoved;
@@ -281,6 +297,7 @@ export type EventResponse =
   | UserCreatedEventResponse
   | UserUpdatedEventResponse
   | UserDeletedEventResponse
+  | UserImpersonatedEventResponse
   | OrganizationMembershipAddedResponse
   | OrganizationMembershipUpdatedResponse
   | OrganizationMembershipRemovedResponse;
@@ -303,6 +320,7 @@ export type EventName =
   | 'user.created'
   | 'user.updated'
   | 'user.deleted'
+  | 'user.impersonated'
   | 'organization_membership.added'
   | 'organization_membership.updated'
   | 'organization_membership.removed';

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -9,6 +9,7 @@ import {
 import { deserializeConnection } from '../../sso/serializers';
 import { deserializeUser } from '../../user-management/serializers';
 import { deserializeOrganizationMembership } from '../../user-management/serializers/organization-membership.serializer';
+import { deserializeSession } from '../../user-management/serializers/session.serializer';
 import { Event, EventBase, EventResponse } from '../interfaces';
 
 export const deserializeEvent = (event: EventResponse): Event => {
@@ -83,6 +84,12 @@ export const deserializeEvent = (event: EventResponse): Event => {
         ...eventBase,
         event: event.event,
         data: deserializeUser(event.data),
+      };
+    case 'user.impersonated':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeSession(event.data),
       };
     case 'organization_membership.added':
     case 'organization_membership.updated':

--- a/src/common/utils/test-utils.ts
+++ b/src/common/utils/test-utils.ts
@@ -1,7 +1,7 @@
 import fetch, { MockParams } from 'jest-fetch-mock';
 
 export function fetchOnce(
-  response: any = {},
+  response: {} = {},
   { status = 200, headers, ...rest }: MockParams = {},
 ) {
   return fetch.once(JSON.stringify(response), {

--- a/src/user-management/interfaces/authentication-response.interface.ts
+++ b/src/user-management/interfaces/authentication-response.interface.ts
@@ -1,3 +1,4 @@
+import { Impersonator, ImpersonatorResponse } from './impersonator.interface';
 import { User, UserResponse } from './user.interface';
 
 export interface AuthenticationResponse {
@@ -5,6 +6,7 @@ export interface AuthenticationResponse {
   organizationId?: string;
   accessToken?: string;
   refreshToken?: string;
+  impersonator?: Impersonator;
 }
 
 export interface AuthenticationResponseResponse {
@@ -12,6 +14,7 @@ export interface AuthenticationResponseResponse {
   organization_id?: string;
   access_token?: string;
   refresh_token?: string;
+  impersonator?: ImpersonatorResponse;
 }
 
 export interface RefreshAuthenticationResponse {

--- a/src/user-management/interfaces/impersonator.interface.ts
+++ b/src/user-management/interfaces/impersonator.interface.ts
@@ -1,0 +1,9 @@
+export interface Impersonator {
+  email: string;
+  reason: string | null;
+}
+
+export interface ImpersonatorResponse {
+  email: string;
+  reason: string | null;
+}

--- a/src/user-management/interfaces/index.ts
+++ b/src/user-management/interfaces/index.ts
@@ -15,4 +15,5 @@ export * from './send-verification-email-options';
 export * from './update-user-options.interface';
 export * from './update-user-password-options.interface';
 export * from './user.interface';
+export * from './session.interface';
 export * from './verify-email-options.interface';

--- a/src/user-management/interfaces/session.interface.ts
+++ b/src/user-management/interfaces/session.interface.ts
@@ -1,0 +1,21 @@
+import { Impersonator } from './impersonator.interface';
+
+export interface Session {
+  object: 'session';
+  id: string;
+  userId: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+  organizationId?: string;
+  impersonator?: Impersonator;
+}
+
+export interface SessionResponse {
+  object: 'session';
+  id: string;
+  user_id: string;
+  ip_address: string | null;
+  user_agent: string | null;
+  organization_id?: string;
+  impersonator?: Impersonator;
+}

--- a/src/user-management/serializers/authentication-response.serializer.ts
+++ b/src/user-management/serializers/authentication-response.serializer.ts
@@ -9,13 +9,21 @@ import { deserializeUser } from './user.serializer';
 export const deserializeAuthenticationResponse = (
   authenticationResponse: AuthenticationResponseResponse,
 ): AuthenticationResponse => {
-  const { user, organization_id, access_token, refresh_token, ...rest } =
-    authenticationResponse;
+  const {
+    user,
+    organization_id,
+    access_token,
+    refresh_token,
+    impersonator,
+    ...rest
+  } = authenticationResponse;
+
   return {
     user: deserializeUser(user),
     organizationId: organization_id,
     accessToken: access_token,
     refreshToken: refresh_token,
+    impersonator,
     ...rest,
   };
 };

--- a/src/user-management/serializers/session.serializer.ts
+++ b/src/user-management/serializers/session.serializer.ts
@@ -1,0 +1,11 @@
+import { Session, SessionResponse } from '../interfaces';
+
+export const deserializeSession = (session: SessionResponse): Session => ({
+  object: 'session',
+  id: session.id,
+  userId: session.user_id,
+  ipAddress: session.ip_address,
+  userAgent: session.user_agent,
+  organizationId: session.organization_id,
+  impersonator: session.impersonator,
+});

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -162,6 +162,32 @@ describe('UserManagement', () => {
         },
       });
     });
+
+    describe('when the code is for an impersonator', () => {
+      it('deserializes the impersonator metadata', async () => {
+        fetchOnce({
+          user: userFixture,
+          impersonator: {
+            email: 'admin@example.com',
+            reason: 'A good reason.',
+          },
+        });
+        const resp = await workos.userManagement.authenticateWithCode({
+          clientId: 'proj_whatever',
+          code: 'or this',
+        });
+
+        expect(resp).toMatchObject({
+          user: {
+            email: 'test01@example.com',
+          },
+          impersonator: {
+            email: 'admin@example.com',
+            reason: 'A good reason.',
+          },
+        });
+      });
+    });
   });
 
   describe('authenticateWithRefreshToken', () => {


### PR DESCRIPTION
## Description

Adds support for the `impersonator` metadata in authentication responses, along with a new `user.impersonated` event.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
