### PR TITLE
Update `grant_type=refresh_token` types

### DIFF
--- a/src/user-management/interfaces/authentication-response.interface.ts
+++ b/src/user-management/interfaces/authentication-response.interface.ts
@@ -26,13 +26,3 @@ export interface AuthenticationResponseResponse {
   impersonator?: ImpersonatorResponse;
   authentication_method?: AuthenticationMethod;
 }
-
-export interface RefreshAuthenticationResponse {
-  accessToken: string;
-  refreshToken: string;
-}
-
-export interface RefreshAuthenticationResponseResponse {
-  access_token: string;
-  refresh_token: string;
-}

--- a/src/user-management/serializers/authentication-response.serializer.ts
+++ b/src/user-management/serializers/authentication-response.serializer.ts
@@ -1,8 +1,6 @@
 import {
   AuthenticationResponse,
   AuthenticationResponseResponse,
-  RefreshAuthenticationResponse,
-  RefreshAuthenticationResponseResponse,
 } from '../interfaces';
 import { deserializeUser } from './user.serializer';
 
@@ -26,19 +24,6 @@ export const deserializeAuthenticationResponse = (
     refreshToken: refresh_token,
     impersonator,
     authenticationMethod: authentication_method,
-    ...rest,
-  };
-};
-
-export const deserializeRefreshAuthenticationResponse = (
-  refreshAuthenticationResponse: RefreshAuthenticationResponseResponse,
-): RefreshAuthenticationResponse => {
-  const { access_token, refresh_token, ...rest } =
-    refreshAuthenticationResponse;
-
-  return {
-    accessToken: access_token,
-    refreshToken: refresh_token,
     ...rest,
   };
 };

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -244,6 +244,7 @@ describe('UserManagement', () => {
   describe('authenticateWithRefreshToken', () => {
     it('sends a refresh_token authentication request', async () => {
       fetchOnce({
+        user: userFixture,
         access_token: 'access_token',
         refresh_token: 'refreshToken2',
       });

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -30,8 +30,6 @@ import {
   VerifyEmailOptions,
   AuthenticateWithRefreshTokenOptions,
   SerializedAuthenticateWithRefreshTokenOptions,
-  RefreshAuthenticationResponseResponse,
-  RefreshAuthenticationResponse,
   MagicAuth,
   MagicAuthResponse,
   CreateMagicAuthOptions,
@@ -57,7 +55,6 @@ import {
   serializeCreateUserOptions,
   serializeSendMagicAuthCodeOptions,
   serializeUpdateUserOptions,
-  deserializeRefreshAuthenticationResponse,
   serializeAuthenticateWithRefreshTokenOptions,
   serializeCreateMagicAuthOptions,
   deserializeMagicAuth,
@@ -229,9 +226,9 @@ export class UserManagement {
 
   async authenticateWithRefreshToken(
     payload: AuthenticateWithRefreshTokenOptions,
-  ): Promise<RefreshAuthenticationResponse> {
+  ): Promise<AuthenticationResponse> {
     const { data } = await this.workos.post<
-      RefreshAuthenticationResponseResponse,
+      AuthenticationResponseResponse,
       SerializedAuthenticateWithRefreshTokenOptions
     >(
       '/user_management/authenticate',
@@ -241,7 +238,7 @@ export class UserManagement {
       }),
     );
 
-    return deserializeRefreshAuthenticationResponse(data);
+    return deserializeAuthenticationResponse(data);
   }
 
   async authenticateWithTotp(


### PR DESCRIPTION
## Description

The refresh_token response used to be more limited, but that is no longer the case.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
