### PR TITLE
Add organization membership deactivate and reactivate API methods

### DIFF
--- a/src/user-management/fixtures/deactivate-organization-membership.json
+++ b/src/user-management/fixtures/deactivate-organization-membership.json
@@ -1,0 +1,12 @@
+{
+  "object": "organization_membership",
+  "id": "om_01H5JQDV7R7ATEYZDEG0W5PRYS",
+  "user_id": "user_01H5JQDV7R7ATEYZDEG0W5PRYS",
+  "organization_id": "organization_01H5JQDV7R7ATEYZDEG0W5PRYS",
+  "status": "inactive",
+  "role": {
+    "slug": "member"
+  },
+  "created_at": "2023-07-18T02:07:19.911Z",
+  "updated_at": "2023-07-18T02:07:19.911Z"
+}

--- a/src/user-management/interfaces/list-organization-memberships-options.interface.ts
+++ b/src/user-management/interfaces/list-organization-memberships-options.interface.ts
@@ -1,12 +1,15 @@
 import { PaginationOptions } from '../../common/interfaces';
+import { OrganizationMembershipStatus } from './organization-membership.interface';
 
 export interface ListOrganizationMembershipsOptions extends PaginationOptions {
   organizationId?: string;
   userId?: string;
+  statuses?: OrganizationMembershipStatus[];
 }
 
 export interface SerializedListOrganizationMembershipsOptions
   extends PaginationOptions {
   organization_id?: string;
   user_id?: string;
+  statuses?: string;
 }

--- a/src/user-management/interfaces/organization-membership.interface.ts
+++ b/src/user-management/interfaces/organization-membership.interface.ts
@@ -1,10 +1,12 @@
 import { RoleResponse } from './role.interface';
 
+export type OrganizationMembershipStatus = 'active' | 'inactive' | 'pending';
+
 export interface OrganizationMembership {
   object: 'organization_membership';
   id: string;
   organizationId: string;
-  status: 'active' | 'pending';
+  status: OrganizationMembershipStatus;
   userId: string;
   createdAt: string;
   updatedAt: string;
@@ -15,7 +17,7 @@ export interface OrganizationMembershipResponse {
   object: 'organization_membership';
   id: string;
   organization_id: string;
-  status: 'active' | 'pending';
+  status: OrganizationMembershipStatus;
   user_id: string;
   created_at: string;
   updated_at: string;

--- a/src/user-management/serializers/list-organization-memberships-options.serializer.ts
+++ b/src/user-management/serializers/list-organization-memberships-options.serializer.ts
@@ -8,6 +8,7 @@ export const serializeListOrganizationMembershipsOptions = (
 ): SerializedListOrganizationMembershipsOptions => ({
   user_id: options.userId,
   organization_id: options.organizationId,
+  statuses: options.statuses?.join(','),
   limit: options.limit,
   before: options.before,
   after: options.after,

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -1,19 +1,20 @@
 import fetch from 'jest-fetch-mock';
 import {
-  fetchOnce,
-  fetchURL,
-  fetchSearchParams,
   fetchBody,
+  fetchOnce,
+  fetchSearchParams,
+  fetchURL,
 } from '../common/utils/test-utils';
 import { WorkOS } from '../workos';
-import userFixture from './fixtures/user.json';
-import listUsersFixture from './fixtures/list-users.json';
-import listFactorFixture from './fixtures/list-factors.json';
-import organizationMembershipFixture from './fixtures/organization-membership.json';
-import listOrganizationMembershipsFixture from './fixtures/list-organization-memberships.json';
+import deactivateOrganizationMembershipsFixture from './fixtures/deactivate-organization-membership.json';
 import invitationFixture from './fixtures/invitation.json';
+import listFactorFixture from './fixtures/list-factors.json';
 import listInvitationsFixture from './fixtures/list-invitations.json';
+import listOrganizationMembershipsFixture from './fixtures/list-organization-memberships.json';
+import listUsersFixture from './fixtures/list-users.json';
 import magicAuthFixture from './fixtures/magic_auth.json';
+import organizationMembershipFixture from './fixtures/organization-membership.json';
+import userFixture from './fixtures/user.json';
 
 const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 const userId = 'user_01H5JQDV7R7ATEYZDEG0W5PRYS';
@@ -665,6 +666,7 @@ describe('UserManagement', () => {
       await workos.userManagement.listOrganizationMemberships({
         userId: 'user_someuser',
         organizationId: 'org_someorg',
+        statuses: ['active', 'inactive'],
         after: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
         limit: 10,
       });
@@ -672,6 +674,7 @@ describe('UserManagement', () => {
       expect(fetchSearchParams()).toEqual({
         user_id: 'user_someuser',
         organization_id: 'org_someorg',
+        statuses: 'active,inactive',
         after: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
         limit: '10',
         order: 'desc',
@@ -743,6 +746,54 @@ describe('UserManagement', () => {
         `/user_management/organization_memberships/${organizationMembershipId}`,
       );
       expect(resp).toBeUndefined();
+    });
+  });
+
+  describe('deactivateOrganizationMembership', () => {
+    it('sends a deactivateOrganizationMembership request', async () => {
+      fetchOnce(deactivateOrganizationMembershipsFixture);
+
+      const organizationMembership =
+        await workos.userManagement.deactivateOrganizationMembership(
+          organizationMembershipId,
+        );
+
+      expect(fetchURL()).toContain(
+        `/user_management/organization_memberships/${organizationMembershipId}/deactivate`,
+      );
+      expect(organizationMembership).toMatchObject({
+        object: 'organization_membership',
+        organizationId: 'organization_01H5JQDV7R7ATEYZDEG0W5PRYS',
+        userId: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+        status: 'inactive',
+        role: {
+          slug: 'member',
+        },
+      });
+    });
+  });
+
+  describe('reactivateOrganizationMembership', () => {
+    it('sends a reactivateOrganizationMembership request', async () => {
+      fetchOnce(organizationMembershipFixture);
+
+      const organizationMembership =
+        await workos.userManagement.reactivateOrganizationMembership(
+          organizationMembershipId,
+        );
+
+      expect(fetchURL()).toContain(
+        `/user_management/organization_memberships/${organizationMembershipId}/reactivate`,
+      );
+      expect(organizationMembership).toMatchObject({
+        object: 'organization_membership',
+        organizationId: 'organization_01H5JQDV7R7ATEYZDEG0W5PRYS',
+        userId: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+        status: 'active',
+        role: {
+          slug: 'member',
+        },
+      });
     });
   });
 

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -501,7 +501,7 @@ export class UserManagement {
   async deactivateOrganizationMembership(
     organizationMembershipId: string,
   ): Promise<OrganizationMembership> {
-    const { data } = await this.workos.post<OrganizationMembershipResponse>(
+    const { data } = await this.workos.put<OrganizationMembershipResponse>(
       `/user_management/organization_memberships/${organizationMembershipId}/deactivate`,
       {},
     );
@@ -512,7 +512,7 @@ export class UserManagement {
   async reactivateOrganizationMembership(
     organizationMembershipId: string,
   ): Promise<OrganizationMembership> {
-    const { data } = await this.workos.post<OrganizationMembershipResponse>(
+    const { data } = await this.workos.put<OrganizationMembershipResponse>(
       `/user_management/organization_memberships/${organizationMembershipId}/reactivate`,
       {},
     );

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -498,6 +498,28 @@ export class UserManagement {
     );
   }
 
+  async deactivateOrganizationMembership(
+    organizationMembershipId: string,
+  ): Promise<OrganizationMembership> {
+    const { data } = await this.workos.post<OrganizationMembershipResponse>(
+      `/user_management/organization_memberships/${organizationMembershipId}/deactivate`,
+      {},
+    );
+
+    return deserializeOrganizationMembership(data);
+  }
+
+  async reactivateOrganizationMembership(
+    organizationMembershipId: string,
+  ): Promise<OrganizationMembership> {
+    const { data } = await this.workos.post<OrganizationMembershipResponse>(
+      `/user_management/organization_memberships/${organizationMembershipId}/reactivate`,
+      {},
+    );
+
+    return deserializeOrganizationMembership(data);
+  }
+
   async getInvitation(invitationId: string): Promise<Invitation> {
     const { data } = await this.workos.get<InvitationResponse>(
       `/user_management/invitations/${invitationId}`,


### PR DESCRIPTION
## Description
Add organization membership deactivate and reactivate API methods.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes (in progress)
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
