### PR TITLE
Bump volta node version to match `engines`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "workos"
   ],
   "volta": {
-    "node": "14.21.3",
+    "node": "19.9.0",
     "yarn": "1.22.19"
   },
   "engines": {


### PR DESCRIPTION
## Description

Our Volta version is quite a bit behind what we now specify is the minimum Node version in `engines`. This bumps the version in order to keep parity for development.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
