### PR TITLE
Add `inviterUserId` to `invitation`

### DIFF
--- a/src/user-management/fixtures/invitation.json
+++ b/src/user-management/fixtures/invitation.json
@@ -7,6 +7,7 @@
   "revoked_at": "2023-07-18T02:07:19.911Z",
   "expires_at": "2023-07-18T02:07:19.911Z",
   "organization_id": "org_01H5JQDV7R7ATEYZDEG0W5PRYS",
+  "inviter_user_id": null,
   "token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
   "accept_invitation_url": "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
   "created_at": "2023-07-18T02:07:19.911Z",

--- a/src/user-management/fixtures/list-invitations.json
+++ b/src/user-management/fixtures/list-invitations.json
@@ -10,6 +10,7 @@
       "revoked_at": "2023-07-18T02:07:19.911Z",
       "expires_at": "2023-07-18T02:07:19.911Z",
       "organization_id": "org_01H5JQDV7R7ATEYZDEG0W5PRYS",
+      "inviter_user_id": null,
       "token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
       "accept_invitation_url": "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
       "created_at": "2023-07-18T02:07:19.911Z",

--- a/src/user-management/interfaces/invitation.interface.ts
+++ b/src/user-management/interfaces/invitation.interface.ts
@@ -7,6 +7,7 @@ export interface Invitation {
   revokedAt: string | null;
   expiresAt: string;
   organizationId: string | null;
+  inviterUserId: string | null;
   token: string;
   acceptInvitationUrl: string;
   createdAt: string;
@@ -22,6 +23,7 @@ export interface InvitationEvent {
   revokedAt: string | null;
   expiresAt: string;
   organizationId: string | null;
+  inviterUserId: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -35,6 +37,7 @@ export interface InvitationResponse {
   revoked_at: string | null;
   expires_at: string;
   organization_id: string | null;
+  inviter_user_id: string | null;
   token: string;
   accept_invitation_url: string;
   created_at: string;
@@ -50,6 +53,7 @@ export interface InvitationEventResponse {
   revoked_at: string | null;
   expires_at: string;
   organization_id: string | null;
+  inviter_user_id: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/user-management/serializers/invitation.serializer.ts
+++ b/src/user-management/serializers/invitation.serializer.ts
@@ -16,6 +16,7 @@ export const deserializeInvitation = (
   revokedAt: invitation.revoked_at,
   expiresAt: invitation.expires_at,
   organizationId: invitation.organization_id,
+  inviterUserId: invitation.inviter_user_id,
   token: invitation.token,
   acceptInvitationUrl: invitation.accept_invitation_url,
   createdAt: invitation.created_at,
@@ -33,6 +34,7 @@ export const deserializeInvitationEvent = (
   revokedAt: invitation.revoked_at,
   expiresAt: invitation.expires_at,
   organizationId: invitation.organization_id,
+  inviterUserId: invitation.inviter_user_id,
   createdAt: invitation.created_at,
   updatedAt: invitation.updated_at,
 });


### PR DESCRIPTION
## Description

Exposes the `inviterUserId` field on the `invitation` object.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
