### PR TITLE
Pre-release deployments should use the version of the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm publish --tag ${{ github.event.release.tag_name }} --access=public
+          # Tags may come prefixed with "v" which we want to remove before putting
+          # it as the version of this deploy. E.g. this will turn "v7.5.0-beta" to "7.5.0-beta"
+          CLEAN_TAG=$(echo "${{ github.event.release.tag_name }}" | sed 's/[^0-9]//')
+          jq ".version=\"${CLEAN_TAG}\"" package.json > package.json.deploy
+          cp package.json.deploy package.json
+
+          echo "Deploying with package.json"
+          cat package.json
+
+          npm publish --tag next --access=public


### PR DESCRIPTION
## Description
npm doesn't let you publish multiple of the same version, but we also don't want to have to update package.json for every prerelease deploy we want to push. This change updates package.json to match the name of the tag triggering this beta deploy ensuring our versions are always unique.

I also reverted back to updating the `next` tag as that should always point to the latest pre-release build.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
