### PR TITLE
Add session.created event

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -7,7 +7,12 @@ import {
   EventDirectoryResponse,
 } from '../../directory-sync/interfaces';
 import { Connection, ConnectionResponse } from '../../sso/interfaces';
-import { User, UserResponse } from '../../user-management/interfaces';
+import {
+  Session,
+  SessionResponse,
+  User,
+  UserResponse,
+} from '../../user-management/interfaces';
 import {
   OrganizationMembership,
   OrganizationMembershipResponse,
@@ -241,6 +246,16 @@ export interface OrganizationMembershipRemovedResponse
   data: OrganizationMembershipResponse;
 }
 
+export interface SessionCreatedEvent extends EventBase {
+  event: 'session.created';
+  data: Session;
+}
+
+export interface SessionCreatedEventResponse extends EventResponseBase {
+  event: 'session.created';
+  data: SessionResponse;
+}
+
 export type Event =
   | ConnectionActivatedEvent
   | ConnectionDeactivatedEvent
@@ -261,7 +276,8 @@ export type Event =
   | UserDeletedEvent
   | OrganizationMembershipAdded
   | OrganizationMembershipUpdated
-  | OrganizationMembershipRemoved;
+  | OrganizationMembershipRemoved
+  | SessionCreatedEvent;
 
 export type EventResponse =
   | ConnectionActivatedEventResponse
@@ -283,6 +299,7 @@ export type EventResponse =
   | UserDeletedEventResponse
   | OrganizationMembershipAddedResponse
   | OrganizationMembershipUpdatedResponse
-  | OrganizationMembershipRemovedResponse;
+  | OrganizationMembershipRemovedResponse
+  | SessionCreatedEventResponse;
 
 export type EventName = Event['event'];

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -9,6 +9,7 @@ import {
 import { deserializeConnection } from '../../sso/serializers';
 import { deserializeUser } from '../../user-management/serializers';
 import { deserializeOrganizationMembership } from '../../user-management/serializers/organization-membership.serializer';
+import { deserializeSession } from '../../user-management/serializers/session.serializer';
 import { Event, EventBase, EventResponse } from '../interfaces';
 
 export const deserializeEvent = (event: EventResponse): Event => {
@@ -91,6 +92,12 @@ export const deserializeEvent = (event: EventResponse): Event => {
         ...eventBase,
         event: event.event,
         data: deserializeOrganizationMembership(event.data),
+      };
+    case 'session.created':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeSession(event.data),
       };
   }
 };


### PR DESCRIPTION
## Description
Adds session.created event.

Fixes https://linear.app/workos/issue/DAAP-424/add-sessioncreated-to-node

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
