### PR TITLE
Drop support for versions < 19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18, 20]
+        node: [19, 20, 21]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [19, 20, 21]
+        node: [19, 20]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/fix-latest.yml
+++ b/.github/workflows/fix-latest.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,9 +1,3 @@
 import { enableFetchMocks } from 'jest-fetch-mock';
-import { Crypto } from '@peculiar/webcrypto';
 
 enableFetchMocks();
-
-// Assign Node's Crypto to global.crypto if it is not already present
-if (!global.crypto) {
-    global.crypto = new Crypto();
-}


### PR DESCRIPTION
## Description
We've moved to using native `global.crypto` which only exists in newer versions of Node.js, so our tests should reflect that reality.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
