### PR TITLE
Support `organizationId` as a valid parameter for `events`

### DIFF
--- a/src/events/events.spec.ts
+++ b/src/events/events.spec.ts
@@ -93,5 +93,20 @@ describe('Event', () => {
         listMetadata: {},
       });
     });
+
+    it(`requests Events with a valid organization id`, async () => {
+      fetchOnce(eventsListResponse);
+
+      const list = await workos.events.listEvents({
+        events: ['connection.activated'],
+        organizationId: 'org_1234',
+      });
+
+      expect(list).toEqual({
+        object: 'list',
+        data: [event],
+        listMetadata: {},
+      });
+    });
   });
 });

--- a/src/events/interfaces/list-events-options.interface.ts
+++ b/src/events/interfaces/list-events-options.interface.ts
@@ -6,6 +6,7 @@ export interface ListEventOptions {
   rangeEnd?: string;
   limit?: number;
   after?: string;
+  organizationId?: string;
 }
 
 export interface SerializedListEventOptions {
@@ -14,4 +15,5 @@ export interface SerializedListEventOptions {
   range_end?: string;
   limit?: number;
   after?: string;
+  organization_id?: string;
 }

--- a/src/events/serializers/list-event-options.serializer.ts
+++ b/src/events/serializers/list-event-options.serializer.ts
@@ -4,6 +4,7 @@ export const serializeListEventOptions = (
   options: ListEventOptions,
 ): SerializedListEventOptions => ({
   events: options.events,
+  organization_id: options.organizationId,
   range_start: options.rangeStart,
   range_end: options.rangeEnd,
   limit: options.limit,


### PR DESCRIPTION
## Description
Allow passing an `organizationId` into the options for the Events API 
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
