### PR TITLE
Add 'password_hash' and 'password_hash_type' to User creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.8.0",
+  "version": "6.8.1",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`SSO SSO getProfileAndToken with all information provided sends a reques
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/6.8.0",
+  "User-Agent": "workos-node/6.8.1",
 }
 `;
 
@@ -58,7 +58,7 @@ exports[`SSO SSO getProfileAndToken without a groups attribute sends a request t
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/6.8.0",
+  "User-Agent": "workos-node/6.8.1",
 }
 `;
 

--- a/src/user-management/interfaces/create-user-options.interface.ts
+++ b/src/user-management/interfaces/create-user-options.interface.ts
@@ -1,6 +1,8 @@
 export interface CreateUserOptions {
   email: string;
   password?: string;
+  passwordHash?: string;
+  passwordHashType?: 'bcrypt' | 'firebase-scrypt' | 'ssha';
   firstName?: string;
   lastName?: string;
   emailVerified?: boolean;
@@ -9,6 +11,8 @@ export interface CreateUserOptions {
 export interface SerializedCreateUserOptions {
   email: string;
   password?: string;
+  password_hash?: string;
+  password_hash_type?: 'bcrypt' | 'firebase-scrypt' | 'ssha';
   first_name?: string;
   last_name?: string;
   email_verified?: boolean;

--- a/src/user-management/serializers/create-user-options.serializer.ts
+++ b/src/user-management/serializers/create-user-options.serializer.ts
@@ -5,6 +5,8 @@ export const serializeCreateUserOptions = (
 ): SerializedCreateUserOptions => ({
   email: options.email,
   password: options.password,
+  password_hash: options.passwordHash,
+  password_hash_type: options.passwordHashType,
   first_name: options.firstName,
   last_name: options.lastName,
   email_verified: options.emailVerified,

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -28,7 +28,7 @@ import { BadRequestException } from './common/exceptions/bad-request.exception';
 import { FetchClient } from './common/utils/fetch-client';
 import { FetchError } from './common/utils/fetch-error';
 
-const VERSION = '6.8.0';
+const VERSION = '6.8.1';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
 


### PR DESCRIPTION
## Description
This PR ensures that the User create process allows for the `password_hash` and `password_hash_type` fields, in addition to the existing `password` field, similar to the Update process.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/26060
