### PR TITLE
Add certificate renewal intent for Admin Portal intents

### DIFF
--- a/src/portal/interfaces/generate-portal-link-intent.interface.ts
+++ b/src/portal/interfaces/generate-portal-link-intent.interface.ts
@@ -4,4 +4,5 @@ export enum GeneratePortalLinkIntent {
   DSync = 'dsync',
   LogStreams = 'log_streams',
   SSO = 'sso',
+  CertificateRenewal = 'certificate_renewal',
 }

--- a/src/portal/portal.spec.ts
+++ b/src/portal/portal.spec.ts
@@ -116,6 +116,50 @@ describe('Portal', () => {
           );
         });
       });
+      describe('with the `certificate_renewal` intent', () => {
+        it('returns an Admin Portal link', async () => {
+          fetchOnce(generateLink, { status: 201 });
+
+          const { link } = await workos.portal.generateLink({
+            intent: GeneratePortalLinkIntent.CertificateRenewal,
+            organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
+            returnUrl: 'https://www.example.com',
+          });
+
+          expect(fetchBody()).toEqual({
+            intent: GeneratePortalLinkIntent.CertificateRenewal,
+            organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
+            return_url: 'https://www.example.com',
+          });
+          expect(link).toEqual(
+            'https://id.workos.com/portal/launch?secret=secret',
+          );
+        });
+      });
+    });
+
+    describe('with an invalid organization', () => {
+      it('throws an error', async () => {
+        fetchOnce(generateLinkInvalid, {
+          status: 400,
+          headers: { 'X-Request-ID': 'a-request-id' },
+        });
+
+        await expect(
+          workos.portal.generateLink({
+            intent: GeneratePortalLinkIntent.SSO,
+            organization: 'bogus-id',
+            returnUrl: 'https://www.example.com',
+          }),
+        ).rejects.toThrowError(
+          'Could not find an organization with the id, bogus-id.',
+        );
+        expect(fetchBody()).toEqual({
+          intent: GeneratePortalLinkIntent.SSO,
+          organization: 'bogus-id',
+          return_url: 'https://www.example.com',
+        });
+      });
     });
 
     describe('with an invalid organization', () => {


### PR DESCRIPTION
## Description
Adding the certificate renewal intent as an option for link generation
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
