### PR TITLE
Update `refreshAndSealSessionData` to accept `organizationId`

### DIFF
--- a/src/user-management/interfaces/authenticate-with-session-cookie.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-session-cookie.interface.ts
@@ -1,5 +1,10 @@
 import { AuthenticationResponse } from './authentication-response.interface';
 
+export interface AuthenticateWithSessionCookieOptions {
+  sessionData: string;
+  cookiePassword?: string;
+}
+
 export interface AccessToken {
   sid: string;
   org_id?: string;

--- a/src/user-management/interfaces/refresh-and-seal-session-data.interface.ts
+++ b/src/user-management/interfaces/refresh-and-seal-session-data.interface.ts
@@ -5,8 +5,14 @@ export enum RefreshAndSealSessionDataFailureReason {
   INVALID_SESSION_COOKE = 'invalid_session_cookie',
   INVALID_SESSION_COOKIE = 'invalid_session_cookie',
   NO_SESSION_COOKIE_PROVIDED = 'no_session_cookie_provided',
+
   // API OauthErrors for refresh tokens
   INVALID_GRANT = 'invalid_grant',
+  MFA_ENROLLMENT = 'mfa_enrollment',
+  SSO_REQUIRED = 'sso_required',
+  /**
+   * @deprecated To be removed in a future major version.
+   */
   ORGANIZATION_NOT_AUTHORIZED = 'organization_not_authorized',
 }
 

--- a/src/user-management/interfaces/session-handler-options.interface.ts
+++ b/src/user-management/interfaces/session-handler-options.interface.ts
@@ -1,4 +1,5 @@
 export interface SessionHandlerOptions {
   sessionData: string;
   cookiePassword?: string;
+  organizationId?: string;
 }

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -59,6 +59,7 @@ import {
   AccessToken,
   AuthenticateWithSessionCookieFailedResponse,
   AuthenticateWithSessionCookieFailureReason,
+  AuthenticateWithSessionCookieOptions,
   AuthenticateWithSessionCookieSuccessResponse,
   SessionCookieData,
 } from './interfaces/authenticate-with-session-cookie.interface';
@@ -360,7 +361,7 @@ export class UserManagement {
   async authenticateWithSessionCookie({
     sessionData,
     cookiePassword = process.env.WORKOS_COOKIE_PASSWORD,
-  }: SessionHandlerOptions): Promise<
+  }: AuthenticateWithSessionCookieOptions): Promise<
     | AuthenticateWithSessionCookieSuccessResponse
     | AuthenticateWithSessionCookieFailedResponse
   > {

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -484,7 +484,8 @@ export class UserManagement {
         // TODO: Add additional known errors and remove re-throw
         (error.error === RefreshAndSealSessionDataFailureReason.INVALID_GRANT ||
           error.error ===
-            RefreshAndSealSessionDataFailureReason.ORGANIZATION_NOT_AUTHORIZED)
+            RefreshAndSealSessionDataFailureReason.MFA_ENROLLMENT ||
+          error.error === RefreshAndSealSessionDataFailureReason.SSO_REQUIRED)
       ) {
         return {
           authenticated: false,

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -434,6 +434,7 @@ export class UserManagement {
 
   async refreshAndSealSessionData({
     sessionData,
+    organizationId,
     cookiePassword = process.env.WORKOS_COOKIE_PASSWORD,
   }: SessionHandlerOptions): Promise<RefreshAndSealSessionDataResponse> {
     if (!cookiePassword) {
@@ -463,10 +464,15 @@ export class UserManagement {
       };
     }
 
+    const { org_id: organizationIdFromAccessToken } = decodeJwt<AccessToken>(
+      session.accessToken,
+    );
+
     try {
       const { sealedSession } = await this.authenticateWithRefreshToken({
         clientId: this.workos.clientId as string,
         refreshToken: session.refreshToken,
+        organizationId: organizationId ?? organizationIdFromAccessToken,
         session: { sealSession: true, cookiePassword },
       });
 


### PR DESCRIPTION
## Description

This matches the `authenticateWithRefreshToken` method which also accepts an `organizationId` to allow "switching".

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
