### PR TITLE
Fix flakey audit_log tests

### DIFF
--- a/src/audit-logs/audit-logs.spec.ts
+++ b/src/audit-logs/audit-logs.spec.ts
@@ -205,13 +205,15 @@ describe('AuditLogs', () => {
           targets: ['user', 'team'],
         };
 
+        const timestamp = new Date().toISOString();
+
         const auditLogExport: AuditLogExport = {
           object: 'audit_log_export',
           id: 'audit_log_export_1234',
           state: 'pending',
           url: undefined,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
+          createdAt: timestamp,
+          updatedAt: timestamp,
         };
 
         const auditLogExportResponse: AuditLogExportResponse = {
@@ -219,8 +221,8 @@ describe('AuditLogs', () => {
           id: 'audit_log_export_1234',
           state: 'pending',
           url: undefined,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
+          created_at: timestamp,
+          updated_at: timestamp,
         };
 
         workosSpy.mockResolvedValueOnce(

--- a/src/audit-logs/audit-logs.spec.ts
+++ b/src/audit-logs/audit-logs.spec.ts
@@ -205,7 +205,7 @@ describe('AuditLogs', () => {
           targets: ['user', 'team'],
         };
 
-        const timestamp = new Date().toISOString();
+        const timestamp: string = new Date().toISOString();
 
         const auditLogExport: AuditLogExport = {
           object: 'audit_log_export',

--- a/src/audit-logs/audit-logs.spec.ts
+++ b/src/audit-logs/audit-logs.spec.ts
@@ -155,13 +155,15 @@ describe('AuditLogs', () => {
           rangeEnd: new Date(),
         };
 
+        const timestamp: string = new Date().toISOString();
+
         const auditLogExport: AuditLogExport = {
           object: 'audit_log_export',
           id: 'audit_log_export_1234',
           state: 'pending',
           url: undefined,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
+          createdAt: timestamp,
+          updatedAt: timestamp,
         };
 
         const auditLogExportResponse: AuditLogExportResponse = {
@@ -169,8 +171,8 @@ describe('AuditLogs', () => {
           id: 'audit_log_export_1234',
           state: 'pending',
           url: undefined,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
+          created_at: timestamp,
+          updated_at: timestamp,
         };
 
         workosSpy.mockResolvedValueOnce(
@@ -274,13 +276,15 @@ describe('AuditLogs', () => {
       it('returns `audit_log_export`', async () => {
         const workosSpy = jest.spyOn(WorkOS.prototype, 'get');
 
+        const timestamp: string = new Date().toISOString();
+
         const auditLogExport: AuditLogExport = {
           object: 'audit_log_export',
           id: 'audit_log_export_1234',
           state: 'pending',
           url: undefined,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
+          createdAt: timestamp,
+          updatedAt: timestamp,
         };
 
         const auditLogExportResponse: AuditLogExportResponse = {
@@ -288,8 +292,8 @@ describe('AuditLogs', () => {
           id: 'audit_log_export_1234',
           state: 'pending',
           url: undefined,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
+          created_at: timestamp,
+          updated_at: timestamp,
         };
 
         workosSpy.mockResolvedValueOnce(


### PR DESCRIPTION
## Description
Builds have been failing due to [flakey tests](https://github.com/workos/workos-node/actions/runs/8618840279/job/23622148733). These are caused by calling `new Date()` sequentially which can sometimes result in a microsecond difference between results:

```
    - Expected  - 1
    + Received  + 1

      Object {
        "createdAt": "2024-04-09T16:06:34.890Z",
        "id": "audit_log_export_1234",
        "object": "audit_log_export",
        "state": "pending",
    -   "updatedAt": "2024-04-09T16:06:34.890Z",
    +   "updatedAt": "2024-04-09T16:06:34.891Z",
        "url": undefined,
      }
```

This fixes those tests by only grabbing a timestamp once.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
