### PR TITLE
Migrate repo to use GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 
 on:
-  push: {}
+  push:
+    branches:
+      - 'main'
   pull_request: {}
 
 defaults:
@@ -12,9 +14,14 @@ jobs:
   test:
     name: Test Node ${{ matrix.node }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [14, 16, 18, 20]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push: {}
+  pull_request: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+
+      - name: Install Dependencies
+        run: |
+          npm install
+
+      - name: Prettier
+        run: |
+          npm run prettier
+
+      - name: Lint
+        run: |
+          npm run lint
+
+      - name: Build
+        run: |
+          npm run build
+
+      - name: Test
+        run: |
+          npm run test
+


### PR DESCRIPTION
## Description

We are working on consolidating all CI to GitHub Actions.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
