### PR TITLE
import crypto

### DIFF
--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -1,6 +1,9 @@
+import { Crypto } from '@peculiar/webcrypto';
 import { SignatureVerificationException } from '../common/exceptions';
 import { deserializeEvent } from '../common/serializers';
 import { Event, EventResponse } from '../common/interfaces';
+
+const crypto = new Crypto();
 
 export class Webhooks {
   private encoder = new TextEncoder();


### PR DESCRIPTION
## Description
Resolves an error when using the SDK `workos.webhooks.constructEvent` method: 
```
An unhandled error of type 'crypto is not defined'
```
Resolves #995 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] No
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
