### PR TITLE
Use typeof to safely check Node process on workers

### DIFF
--- a/src/workos.ts
+++ b/src/workos.ts
@@ -62,7 +62,10 @@ export class WorkOS {
   constructor(readonly key?: string, readonly options: WorkOSOptions = {}) {
     if (!key) {
       // process might be undefined in some environments
-      this.key = process?.env.WORKOS_API_KEY;
+      this.key =
+        typeof process !== 'undefined'
+          ? process?.env.WORKOS_API_KEY
+          : undefined;
 
       if (!this.key) {
         throw new NoApiKeyProvidedException();
@@ -73,7 +76,10 @@ export class WorkOS {
       this.options.https = true;
     }
 
-    this.clientId = this.options.clientId ?? process?.env.WORKOS_CLIENT_ID;
+    this.clientId = this.options.clientId;
+    if (!this.clientId && typeof process !== 'undefined') {
+      this.clientId = process?.env.WORKOS_CLIENT_ID;
+    }
 
     const protocol: string = this.options.https ? 'https' : 'http';
     const apiHostname: string = this.options.apiHostname || DEFAULT_HOSTNAME;


### PR DESCRIPTION
## Description
Use typeof to safely check Node process on workers.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
