### PR TITLE
Add getLogoutUrlFromSessionCookie helper method

### DIFF
--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -1905,7 +1905,9 @@ describe('UserManagement', () => {
           cookiePassword: 'secret',
         }),
       ).rejects.toThrowError(
-        new Error('Failed to authenticate session: no_session_cookie_provided'),
+        new Error(
+          'Failed to extract session ID for logout URL: no_session_cookie_provided',
+        ),
       );
     });
 
@@ -1916,7 +1918,9 @@ describe('UserManagement', () => {
           cookiePassword: 'secret',
         }),
       ).rejects.toThrowError(
-        new Error('Failed to authenticate session: invalid_session_cookie'),
+        new Error(
+          'Failed to extract session ID for logout URL: invalid_session_cookie',
+        ),
       );
     });
 
@@ -1941,7 +1945,9 @@ describe('UserManagement', () => {
           cookiePassword: 'secretpasswordwhichisalsolongbutnottherightone',
         }),
       ).rejects.toThrowError(
-        new Error('Failed to authenticate session: invalid_session_cookie'),
+        new Error(
+          'Failed to extract session ID for logout URL: invalid_session_cookie',
+        ),
       );
     });
 
@@ -1970,7 +1976,7 @@ describe('UserManagement', () => {
           cookiePassword,
         }),
       ).rejects.toThrowError(
-        new Error('Failed to authenticate session: invalid_jwt'),
+        new Error('Failed to extract session ID for logout URL: invalid_jwt'),
       );
     });
 

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -1860,6 +1860,151 @@ describe('UserManagement', () => {
     });
   });
 
+  describe('getLogoutUrlFromSessionCookie', () => {
+    beforeEach(() => {
+      // Mock createRemoteJWKSet
+      jest
+        .spyOn(jose, 'createRemoteJWKSet')
+        .mockImplementation(
+          (_url: URL, _options?: jose.RemoteJWKSetOptions) => {
+            // This function simulates the token verification process
+            const verifyFunction = (
+              _protectedHeader: jose.JWSHeaderParameters,
+              _token: jose.FlattenedJWSInput,
+            ): Promise<jose.KeyLike> => {
+              return Promise.resolve({
+                type: 'public',
+              });
+            };
+
+            // Return an object that includes the verify function and the additional expected properties
+            return {
+              __call__: verifyFunction,
+              coolingDown: false,
+              fresh: false,
+              reloading: false,
+              reload: jest.fn().mockResolvedValue(undefined),
+              jwks: () => undefined,
+            } as unknown as ReturnType<typeof jose.createRemoteJWKSet>;
+          },
+        );
+    });
+
+    it('throws an error when the cookie password is undefined', async () => {
+      await expect(
+        workos.userManagement.getLogoutUrlFromSessionCookie({
+          sessionData: 'session_cookie',
+        }),
+      ).rejects.toThrow('Cookie password is required');
+    });
+
+    it('returns authenticated = false when the session cookie is empty', async () => {
+      await expect(
+        workos.userManagement.getLogoutUrlFromSessionCookie({
+          sessionData: '',
+          cookiePassword: 'secret',
+        }),
+      ).rejects.toThrowError(
+        new Error('Failed to authenticate session: no_session_cookie_provided'),
+      );
+    });
+
+    it('returns authenticated = false when session cookie is invalid', async () => {
+      await expect(
+        workos.userManagement.getLogoutUrlFromSessionCookie({
+          sessionData: 'thisisacookie',
+          cookiePassword: 'secret',
+        }),
+      ).rejects.toThrowError(
+        new Error('Failed to authenticate session: invalid_session_cookie'),
+      );
+    });
+
+    it('returns authenticated = false when session cookie cannot be unsealed', async () => {
+      const cookiePassword = 'alongcookiesecretmadefortestingsessions';
+      const sessionData = await sealData(
+        {
+          accessToken: 'abc123',
+          refreshToken: 'def456',
+          user: {
+            object: 'user',
+            id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+            email: 'test@example.com',
+          },
+        },
+        { password: cookiePassword },
+      );
+
+      await expect(
+        workos.userManagement.getLogoutUrlFromSessionCookie({
+          sessionData,
+          cookiePassword: 'secretpasswordwhichisalsolongbutnottherightone',
+        }),
+      ).rejects.toThrowError(
+        new Error('Failed to authenticate session: invalid_session_cookie'),
+      );
+    });
+
+    it('returns authenticated = false when the JWT is invalid', async () => {
+      jest.spyOn(jose, 'jwtVerify').mockImplementationOnce(() => {
+        throw new Error('Invalid JWT');
+      });
+
+      const cookiePassword = 'alongcookiesecretmadefortestingsessions';
+      const sessionData = await sealData(
+        {
+          accessToken: 'abc123',
+          refreshToken: 'def456',
+          user: {
+            object: 'user',
+            id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+            email: 'test@example.com',
+          },
+        },
+        { password: cookiePassword },
+      );
+
+      await expect(
+        workos.userManagement.getLogoutUrlFromSessionCookie({
+          sessionData,
+          cookiePassword,
+        }),
+      ).rejects.toThrowError(
+        new Error('Failed to authenticate session: invalid_jwt'),
+      );
+    });
+
+    it('returns the logout URL for the session when provided a valid JWT', async () => {
+      jest
+        .spyOn(jose, 'jwtVerify')
+        .mockResolvedValue({} as jose.JWTVerifyResult & jose.ResolvedKey);
+
+      const cookiePassword = 'alongcookiesecretmadefortestingsessions';
+      const sessionData = await sealData(
+        {
+          accessToken:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+          refreshToken: 'def456',
+          user: {
+            object: 'user',
+            id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+            email: 'test@example.com',
+          },
+        },
+        { password: cookiePassword },
+      );
+
+      await expect(
+        workos.userManagement.getLogoutUrlFromSessionCookie({
+          sessionData,
+          cookiePassword,
+        }),
+      ).resolves.toEqual(
+        `https://api.workos.test/user_management/sessions/logout?session_id=session_123`,
+      );
+    });
+  });
+
   describe('getJwksUrl', () => {
     it('returns the jwks url', () => {
       const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -961,6 +961,23 @@ export class UserManagement {
     return `${this.workos.baseURL}/user_management/sessions/logout?session_id=${sessionId}`;
   }
 
+  async getLogoutUrlFromSessionCookie({
+    sessionData,
+    cookiePassword = process.env.WORKOS_COOKIE_PASSWORD,
+  }: SessionHandlerOptions): Promise<string> {
+    const authenticationResponse = await this.authenticateWithSessionCookie({
+      sessionData,
+      cookiePassword,
+    });
+
+    if (!authenticationResponse.authenticated) {
+      const { reason } = authenticationResponse;
+      throw new Error(`Failed to authenticate session: ${reason}`);
+    }
+
+    return `${this.workos.baseURL}/user_management/sessions/logout?session_id=${authenticationResponse.sessionId}`;
+  }
+
   getJwksUrl(clientId: string): string {
     if (!clientId) {
       throw TypeError('clientId must be a valid clientId');

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -961,6 +961,12 @@ export class UserManagement {
     return `${this.workos.baseURL}/user_management/sessions/logout?session_id=${sessionId}`;
   }
 
+  /**
+   * getLogoutUrlFromSessionCookie takes in session cookie data, unseals the cookie, decodes the JWT claims,
+   * and uses the session ID to generate the logout URL.
+   *
+   * Use this over `getLogoutUrl` if you'd like to the SDK to handle session cookies for you.
+   */
   async getLogoutUrlFromSessionCookie({
     sessionData,
     cookiePassword = process.env.WORKOS_COOKIE_PASSWORD,
@@ -972,10 +978,10 @@ export class UserManagement {
 
     if (!authenticationResponse.authenticated) {
       const { reason } = authenticationResponse;
-      throw new Error(`Failed to authenticate session: ${reason}`);
+      throw new Error(`Failed to extract session ID for logout URL: ${reason}`);
     }
 
-    return `${this.workos.baseURL}/user_management/sessions/logout?session_id=${authenticationResponse.sessionId}`;
+    return this.getLogoutUrl({ sessionId: authenticationResponse.sessionId });
   }
 
   getJwksUrl(clientId: string): string {


### PR DESCRIPTION
## Description
Add getLogoutUrlFromSessionCookie helper method.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
