### PR TITLE
Mark `allow_profiles_outside_organization` as deprecated

### DIFF
--- a/src/organizations/interfaces/create-organization-options.interface.ts
+++ b/src/organizations/interfaces/create-organization-options.interface.ts
@@ -6,7 +6,7 @@ export interface CreateOrganizationOptions {
   domainData?: DomainData[];
 
   /**
-   * @deprecated Contact support@workos.com to enable the replacement for this setting.
+   * @deprecated If you need to allow sign-ins from any email domain, contact support@workos.com.
    */
   allowProfilesOutsideOrganization?: boolean;
   /**
@@ -20,7 +20,7 @@ export interface SerializedCreateOrganizationOptions {
   domain_data?: DomainData[];
 
   /**
-   * @deprecated Contact support@workos.com to enable the replacement for this setting.
+   * @deprecated If you need to allow sign-ins from any email domain, contact support@workos.com.
    */
   allow_profiles_outside_organization?: boolean;
   /**

--- a/src/organizations/interfaces/create-organization-options.interface.ts
+++ b/src/organizations/interfaces/create-organization-options.interface.ts
@@ -6,8 +6,8 @@ export interface CreateOrganizationOptions {
   domainData?: DomainData[];
 
   /**
-  * @deprecated Contact support@workos.com to enable the replacement for this setting.
-  */
+   * @deprecated Contact support@workos.com to enable the replacement for this setting.
+   */
   allowProfilesOutsideOrganization?: boolean;
   /**
    * @deprecated Use `domain_data` instead.
@@ -20,8 +20,8 @@ export interface SerializedCreateOrganizationOptions {
   domain_data?: DomainData[];
 
   /**
-  * @deprecated Contact support@workos.com to enable the replacement for this setting.
-  */
+   * @deprecated Contact support@workos.com to enable the replacement for this setting.
+   */
   allow_profiles_outside_organization?: boolean;
   /**
    * @deprecated Use `domain_data` instead.

--- a/src/organizations/interfaces/create-organization-options.interface.ts
+++ b/src/organizations/interfaces/create-organization-options.interface.ts
@@ -3,8 +3,12 @@ import { DomainData } from './domain-data.interface';
 
 export interface CreateOrganizationOptions {
   name: string;
-  allowProfilesOutsideOrganization?: boolean;
   domainData?: DomainData[];
+
+  /**
+  * @deprecated Contact support@workos.com to enable the replacement for this setting.
+  */
+  allowProfilesOutsideOrganization?: boolean;
   /**
    * @deprecated Use `domain_data` instead.
    */
@@ -13,8 +17,12 @@ export interface CreateOrganizationOptions {
 
 export interface SerializedCreateOrganizationOptions {
   name: string;
-  allow_profiles_outside_organization?: boolean;
   domain_data?: DomainData[];
+
+  /**
+  * @deprecated Contact support@workos.com to enable the replacement for this setting.
+  */
+  allow_profiles_outside_organization?: boolean;
   /**
    * @deprecated Use `domain_data` instead.
    */

--- a/src/organizations/interfaces/update-organization-options.interface.ts
+++ b/src/organizations/interfaces/update-organization-options.interface.ts
@@ -6,7 +6,7 @@ export interface UpdateOrganizationOptions {
   domainData?: DomainData[];
 
   /**
-   * @deprecated Contact support@workos.com to enable the replacement for this setting.
+   * @deprecated If you need to allow sign-ins from any email domain, contact support@workos.com.
    */
   allowProfilesOutsideOrganization?: boolean;
   /**
@@ -20,7 +20,7 @@ export interface SerializedUpdateOrganizationOptions {
   domain_data?: DomainData[];
 
   /**
-   * @deprecated Contact support@workos.com to enable the replacement for this setting.
+   * @deprecated If you need to allow sign-ins from any email domain, contact support@workos.com.
    */
   allow_profiles_outside_organization?: boolean;
   /**

--- a/src/organizations/interfaces/update-organization-options.interface.ts
+++ b/src/organizations/interfaces/update-organization-options.interface.ts
@@ -3,8 +3,12 @@ import { DomainData } from './domain-data.interface';
 export interface UpdateOrganizationOptions {
   organization: string;
   name: string;
-  allowProfilesOutsideOrganization?: boolean;
   domainData?: DomainData[];
+
+  /**
+  * @deprecated Contact support@workos.com to enable the replacement for this setting.
+  */
+  allowProfilesOutsideOrganization?: boolean;
   /**
    * @deprecated Use `domain_data` instead.
    */
@@ -13,8 +17,12 @@ export interface UpdateOrganizationOptions {
 
 export interface SerializedUpdateOrganizationOptions {
   name: string;
-  allow_profiles_outside_organization?: boolean;
   domain_data?: DomainData[];
+
+  /**
+  * @deprecated Contact support@workos.com to enable the replacement for this setting.
+  */
+  allow_profiles_outside_organization?: boolean;
   /**
    * @deprecated Use `domain_data` instead.
    */

--- a/src/organizations/interfaces/update-organization-options.interface.ts
+++ b/src/organizations/interfaces/update-organization-options.interface.ts
@@ -6,8 +6,8 @@ export interface UpdateOrganizationOptions {
   domainData?: DomainData[];
 
   /**
-  * @deprecated Contact support@workos.com to enable the replacement for this setting.
-  */
+   * @deprecated Contact support@workos.com to enable the replacement for this setting.
+   */
   allowProfilesOutsideOrganization?: boolean;
   /**
    * @deprecated Use `domain_data` instead.
@@ -20,8 +20,8 @@ export interface SerializedUpdateOrganizationOptions {
   domain_data?: DomainData[];
 
   /**
-  * @deprecated Contact support@workos.com to enable the replacement for this setting.
-  */
+   * @deprecated Contact support@workos.com to enable the replacement for this setting.
+   */
   allow_profiles_outside_organization?: boolean;
   /**
    * @deprecated Use `domain_data` instead.


### PR DESCRIPTION
## Description

Marks `allow_profiles_outside_organization` as now being deprecated.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
