### PR TITLE
Remove `dsync.deactivated` event

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -175,11 +175,17 @@ export interface DsyncActivatedEventResponse extends EventResponseBase {
   data: EventDirectoryResponse;
 }
 
+/**
+ * @deprecated Use dsync.deleted only. Will be removed in a future major version.
+ */
 export interface DsyncDeactivatedEvent extends EventBase {
   event: 'dsync.deactivated';
   data: EventDirectory;
 }
 
+/**
+ * @deprecated Use dsync.deleted only. Will be removed in a future major version.
+ */
 export interface DsyncDeactivatedEventResponse extends EventResponseBase {
   event: 'dsync.deactivated';
   data: EventDirectoryResponse;

--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -175,22 +175,6 @@ export interface DsyncActivatedEventResponse extends EventResponseBase {
   data: EventDirectoryResponse;
 }
 
-/**
- * @deprecated Use dsync.deleted only. Will be removed in a future major version.
- */
-export interface DsyncDeactivatedEvent extends EventBase {
-  event: 'dsync.deactivated';
-  data: EventDirectory;
-}
-
-/**
- * @deprecated Use dsync.deleted only. Will be removed in a future major version.
- */
-export interface DsyncDeactivatedEventResponse extends EventResponseBase {
-  event: 'dsync.deactivated';
-  data: EventDirectoryResponse;
-}
-
 export interface DsyncDeletedEvent extends EventBase {
   event: 'dsync.deleted';
   data: Omit<EventDirectory, 'domains' | 'externalKey'>;
@@ -507,7 +491,6 @@ export type Event =
   | ConnectionDeactivatedEvent
   | ConnectionDeletedEvent
   | DsyncActivatedEvent
-  | DsyncDeactivatedEvent
   | DsyncDeletedEvent
   | DsyncGroupCreatedEvent
   | DsyncGroupUpdatedEvent
@@ -549,7 +532,6 @@ export type EventResponse =
   | ConnectionDeactivatedEventResponse
   | ConnectionDeletedEventResponse
   | DsyncActivatedEventResponse
-  | DsyncDeactivatedEventResponse
   | DsyncDeletedEventResponse
   | DsyncGroupCreatedEventResponse
   | DsyncGroupUpdatedEventResponse

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -50,7 +50,6 @@ export const deserializeEvent = (event: EventResponse): Event => {
         data: deserializeConnection(event.data),
       };
     case 'dsync.activated':
-    case 'dsync.deactivated':
       return {
         ...eventBase,
         event: event.event,


### PR DESCRIPTION
## Description

This event is [never emitted](https://work-os.slack.com/archives/C07CZA4UJ81/p1721849550636049) so we are officially deprecating. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates. 

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

No this was removed from the docs [in this PR](https://github.com/workos/workos/pull/18924) and removed from the dashboard [in this PR](https://github.com/workos/workos/pull/29101).
