### PR TITLE
Move the crypto polyfill into the library itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
+    "@peculiar/webcrypto": "^1.4.5",
     "pluralize": "8.0.0"
   },
   "devDependencies": {
-    "@peculiar/webcrypto": "^1.4.5",
     "@types/jest": "29.5.3",
     "@types/node": "14.18.54",
     "@types/pluralize": "0.0.30",

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,9 +1,4 @@
 import { enableFetchMocks } from 'jest-fetch-mock';
-import { Crypto } from '@peculiar/webcrypto';
 
 enableFetchMocks();
 
-// Assign Node's Crypto to global.crypto if it is not already present
-if (!global.crypto) {
-    global.crypto = new Crypto();
-}

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -28,6 +28,13 @@ import { BadRequestException } from './common/exceptions/bad-request.exception';
 import { FetchClient } from './common/utils/fetch-client';
 import { FetchError } from './common/utils/fetch-error';
 
+import { Crypto } from '@peculiar/webcrypto';
+
+// Assign Node's Crypto to global.crypto if it is not already present
+if (!global.crypto) {
+  global.crypto = new Crypto();
+}
+
 const VERSION = '6.8.0';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';


### PR DESCRIPTION
## Description
This lets us keep support for Node 16 and 18, while running under 19 or newer will default to the now-built-in crypto support.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
