### PR TITLE
Add om.created and om.deleted event types

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -218,13 +218,41 @@ export interface UserDeletedEventResponse extends EventResponseBase {
   data: UserResponse;
 }
 
+/**
+ * @deprecated Use OrganizationMembershipCreated instead.
+ */
 export interface OrganizationMembershipAdded extends EventBase {
   event: 'organization_membership.added';
   data: OrganizationMembership;
 }
 
+/**
+ * @deprecated Use OrganizationMembershipCreatedResponse instead.
+ */
 export interface OrganizationMembershipAddedResponse extends EventResponseBase {
   event: 'organization_membership.added';
+  data: OrganizationMembershipResponse;
+}
+
+export interface OrganizationMembershipCreated extends EventBase {
+  event: 'organization_membership.created';
+  data: OrganizationMembership;
+}
+
+export interface OrganizationMembershipCreatedResponse
+  extends EventResponseBase {
+  event: 'organization_membership.created';
+  data: OrganizationMembershipResponse;
+}
+
+export interface OrganizationMembershipDeleted extends EventBase {
+  event: 'organization_membership.deleted';
+  data: OrganizationMembership;
+}
+
+export interface OrganizationMembershipDeletedResponse
+  extends EventResponseBase {
+  event: 'organization_membership.deleted';
   data: OrganizationMembershipResponse;
 }
 
@@ -239,11 +267,17 @@ export interface OrganizationMembershipUpdatedResponse
   data: OrganizationMembershipResponse;
 }
 
+/**
+ * @deprecated Use OrganizationMembershipDeleted instead.
+ */
 export interface OrganizationMembershipRemoved extends EventBase {
   event: 'organization_membership.removed';
   data: OrganizationMembership;
 }
 
+/**
+ * @deprecated Use OrganizationMembershipDeletedResponse instead.
+ */
 export interface OrganizationMembershipRemovedResponse
   extends EventResponseBase {
   event: 'organization_membership.removed';
@@ -309,6 +343,8 @@ export type Event =
   | UserUpdatedEvent
   | UserDeletedEvent
   | OrganizationMembershipAdded
+  | OrganizationMembershipCreated
+  | OrganizationMembershipDeleted
   | OrganizationMembershipUpdated
   | OrganizationMembershipRemoved
   | SessionCreatedEvent
@@ -335,6 +371,8 @@ export type EventResponse =
   | UserUpdatedEventResponse
   | UserDeletedEventResponse
   | OrganizationMembershipAddedResponse
+  | OrganizationMembershipCreatedResponse
+  | OrganizationMembershipDeletedResponse
   | OrganizationMembershipUpdatedResponse
   | OrganizationMembershipRemovedResponse
   | SessionCreatedEventResponse

--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -219,7 +219,7 @@ export interface UserDeletedEventResponse extends EventResponseBase {
 }
 
 /**
- * @deprecated Use OrganizationMembershipCreated instead.
+ * @deprecated Use OrganizationMembershipCreated instead. Will be removed in a future major version.
  */
 export interface OrganizationMembershipAdded extends EventBase {
   event: 'organization_membership.added';
@@ -227,7 +227,7 @@ export interface OrganizationMembershipAdded extends EventBase {
 }
 
 /**
- * @deprecated Use OrganizationMembershipCreatedResponse instead.
+ * @deprecated Use OrganizationMembershipCreatedResponse instead. Will be removed in a future major version.
  */
 export interface OrganizationMembershipAddedResponse extends EventResponseBase {
   event: 'organization_membership.added';
@@ -268,7 +268,7 @@ export interface OrganizationMembershipUpdatedResponse
 }
 
 /**
- * @deprecated Use OrganizationMembershipDeleted instead.
+ * @deprecated Use OrganizationMembershipDeleted instead. Will be removed in a future major version.
  */
 export interface OrganizationMembershipRemoved extends EventBase {
   event: 'organization_membership.removed';
@@ -276,7 +276,7 @@ export interface OrganizationMembershipRemoved extends EventBase {
 }
 
 /**
- * @deprecated Use OrganizationMembershipDeletedResponse instead.
+ * @deprecated Use OrganizationMembershipDeletedResponse instead. Will be removed in a future major version.
  */
 export interface OrganizationMembershipRemovedResponse
   extends EventResponseBase {

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -87,6 +87,8 @@ export const deserializeEvent = (event: EventResponse): Event => {
         data: deserializeUser(event.data),
       };
     case 'organization_membership.added':
+    case 'organization_membership.created':
+    case 'organization_membership.deleted':
     case 'organization_membership.updated':
     case 'organization_membership.removed':
       return {


### PR DESCRIPTION
## Description
Add om.created and om.deleted event types and mark om.added and om.removed as deprecated.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
