### PR TITLE
Add PKCE parameters to User Management authentication methods in Node SDK

### DIFF
--- a/src/user-management/__snapshots__/user-management.spec.ts.snap
+++ b/src/user-management/__snapshots__/user-management.spec.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`UserManagement getAuthorizationUrl with a code_challenge and code_challenge_method generates an authorize url 1`] = `"https://api.workos.com/user_management/authorize?client_id=proj_123&code_challenge=code_challenge_value&code_challenge_method=S256&provider=authkit&redirect_uri=example.com%2Fauth%2Fworkos%2Fcallback&response_type=code"`;
+
 exports[`UserManagement getAuthorizationUrl with a connectionId generates an authorize url with the connection 1`] = `"https://api.workos.com/user_management/authorize?client_id=proj_123&connection_id=connection_123&redirect_uri=example.com%2Fauth%2Fworkos%2Fcallback&response_type=code"`;
 
 exports[`UserManagement getAuthorizationUrl with a custom api hostname generates an authorize url with the custom api hostname 1`] = `"https://api.workos.dev/user_management/authorize?client_id=proj_123&organization_id=organization_123&redirect_uri=example.com%2Fauth%2Fworkos%2Fcallback&response_type=code"`;

--- a/src/user-management/interfaces/authenticate-with-code-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-code-options.interface.ts
@@ -5,6 +5,7 @@ import {
 
 export interface AuthenticateWithCodeOptions
   extends AuthenticateWithOptionsBase {
+  codeVerifier?: string;
   code: string;
   invitationToken?: string;
 }
@@ -16,6 +17,7 @@ export interface AuthenticateUserWithCodeCredentials {
 export interface SerializedAuthenticateWithCodeOptions
   extends SerializedAuthenticateWithOptionsBase {
   grant_type: 'authorization_code';
+  code_verifier?: string;
   code: string;
   invitation_token?: string;
 }

--- a/src/user-management/interfaces/authorization-url-options.interface.ts
+++ b/src/user-management/interfaces/authorization-url-options.interface.ts
@@ -1,5 +1,7 @@
 export interface AuthorizationURLOptions {
   clientId: string;
+  codeChallenge?: string;
+  codeChallengeMethod?: 'S256';
   connectionId?: string;
   organizationId?: string;
   domainHint?: string;

--- a/src/user-management/serializers/authenticate-with-code-options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-code-options.serializer.ts
@@ -11,6 +11,7 @@ export const serializeAuthenticateWithCodeOptions = (
   client_id: options.clientId,
   client_secret: options.clientSecret,
   code: options.code,
+  code_verifier: options.codeVerifier,
   invitation_token: options.invitationToken,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -170,6 +170,30 @@ describe('UserManagement', () => {
       });
     });
 
+    it('sends a token authentication request when including the code_verifier', async () => {
+      fetchOnce({ user: userFixture });
+      const resp = await workos.userManagement.authenticateWithCode({
+        clientId: 'proj_whatever',
+        code: 'or this',
+        codeVerifier: 'code_verifier_value',
+      });
+
+      expect(fetchURL()).toContain('/user_management/authenticate');
+      expect(fetchBody()).toEqual({
+        client_id: 'proj_whatever',
+        client_secret: 'sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU',
+        code: 'or this',
+        code_verifier: 'code_verifier_value',
+        grant_type: 'authorization_code',
+      });
+
+      expect(resp).toMatchObject({
+        user: {
+          email: 'test01@example.com',
+        },
+      });
+    });
+
     it('deserializes authentication_method', async () => {
       fetchOnce({
         user: userFixture,
@@ -1006,6 +1030,22 @@ describe('UserManagement', () => {
           clientId: 'proj_123',
           redirectUri: 'example.com/auth/workos/callback',
           screenHint: 'sign-up',
+        });
+
+        expect(url).toMatchSnapshot();
+      });
+    });
+
+    describe('with a code_challenge and code_challenge_method', () => {
+      it('generates an authorize url', () => {
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        const url = workos.userManagement.getAuthorizationUrl({
+          provider: 'authkit',
+          clientId: 'proj_123',
+          redirectUri: 'example.com/auth/workos/callback',
+          codeChallenge: 'code_challenge_value',
+          codeChallengeMethod: 'S256',
         });
 
         expect(url).toMatchSnapshot();

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -627,6 +627,8 @@ export class UserManagement {
 
   getAuthorizationUrl({
     connectionId,
+    codeChallenge,
+    codeChallengeMethod,
     clientId,
     domainHint,
     loginHint,
@@ -650,6 +652,8 @@ export class UserManagement {
 
     const query = toQueryString({
       connection_id: connectionId,
+      code_challenge: codeChallenge,
+      code_challenge_method: codeChallengeMethod,
       organization_id: organizationId,
       domain_hint: domainHint,
       login_hint: loginHint,


### PR DESCRIPTION
## Description
Add PKCE parameters to User Management authentication methods in Node SDK

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
