### PR TITLE
Add `domain_data` to Organization API and deprecate `domains`

### DIFF
--- a/src/organizations/interfaces/create-organization-options.interface.ts
+++ b/src/organizations/interfaces/create-organization-options.interface.ts
@@ -4,21 +4,21 @@ import { DomainData } from './domain-data.interface';
 export interface CreateOrganizationOptions {
   name: string;
   allowProfilesOutsideOrganization?: boolean;
+  domainData?: DomainData[];
   /**
    * @deprecated Use `domain_data` instead.
    */
   domains?: string[];
-  domain_data?: DomainData[];
 }
 
 export interface SerializedCreateOrganizationOptions {
   name: string;
   allow_profiles_outside_organization?: boolean;
+  domain_data?: DomainData[];
   /**
    * @deprecated Use `domain_data` instead.
    */
   domains?: string[];
-  domain_data?: DomainData[];
 }
 
 export interface CreateOrganizationRequestOptions

--- a/src/organizations/interfaces/create-organization-options.interface.ts
+++ b/src/organizations/interfaces/create-organization-options.interface.ts
@@ -1,15 +1,24 @@
 import { PostOptions } from '../../common/interfaces';
+import { DomainData } from './domain-data.interface';
 
 export interface CreateOrganizationOptions {
   name: string;
   allowProfilesOutsideOrganization?: boolean;
+  /**
+   * @deprecated Use `domain_data` instead.
+   */
   domains?: string[];
+  domain_data?: DomainData[];
 }
 
 export interface SerializedCreateOrganizationOptions {
   name: string;
   allow_profiles_outside_organization?: boolean;
+  /**
+   * @deprecated Use `domain_data` instead.
+   */
   domains?: string[];
+  domain_data?: DomainData[];
 }
 
 export interface CreateOrganizationRequestOptions

--- a/src/organizations/interfaces/domain-data.interface.ts
+++ b/src/organizations/interfaces/domain-data.interface.ts
@@ -1,0 +1,10 @@
+// These are the only possible states to create an organization domain with
+export enum DomainDataState {
+  Verified = 'verified',
+  Pending = 'pending',
+}
+
+export interface DomainData {
+  domain: string;
+  state: DomainDataState;
+}

--- a/src/organizations/interfaces/index.ts
+++ b/src/organizations/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './create-organization-options.interface';
+export * from './domain-data.interface';
 export * from './list-organizations-options.interface';
 export * from './organization-domain.interface';
 export * from './organization.interface';

--- a/src/organizations/interfaces/update-organization-options.interface.ts
+++ b/src/organizations/interfaces/update-organization-options.interface.ts
@@ -1,12 +1,22 @@
+import { DomainData } from './domain-data.interface';
+
 export interface UpdateOrganizationOptions {
   organization: string;
   name: string;
   allowProfilesOutsideOrganization?: boolean;
+  /**
+   * @deprecated Use `domain_data` instead.
+   */
   domains?: string[];
+  domain_data?: DomainData[];
 }
 
 export interface SerializedUpdateOrganizationOptions {
   name: string;
   allow_profiles_outside_organization?: boolean;
+  /**
+   * @deprecated Use `domain_data` instead.
+   */
   domains?: string[];
+  domain_data?: DomainData[];
 }

--- a/src/organizations/interfaces/update-organization-options.interface.ts
+++ b/src/organizations/interfaces/update-organization-options.interface.ts
@@ -4,19 +4,19 @@ export interface UpdateOrganizationOptions {
   organization: string;
   name: string;
   allowProfilesOutsideOrganization?: boolean;
+  domainData?: DomainData[];
   /**
    * @deprecated Use `domain_data` instead.
    */
   domains?: string[];
-  domain_data?: DomainData[];
 }
 
 export interface SerializedUpdateOrganizationOptions {
   name: string;
   allow_profiles_outside_organization?: boolean;
+  domain_data?: DomainData[];
   /**
    * @deprecated Use `domain_data` instead.
    */
   domains?: string[];
-  domain_data?: DomainData[];
 }

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -12,6 +12,7 @@ import createOrganization from './fixtures/create-organization.json';
 import getOrganization from './fixtures/get-organization.json';
 import listOrganizationsFixture from './fixtures/list-organizations.json';
 import updateOrganization from './fixtures/update-organization.json';
+import { DomainDataState } from './interfaces';
 
 const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
@@ -143,21 +144,44 @@ describe('Organizations', () => {
     });
 
     describe('with a valid payload', () => {
-      it('creates an organization', async () => {
-        fetchOnce(createOrganization, { status: 201 });
+      describe('with `domains`', () => {
+        it('creates an organization', async () => {
+          fetchOnce(createOrganization, { status: 201 });
 
-        const subject = await workos.organizations.createOrganization({
-          domains: ['example.com'],
-          name: 'Test Organization',
-        });
+          const subject = await workos.organizations.createOrganization({
+            domains: ['example.com'],
+            name: 'Test Organization',
+          });
 
-        expect(fetchBody()).toEqual({
-          domains: ['example.com'],
-          name: 'Test Organization',
+          expect(fetchBody()).toEqual({
+            domains: ['example.com'],
+            name: 'Test Organization',
+          });
+          expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
+          expect(subject.name).toEqual('Test Organization');
+          expect(subject.domains).toHaveLength(1);
         });
-        expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
-        expect(subject.name).toEqual('Test Organization');
-        expect(subject.domains).toHaveLength(1);
+      });
+
+      describe('with `domain_data`', () => {
+        it('creates an organization', async () => {
+          fetchOnce(createOrganization, { status: 201 });
+
+          const subject = await workos.organizations.createOrganization({
+            domain_data: [
+              { domain: 'example.com', state: DomainDataState.Verified },
+            ],
+            name: 'Test Organization',
+          });
+
+          expect(fetchBody()).toEqual({
+            domain_data: [{ domain: 'example.com', state: 'verified' }],
+            name: 'Test Organization',
+          });
+          expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
+          expect(subject.name).toEqual('Test Organization');
+          expect(subject.domains).toHaveLength(1);
+        });
       });
     });
 
@@ -220,22 +244,46 @@ describe('Organizations', () => {
 
   describe('updateOrganization', () => {
     describe('with a valid payload', () => {
-      it('updates an organization', async () => {
-        fetchOnce(updateOrganization, { status: 201 });
+      describe('with `domains', () => {
+        it('updates an organization', async () => {
+          fetchOnce(updateOrganization, { status: 201 });
 
-        const subject = await workos.organizations.updateOrganization({
-          organization: 'org_01EHT88Z8J8795GZNQ4ZP1J81T',
-          domains: ['example.com'],
-          name: 'Test Organization 2',
-        });
+          const subject = await workos.organizations.updateOrganization({
+            organization: 'org_01EHT88Z8J8795GZNQ4ZP1J81T',
+            domains: ['example.com'],
+            name: 'Test Organization 2',
+          });
 
-        expect(fetchBody()).toEqual({
-          domains: ['example.com'],
-          name: 'Test Organization 2',
+          expect(fetchBody()).toEqual({
+            domains: ['example.com'],
+            name: 'Test Organization 2',
+          });
+          expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
+          expect(subject.name).toEqual('Test Organization 2');
+          expect(subject.domains).toHaveLength(1);
         });
-        expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
-        expect(subject.name).toEqual('Test Organization 2');
-        expect(subject.domains).toHaveLength(1);
+      });
+
+      describe('with `domain_data`', () => {
+        it('updates an organization', async () => {
+          fetchOnce(updateOrganization, { status: 201 });
+
+          const subject = await workos.organizations.updateOrganization({
+            organization: 'org_01EHT88Z8J8795GZNQ4ZP1J81T',
+            domain_data: [
+              { domain: 'example.com', state: DomainDataState.Verified },
+            ],
+            name: 'Test Organization 2',
+          });
+
+          expect(fetchBody()).toEqual({
+            domain_data: [{ domain: 'example.com', state: 'verified' }],
+            name: 'Test Organization 2',
+          });
+          expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
+          expect(subject.name).toEqual('Test Organization 2');
+          expect(subject.domains).toHaveLength(1);
+        });
       });
     });
   });

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -168,7 +168,7 @@ describe('Organizations', () => {
           fetchOnce(createOrganization, { status: 201 });
 
           const subject = await workos.organizations.createOrganization({
-            domain_data: [
+            domainData: [
               { domain: 'example.com', state: DomainDataState.Verified },
             ],
             name: 'Test Organization',
@@ -270,7 +270,7 @@ describe('Organizations', () => {
 
           const subject = await workos.organizations.updateOrganization({
             organization: 'org_01EHT88Z8J8795GZNQ4ZP1J81T',
-            domain_data: [
+            domainData: [
               { domain: 'example.com', state: DomainDataState.Verified },
             ],
             name: 'Test Organization 2',

--- a/src/organizations/serializers/create-organization-options.serializer.ts
+++ b/src/organizations/serializers/create-organization-options.serializer.ts
@@ -8,6 +8,6 @@ export const serializeCreateOrganizationOptions = (
 ): SerializedCreateOrganizationOptions => ({
   name: options.name,
   allow_profiles_outside_organization: options.allowProfilesOutsideOrganization,
+  domain_data: options.domainData,
   domains: options.domains,
-  domain_data: options.domain_data,
 });

--- a/src/organizations/serializers/create-organization-options.serializer.ts
+++ b/src/organizations/serializers/create-organization-options.serializer.ts
@@ -9,4 +9,5 @@ export const serializeCreateOrganizationOptions = (
   name: options.name,
   allow_profiles_outside_organization: options.allowProfilesOutsideOrganization,
   domains: options.domains,
+  domain_data: options.domain_data,
 });

--- a/src/organizations/serializers/update-organization-options.serializer.ts
+++ b/src/organizations/serializers/update-organization-options.serializer.ts
@@ -8,6 +8,6 @@ export const serializeUpdateOrganizationOptions = (
 ): SerializedUpdateOrganizationOptions => ({
   name: options.name,
   allow_profiles_outside_organization: options.allowProfilesOutsideOrganization,
+  domain_data: options.domainData,
   domains: options.domains,
-  domain_data: options.domain_data,
 });

--- a/src/organizations/serializers/update-organization-options.serializer.ts
+++ b/src/organizations/serializers/update-organization-options.serializer.ts
@@ -9,4 +9,5 @@ export const serializeUpdateOrganizationOptions = (
   name: options.name,
   allow_profiles_outside_organization: options.allowProfilesOutsideOrganization,
   domains: options.domains,
+  domain_data: options.domain_data,
 });


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
