### PR TITLE
Add `ssha` as valid `passwordHashType`

### DIFF
--- a/src/user-management/interfaces/update-user-options.interface.ts
+++ b/src/user-management/interfaces/update-user-options.interface.ts
@@ -5,7 +5,7 @@ export interface UpdateUserOptions {
   emailVerified?: boolean;
   password?: string;
   passwordHash?: string;
-  passwordHashType?: 'bcrypt' | 'firebase-scrypt';
+  passwordHashType?: 'bcrypt' | 'firebase-scrypt' | 'ssha';
 }
 
 export interface SerializedUpdateUserOptions {
@@ -14,5 +14,5 @@ export interface SerializedUpdateUserOptions {
   email_verified?: boolean;
   password?: string;
   password_hash?: string;
-  password_hash_type?: 'bcrypt' | 'firebase-scrypt';
+  password_hash_type?: 'bcrypt' | 'firebase-scrypt' | 'ssha';
 }


### PR DESCRIPTION
## Description

Updates the `passwordHashType` parameter to `updateUser` to support the new `ssha` type.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
