### PR TITLE
Add `organizationId` parameter to `AuthenticateWithRefreshTokenOptions`

### DIFF
--- a/src/user-management/interfaces/authenticate-with-refresh-token-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-refresh-token-options.interface.ts
@@ -6,6 +6,7 @@ import {
 export interface AuthenticateWithRefreshTokenOptions
   extends AuthenticateWithOptionsBase {
   refreshToken: string;
+  organizationId?: string;
 }
 
 export interface AuthenticateUserWithRefreshTokenCredentials {
@@ -16,4 +17,5 @@ export interface SerializedAuthenticateWithRefreshTokenOptions
   extends SerializedAuthenticateWithOptionsBase {
   grant_type: 'refresh_token';
   refresh_token: string;
+  organization_id: string | undefined;
 }

--- a/src/user-management/serializers/authenticate-with-refresh-token.options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-refresh-token.options.serializer.ts
@@ -12,6 +12,7 @@ export const serializeAuthenticateWithRefreshTokenOptions = (
   client_id: options.clientId,
   client_secret: options.clientSecret,
   refresh_token: options.refreshToken,
+  organization_id: options.organizationId,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
 });


### PR DESCRIPTION
## Description

Adds the new `organizationId` parameter to the `AuthenticateWithRefreshTokenOptions`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
