### PR TITLE
Provide a manual workflow for fixing the npm @latest tag

### DIFF
--- a/.github/workflows/fix-latest.yml
+++ b/.github/workflows/fix-latest.yml
@@ -1,0 +1,36 @@
+name: Fix @latest tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      latest-version:
+        description: 'The version that should be @latest, e.g. "6.7.0"'
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Update @latest tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: |
+          npm install
+
+      - name: Tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          LATEST_VERSION: ${{ inputs.latest-version }}
+        run: |
+          echo "Setting @workos-inc/node@latest to $LATEST_VERSION"
+          npm dist-tag add @workos-inc/node@$LATEST_VERSION latest


### PR DESCRIPTION
## Description
Users wanting to deploy a non-latest version will use this workflow to fix the @latest tag to the correct version once new release is published.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
