### PR TITLE
fix(package): add default exports for non-ESM projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,12 @@
   "exports": {
     "types": "./lib/index.d.ts",
     "worker": {
-      "import": "./lib/index.worker.js"
+      "import": "./lib/index.worker.js",
+      "default": "./lib/index.worker.js"
     },
     "default": {
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "default": "./lib/index.js"
     }
   }
 }


### PR DESCRIPTION
## Description

It appears that the latest version of the `@workos-inc/node` package (7.11.2) has [introduced](https://github.com/workos/workos-node/pull/1062) some [changes](https://github.com/workos/workos-node/commit/e5292bff1380dc71b25e0a4ce585036737a5670b) that are causing the following error:

```
No "exports" main defined in /Users/user/Projects/app/node_modules/@workos-inc/node/package.json Error: No "exports" main defined in /Users/user/Projects/app/node_modules/@workos-inc/node/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:304:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:594:13)
    at resolveExports (node:internal/modules/cjs/loader:592:36)
    at Function.Module._findPath (node:internal/modules/cjs/loader:669:31)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1131:27)
    at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue [as _resolveFilename] (/Users/user/Projects/app/node_modules/@cspotcode/source-map-support/source-map-support.js:811:30)
    at Function.Module._load (node:internal/modules/cjs/loader:986:27)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/Users/user/Projects/app/src/services/auth/auth.service.ts:2:1) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```

In order to fix it, there are three options:
1. Affected users can switch their node project into ESM (by adding "type": "module" to the root package.json
2. Use node@22+ which added support for require(esm) packages ([source](https://nodejs.org/en/blog/announcements/v22-release-announce#support-requireing-synchronous-esm-graphs))
3. Merge this PR

1 and 2 mean `@workos-inc/node` is introducing breaking change, while 3rd option will make it work for all the users without breaking changes.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
