### PR TITLE
Fix the README build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WorkOS Node.js Library
 
 ![npm](https://img.shields.io/npm/v/@workos-inc/node)
-[![Build Status](https://workos.semaphoreci.com/badges/workos-node/branches/main.svg?style=shields)](https://workos.semaphoreci.com/projects/workos-node)
+[![Build Status](https://github.com/workos/workos-node/actions/workflows/ci.yml/badge.svg)](https://github.com/workos/workos-node/actions/workflows/ci.yml)
 
 The WorkOS library for Node.js provides convenient access to the WorkOS API from applications written in server-side JavaScript.
 


### PR DESCRIPTION
## Description
We are no longer relying on Semaphore for CI status, so need to update the badge.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
