### PR TITLE
Export `BadRequestException`

### DIFF
--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -1,4 +1,5 @@
 export * from './generic-server.exception';
+export * from './bad-request.exception';
 export * from './no-api-key-provided.exception';
 export * from './not-found.exception';
 export * from './oauth.exception';


### PR DESCRIPTION
## Description

Export `BadRequestException` to be able to narrow it's type on `try` `clause` clauses:

```ts
try {
      await this.client.userManagement.createUser(options);
    } catch (error) {
      if (error instanceof BadRequestException) {}
}}
```

As an example, `createUser` returns two exceptions that are inherited from our `BadRequestException` class.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
