### PR TITLE
Make events array required for listEvents

### DIFF
--- a/src/events/events.spec.ts
+++ b/src/events/events.spec.ts
@@ -80,21 +80,6 @@ describe('Event', () => {
       });
     });
 
-    it(`requests Events`, async () => {
-      fetchOnce(eventsListResponse);
-
-      const subject = await workos.events.listEvents({
-        rangeStart: '2020-05-05',
-        rangeEnd: '2020-05-07',
-      });
-
-      expect(subject).toEqual({
-        object: 'list',
-        data: [event],
-        listMetadata: {},
-      });
-    });
-
     it(`requests Events with a valid event name`, async () => {
       fetchOnce(eventsListResponse);
 

--- a/src/events/interfaces/list-events-options.interface.ts
+++ b/src/events/interfaces/list-events-options.interface.ts
@@ -1,7 +1,7 @@
 import { EventName } from '../../common/interfaces';
 
 export interface ListEventOptions {
-  events?: EventName[];
+  events: EventName[];
   rangeStart?: string;
   rangeEnd?: string;
   limit?: number;
@@ -9,7 +9,7 @@ export interface ListEventOptions {
 }
 
 export interface SerializedListEventOptions {
-  events?: EventName[];
+  events: EventName[];
   range_start?: string;
   range_end?: string;
   limit?: number;


### PR DESCRIPTION
## Description
Make events array required for listEvents.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
https://github.com/workos/workos/pull/26139