### PR TITLE
Fix `NodeHttpClient` handling of `URLSearchParam` request bodies 

### DIFF
--- a/src/common/net/node-client.ts
+++ b/src/common/net/node-client.ts
@@ -40,6 +40,18 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
     return 'node';
   }
 
+  static override getBody(entity: unknown): string | null {
+    if (entity === null || entity === undefined) {
+      return null;
+    }
+
+    if (entity instanceof URLSearchParams) {
+      return entity.toString();
+    }
+
+    return JSON.stringify(entity);
+  }
+
   async get(
     path: string,
     options: RequestOptions,
@@ -67,7 +79,7 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
     return await this.nodeRequest(
       resourceURL,
       'POST',
-      HttpClient.getBody(entity),
+      NodeHttpClient.getBody(entity),
       {
         ...HttpClient.getContentTypeHeader(entity),
         ...options.headers,
@@ -89,7 +101,7 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
     return await this.nodeRequest(
       resourceURL,
       'PUT',
-      HttpClient.getBody(entity),
+      NodeHttpClient.getBody(entity),
       {
         ...HttpClient.getContentTypeHeader(entity),
         ...options.headers,
@@ -113,7 +125,7 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
   private async nodeRequest(
     url: string,
     method: string,
-    body?: any,
+    body: string | null,
     headers?: RequestHeaders,
   ): Promise<HttpClientResponseInterface> {
     return new Promise<HttpClientResponseInterface>((resolve, reject) => {


### PR DESCRIPTION
## Description

Previously the client was passing the body directly down to the low level `write` and `byteLength` calls, which failed in cases where the body wasn't already serialized as a `string` or form of buffer.

This was not noticed on newer versions of Node since they include a global `fetch`, resulting in the SDK preferring the `FetchHttpClient`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
