### PR TITLE
Add export types for CFW and Next.js 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,11 @@
   },
   "exports": {
     "types": "./lib/index.d.ts",
-    "worker": {
+    "workerd": {
+      "import": "./lib/index.worker.js",
+      "default": "./lib/index.worker.js"
+    },
+    "edge-light": {
       "import": "./lib/index.worker.js",
       "default": "./lib/index.worker.js"
     },


### PR DESCRIPTION
## Description
Fixes https://github.com/workos/workos-node/issues/1101

As per https://github.com/vercel/next.js/pull/66808, our imports weren't [correctly targeting](https://runtime-keys.proposal.wintercg.org/#workerd) Cloudflare Workers and Edge infrastructure. Now they are.


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
