### PR TITLE
Add test for worker environment

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,8 +6,11 @@ module.exports = {
   testEnvironment: 'node',
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   roots: ['<rootDir>/src'],
-  setupFiles: ['./setup-jest.ts'],
+  setupFilesAfterEnv: ['./setup-jest.ts'],
   transform: {
     '^.+\\.ts?$': 'ts-jest',
+  },
+  moduleNameMapper: {
+    '^jose': require.resolve('jose'),
   },
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:worker": "jest src/worker.spec.ts",
     "prettier": "prettier \"src/**/*.{js,ts,tsx}\" --check",
     "format": "prettier \"src/**/*.{js,ts,tsx}\" --write",
     "prepublishOnly": "yarn run build"
@@ -47,6 +48,7 @@
     "@types/node": "14.18.54",
     "@types/pluralize": "0.0.30",
     "jest": "29.6.2",
+    "jest-environment-miniflare": "^2.14.2",
     "jest-fetch-mock": "^3.0.3",
     "prettier": "2.8.8",
     "supertest": "6.3.3",

--- a/src/worker.spec.ts
+++ b/src/worker.spec.ts
@@ -5,7 +5,5 @@
 import { WorkOS } from './index.worker';
 
 test('WorkOS is initialized without errors', () => {
-  expect(() => {
-    new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
-  }).not.toThrow();
+  expect(() => new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU')).not.toThrow();
 });

--- a/src/worker.spec.ts
+++ b/src/worker.spec.ts
@@ -1,0 +1,11 @@
+/**
+ * @jest-environment miniflare
+ */
+
+import { WorkOS } from './index.worker';
+
+test('WorkOS is initialized without errors', () => {
+  expect(() => {
+    new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+  }).not.toThrow();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "declaration": true,
     "outDir": "lib",
     "strict": true,
-    "lib": ["dom", "es2019"]
+    "lib": ["dom", "es2019"],
+    "types": ["jest", "jest-environment-miniflare/globals"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Description
Adds a test in Miniflare, Cloudflare's dev environment for workers. Idea is that if the test runs and passes then the SDK should work in woeker environments.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
