### PR TITLE
Rework session helpers

### DIFF
--- a/src/user-management/interfaces/authenticate-with-session-cookie.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-session-cookie.interface.ts
@@ -36,6 +36,6 @@ export type AuthenticateWithSessionCookieSuccessResponse = {
   organizationId?: string;
   role?: string;
   permissions?: string[];
-  user?: User;
+  user: User;
   impersonator?: Impersonator;
 };

--- a/src/user-management/interfaces/authenticate-with-session-cookie.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-session-cookie.interface.ts
@@ -1,4 +1,6 @@
 import { AuthenticationResponse } from './authentication-response.interface';
+import { Impersonator } from './impersonator.interface';
+import { User } from './user.interface';
 
 export interface AuthenticateWithSessionCookieOptions {
   sessionData: string;
@@ -34,4 +36,6 @@ export type AuthenticateWithSessionCookieSuccessResponse = {
   organizationId?: string;
   role?: string;
   permissions?: string[];
+  user?: User;
+  impersonator?: Impersonator;
 };

--- a/src/user-management/interfaces/refresh-and-seal-session-data.interface.ts
+++ b/src/user-management/interfaces/refresh-and-seal-session-data.interface.ts
@@ -18,6 +18,7 @@ export enum RefreshAndSealSessionDataFailureReason {
   ORGANIZATION_NOT_AUTHORIZED = 'organization_not_authorized',
 }
 
+// TODO: These should be renamed since it's possible to have an unsealed session
 type RefreshAndSealSessionDataFailedResponse = {
   authenticated: false;
   reason: RefreshAndSealSessionDataFailureReason;

--- a/src/user-management/interfaces/refresh-and-seal-session-data.interface.ts
+++ b/src/user-management/interfaces/refresh-and-seal-session-data.interface.ts
@@ -1,3 +1,5 @@
+import { AuthenticationResponse } from './authentication-response.interface';
+
 export enum RefreshAndSealSessionDataFailureReason {
   /**
    * @deprecated To be removed in a future major version.
@@ -23,7 +25,7 @@ type RefreshAndSealSessionDataFailedResponse = {
 
 type RefreshAndSealSessionDataSuccessResponse = {
   authenticated: true;
-  sealedSession: string;
+  session: string | AuthenticationResponse;
 };
 
 export type RefreshAndSealSessionDataResponse =

--- a/src/user-management/interfaces/refresh-and-seal-session-data.interface.ts
+++ b/src/user-management/interfaces/refresh-and-seal-session-data.interface.ts
@@ -26,7 +26,8 @@ type RefreshAndSealSessionDataFailedResponse = {
 
 type RefreshAndSealSessionDataSuccessResponse = {
   authenticated: true;
-  session: string | AuthenticationResponse;
+  session?: AuthenticationResponse;
+  sealedSession?: string;
 };
 
 export type RefreshAndSealSessionDataResponse =

--- a/src/user-management/session.spec.ts
+++ b/src/user-management/session.spec.ts
@@ -1,0 +1,299 @@
+import { WorkOS } from '../workos';
+import { Session } from './session';
+import * as jose from 'jose';
+import { sealData } from 'iron-session';
+import userFixture from './fixtures/user.json';
+import fetch from 'jest-fetch-mock';
+import { fetchOnce } from '../common/utils/test-utils';
+
+describe('Session', () => {
+  let workos: WorkOS;
+
+  beforeAll(() => {
+    workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
+      clientId: 'client_123',
+    });
+  });
+
+  beforeEach(() => fetch.resetMocks());
+
+  describe('constructor', () => {
+    it('throws an error if cookiePassword is not provided', () => {
+      expect(() => {
+        workos.userManagement.session('sessionData', '');
+      }).toThrow('cookiePassword is required');
+    });
+
+    it('creates a new Session instance', () => {
+      const session = workos.userManagement.session(
+        'sessionData',
+        'cookiePassword',
+      );
+
+      expect(session).toBeInstanceOf(Session);
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns a failed response if no sessionData is provided', async () => {
+      const session = workos.userManagement.session('', 'cookiePassword');
+      const response = await session.authenticate();
+
+      expect(response).toEqual({
+        authenticated: false,
+        reason: 'no_session_cookie_provided',
+      });
+    });
+
+    it('returns a failed response if no accessToken is found in the sessionData', async () => {
+      const session = workos.userManagement.session(
+        'sessionData',
+        'cookiePassword',
+      );
+      const response = await session.authenticate();
+
+      expect(response).toEqual({
+        authenticated: false,
+        reason: 'invalid_session_cookie',
+      });
+    });
+
+    it('returns a failed response if the accessToken is not a valid JWT', async () => {
+      jest.spyOn(jose, 'jwtVerify').mockImplementation(() => {
+        throw new Error('Invalid JWT');
+      });
+
+      const cookiePassword = 'alongcookiesecretmadefortestingsessions';
+
+      const sessionData = await sealData(
+        {
+          accessToken:
+            'ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9',
+          refreshToken: 'def456',
+          user: {
+            object: 'user',
+            id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+            email: 'test@example.com',
+          },
+        },
+        { password: cookiePassword },
+      );
+
+      const session = workos.userManagement.session(
+        sessionData,
+        cookiePassword,
+      );
+      const response = await session.authenticate();
+
+      expect(response).toEqual({
+        authenticated: false,
+        reason: 'invalid_jwt',
+      });
+    });
+
+    it('returns a successful response if the sessionData is valid', async () => {
+      jest
+        .spyOn(jose, 'jwtVerify')
+        .mockResolvedValue({} as jose.JWTVerifyResult & jose.ResolvedKey);
+
+      const cookiePassword = 'alongcookiesecretmadefortestingsessions';
+
+      const sessionData = await sealData(
+        {
+          accessToken:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+          refreshToken: 'def456',
+          impersonator: {
+            email: 'admin@example.com',
+            reason: 'test',
+          },
+          user: {
+            object: 'user',
+            id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+            email: 'test@example.com',
+          },
+        },
+        { password: cookiePassword },
+      );
+
+      const session = workos.userManagement.session(
+        sessionData,
+        cookiePassword,
+      );
+
+      await expect(session.authenticate()).resolves.toEqual({
+        authenticated: true,
+        impersonator: {
+          email: 'admin@example.com',
+          reason: 'test',
+        },
+        sessionId: 'session_123',
+        organizationId: 'org_123',
+        role: 'member',
+        permissions: ['posts:create', 'posts:delete'],
+        user: {
+          object: 'user',
+          id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+          email: 'test@example.com',
+        },
+      });
+    });
+  });
+
+  describe('refresh', () => {
+    it('throws an error if no sealed option is provided without a cookiePassword', async () => {
+      const session = workos.userManagement.session(
+        'sessionData',
+        'cookiePassword',
+      );
+
+      await expect(
+        session.refresh({ sealed: true, cookiePassword: '' }),
+      ).rejects.toThrow('Cookie password is required for sealed sessions');
+    });
+
+    it('returns a failed response if invalid session data is provided', async () => {
+      fetchOnce({ user: userFixture });
+
+      const session = workos.userManagement.session('', 'cookiePassword');
+
+      const response = await session.refresh({
+        sealed: true,
+        cookiePassword: 'cookiePassword',
+      });
+
+      expect(response).toEqual({
+        authenticated: false,
+        reason: 'invalid_session_cookie',
+      });
+    });
+
+    describe('when the session data is valid', () => {
+      describe('and sealed = true', () => {
+        it('returns a successful response with a sealed session', async () => {
+          fetchOnce({ user: userFixture });
+
+          const cookiePassword = 'alongcookiesecretmadefortestingsessions';
+
+          const sessionData = await sealData(
+            {
+              accessToken:
+                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+              refreshToken: 'def456',
+              impersonator: {
+                email: 'admin@example.com',
+                reason: 'test',
+              },
+              user: {
+                object: 'user',
+                id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+                email: 'test@example.com',
+              },
+            },
+            { password: cookiePassword },
+          );
+
+          const session = workos.userManagement.session(
+            sessionData,
+            cookiePassword,
+          );
+
+          const response = await session.refresh({
+            sealed: true,
+            cookiePassword,
+          });
+
+          expect(response).toEqual({
+            authenticated: true,
+            session: expect.any(String),
+          });
+        });
+      });
+
+      describe('and sealed = false', () => {
+        it('returns a successful response with an unsealed session', async () => {
+          fetchOnce({ user: userFixture });
+
+          const cookiePassword = 'alongcookiesecretmadefortestingsessions';
+
+          const sessionData = await sealData(
+            {
+              accessToken:
+                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+              refreshToken: 'def456',
+              user: {
+                object: 'user',
+                id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+                email: 'test01@example.com',
+              },
+            },
+            { password: cookiePassword },
+          );
+
+          const session = workos.userManagement.session(
+            sessionData,
+            cookiePassword,
+          );
+
+          const response = await session.refresh({
+            sealed: false,
+            cookiePassword,
+          });
+
+          expect(response).toEqual({
+            authenticated: true,
+            session: expect.objectContaining({
+              sealedSession: expect.any(String),
+              user: expect.objectContaining({
+                email: 'test01@example.com',
+              }),
+            }),
+          });
+        });
+      });
+    });
+  });
+
+  describe('getLogoutUrl', () => {
+    it('returns a logout URL for the user', async () => {
+      jest
+        .spyOn(jose, 'jwtVerify')
+        .mockResolvedValue({} as jose.JWTVerifyResult & jose.ResolvedKey);
+
+      const cookiePassword = 'alongcookiesecretmadefortestingsessions';
+
+      const sessionData = await sealData(
+        {
+          accessToken:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+          refreshToken: 'def456',
+          user: {
+            object: 'user',
+            id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+            email: 'test01@example.com',
+          },
+        },
+        { password: cookiePassword },
+      );
+
+      const session = workos.userManagement.session(
+        sessionData,
+        cookiePassword,
+      );
+
+      const url = await session.getLogoutUrl();
+
+      expect(url).toEqual(
+        'https://api.workos.com/user_management/sessions/logout?session_id=session_123',
+      );
+    });
+
+    it('returns an error if the session is invalid', async () => {
+      const session = workos.userManagement.session('', 'cookiePassword');
+
+      await expect(session.getLogoutUrl()).rejects.toThrow(
+        'Failed to extract session ID for logout URL: no_session_cookie_provided',
+      );
+    });
+  });
+});

--- a/src/user-management/session.spec.ts
+++ b/src/user-management/session.spec.ts
@@ -148,7 +148,7 @@ describe('Session', () => {
       );
 
       await expect(
-        session.refresh({ sealed: true, cookiePassword: '' }),
+        session.refresh({ sealSession: true, cookiePassword: '' }),
       ).rejects.toThrow('Cookie password is required for sealed sessions');
     });
 
@@ -158,7 +158,7 @@ describe('Session', () => {
       const session = workos.userManagement.session('', 'cookiePassword');
 
       const response = await session.refresh({
-        sealed: true,
+        sealSession: true,
         cookiePassword: 'cookiePassword',
       });
 
@@ -199,7 +199,7 @@ describe('Session', () => {
           );
 
           const response = await session.refresh({
-            sealed: true,
+            sealSession: true,
             cookiePassword,
           });
 
@@ -236,7 +236,7 @@ describe('Session', () => {
           );
 
           const response = await session.refresh({
-            sealed: false,
+            sealSession: false,
             cookiePassword,
           });
 

--- a/src/user-management/session.spec.ts
+++ b/src/user-management/session.spec.ts
@@ -147,9 +147,9 @@ describe('Session', () => {
         'cookiePassword',
       );
 
-      await expect(
-        session.refresh({ sealSession: true, cookiePassword: '' }),
-      ).rejects.toThrow('Cookie password is required for sealed sessions');
+      await expect(session.refresh({ cookiePassword: '' })).rejects.toThrow(
+        'Cookie password is required for sealed sessions',
+      );
     });
 
     it('returns a failed response if invalid session data is provided', async () => {
@@ -158,7 +158,6 @@ describe('Session', () => {
       const session = workos.userManagement.session('', 'cookiePassword');
 
       const response = await session.refresh({
-        sealSession: true,
         cookiePassword: 'cookiePassword',
       });
 
@@ -169,86 +168,52 @@ describe('Session', () => {
     });
 
     describe('when the session data is valid', () => {
-      describe('and sealed = true', () => {
-        it('returns a successful response with a sealed session', async () => {
-          fetchOnce({ user: userFixture });
+      it('returns a successful response with a sealed and unsealed session', async () => {
+        fetchOnce({ user: userFixture });
 
-          const cookiePassword = 'alongcookiesecretmadefortestingsessions';
+        const cookiePassword = 'alongcookiesecretmadefortestingsessions';
 
-          const sessionData = await sealData(
-            {
-              accessToken:
-                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
-              refreshToken: 'def456',
-              impersonator: {
-                email: 'admin@example.com',
-                reason: 'test',
-              },
-              user: {
-                object: 'user',
-                id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
-                email: 'test@example.com',
-              },
+        const sessionData = await sealData(
+          {
+            accessToken:
+              'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+            refreshToken: 'def456',
+            impersonator: {
+              email: 'admin@example.com',
+              reason: 'test',
             },
-            { password: cookiePassword },
-          );
+            user: {
+              object: 'user',
+              id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+              email: 'test@example.com',
+            },
+          },
+          { password: cookiePassword },
+        );
 
-          const session = workos.userManagement.session(
-            sessionData,
-            cookiePassword,
-          );
+        const session = workos.userManagement.session(
+          sessionData,
+          cookiePassword,
+        );
 
-          const response = await session.refresh({
-            sealSession: true,
-            cookiePassword,
-          });
-
-          expect(response).toEqual({
-            authenticated: true,
-            session: expect.any(String),
-          });
+        const response = await session.refresh({
+          cookiePassword,
         });
-      });
 
-      describe('and sealed = false', () => {
-        it('returns a successful response with an unsealed session', async () => {
-          fetchOnce({ user: userFixture });
-
-          const cookiePassword = 'alongcookiesecretmadefortestingsessions';
-
-          const sessionData = await sealData(
-            {
-              accessToken:
-                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
-              refreshToken: 'def456',
-              user: {
-                object: 'user',
-                id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
-                email: 'test01@example.com',
-              },
-            },
-            { password: cookiePassword },
-          );
-
-          const session = workos.userManagement.session(
-            sessionData,
-            cookiePassword,
-          );
-
-          const response = await session.refresh({
-            sealSession: false,
-            cookiePassword,
-          });
-
-          expect(response).toEqual({
-            authenticated: true,
-            session: expect.objectContaining({
-              sealedSession: expect.any(String),
-              user: expect.objectContaining({
-                email: 'test01@example.com',
-              }),
+        expect(response).toEqual({
+          authenticated: true,
+          accessToken: undefined,
+          authenticationMethod: undefined,
+          impersonator: undefined,
+          organizationId: undefined,
+          refreshToken: undefined,
+          sealedSession: expect.any(String),
+          session: expect.objectContaining({
+            sealedSession: expect.any(String),
+            user: expect.objectContaining({
+              email: 'test01@example.com',
             }),
-          });
+          }),
         });
       });
     });

--- a/src/user-management/session.spec.ts
+++ b/src/user-management/session.spec.ts
@@ -166,15 +166,22 @@ describe('Session', () => {
 
     describe('when the session data is valid', () => {
       it('returns a successful response with a sealed and unsealed session', async () => {
-        fetchOnce({ user: userFixture });
+        const accessToken =
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+        const refreshToken = 'def456';
+
+        fetchOnce({
+          user: userFixture,
+          accessToken,
+          refreshToken,
+        });
 
         const cookiePassword = 'alongcookiesecretmadefortestingsessions';
 
         const sessionData = await sealData(
           {
-            accessToken:
-              'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
-            refreshToken: 'def456',
+            accessToken,
+            refreshToken,
             impersonator: {
               email: 'admin@example.com',
               reason: 'test',

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -13,17 +13,10 @@ import {
   SessionCookieData,
 } from './interfaces';
 
-type RefreshOptions =
-  | {
-      sealSession: true;
-      cookiePassword: string;
-      organizationId?: string;
-    }
-  | {
-      sealSession: false;
-      cookiePassword?: string;
-      organizationId?: string;
-    };
+type RefreshOptions = {
+  cookiePassword: string;
+  organizationId?: string;
+};
 
 export class Session {
   private jwks: ReturnType<typeof createRemoteJWKSet> | undefined;
@@ -109,7 +102,7 @@ export class Session {
   async refresh(
     options: RefreshOptions,
   ): Promise<RefreshAndSealSessionDataResponse> {
-    if (options.sealSession && !options.cookiePassword) {
+    if (!options.cookiePassword) {
       throw new Error('Cookie password is required for sealed sessions');
     }
 
@@ -146,16 +139,13 @@ export class Session {
           },
         });
 
-      if (options.sealSession) {
-        this.cookiePassword = options.cookiePassword;
-      }
+      this.cookiePassword = options.cookiePassword;
       this.sessionData = authenticationResponse.sealedSession as string;
 
       return {
         authenticated: true,
-        session: options.sealSession
-          ? (authenticationResponse.sealedSession as string)
-          : (authenticationResponse as AuthenticationResponse),
+        sealedSession: authenticationResponse.sealedSession,
+        session: authenticationResponse as AuthenticationResponse,
       };
     } catch (error) {
       if (

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -58,13 +58,22 @@ export class Session {
       };
     }
 
-    const session =
-      await this.ironSessionProvider.unsealData<SessionCookieData>(
+    let session: SessionCookieData;
+
+    try {
+      session = await this.ironSessionProvider.unsealData<SessionCookieData>(
         this.sessionData,
         {
           password: this.cookiePassword,
         },
       );
+    } catch (e) {
+      return {
+        authenticated: false,
+        reason:
+          AuthenticateWithSessionCookieFailureReason.INVALID_SESSION_COOKIE,
+      };
+    }
 
     if (!session.accessToken) {
       return {

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -142,7 +142,7 @@ export class Session {
           session: {
             // We want to store the new sealed session in this class instance, so this always needs to be true
             sealSession: true,
-            cookiePassword: cookiePassword,
+            cookiePassword,
           },
         });
 

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -146,7 +146,9 @@ export class Session {
           },
         });
 
-      if (options.sealSession) this.cookiePassword = options.cookiePassword;
+      if (options.sealSession) {
+        this.cookiePassword = options.cookiePassword;
+      }
       this.sessionData = authenticationResponse.sealedSession as string;
 
       return {

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -1,0 +1,200 @@
+import { UserManagement } from './user-management';
+import { IronSessionProvider } from '../common/iron-session/iron-session-provider';
+import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
+import { OauthException } from '../common/exceptions/oauth.exception';
+import {
+  AccessToken,
+  AuthenticateWithSessionCookieFailedResponse,
+  AuthenticateWithSessionCookieFailureReason,
+  AuthenticateWithSessionCookieSuccessResponse,
+  AuthenticationResponse,
+  RefreshAndSealSessionDataFailureReason,
+  RefreshAndSealSessionDataResponse,
+  SessionCookieData,
+} from './interfaces';
+
+type RefreshOptions =
+  | {
+      sealed: true;
+      cookiePassword: string;
+      organizationId?: string;
+    }
+  | {
+      sealed: false;
+      cookiePassword?: string;
+      organizationId?: string;
+    };
+
+export class Session {
+  private jwks: ReturnType<typeof createRemoteJWKSet> | undefined;
+  private userManagement: UserManagement;
+  private ironSessionProvider: IronSessionProvider;
+  private cookiePassword: string;
+  private sessionData: string;
+
+  constructor(
+    userManagement: UserManagement,
+    sessionData: string,
+    cookiePassword: string,
+  ) {
+    if (!cookiePassword) {
+      throw new Error('cookiePassword is required');
+    }
+
+    this.userManagement = userManagement;
+    this.ironSessionProvider = userManagement.ironSessionProvider;
+    this.cookiePassword = cookiePassword;
+    this.sessionData = sessionData;
+
+    const { clientId, getJwksUrl } = this.userManagement;
+
+    this.jwks = clientId
+      ? createRemoteJWKSet(new URL(getJwksUrl(clientId)))
+      : undefined;
+  }
+
+  async authenticate(): Promise<
+    | AuthenticateWithSessionCookieSuccessResponse
+    | AuthenticateWithSessionCookieFailedResponse
+  > {
+    if (!this.sessionData) {
+      return {
+        authenticated: false,
+        reason:
+          AuthenticateWithSessionCookieFailureReason.NO_SESSION_COOKIE_PROVIDED,
+      };
+    }
+
+    const session =
+      await this.ironSessionProvider.unsealData<SessionCookieData>(
+        this.sessionData,
+        {
+          password: this.cookiePassword,
+        },
+      );
+
+    if (!session.accessToken) {
+      return {
+        authenticated: false,
+        reason:
+          AuthenticateWithSessionCookieFailureReason.INVALID_SESSION_COOKIE,
+      };
+    }
+
+    if (!(await this.isValidJwt(session.accessToken))) {
+      return {
+        authenticated: false,
+        reason: AuthenticateWithSessionCookieFailureReason.INVALID_JWT,
+      };
+    }
+
+    const {
+      sid: sessionId,
+      org_id: organizationId,
+      role,
+      permissions,
+    } = decodeJwt<AccessToken>(session.accessToken);
+
+    return {
+      authenticated: true,
+      sessionId,
+      organizationId,
+      role,
+      permissions,
+    };
+  }
+
+  async refresh(
+    options: RefreshOptions,
+  ): Promise<RefreshAndSealSessionDataResponse> {
+    if (options.sealed && !options.cookiePassword) {
+      throw new Error('Cookie password is required for sealed sessions');
+    }
+
+    const session =
+      await this.ironSessionProvider.unsealData<SessionCookieData>(
+        this.sessionData,
+        {
+          password: options.cookiePassword as string,
+        },
+      );
+
+    if (!session.refreshToken || !session.user) {
+      return {
+        authenticated: false,
+        reason: RefreshAndSealSessionDataFailureReason.INVALID_SESSION_COOKIE,
+      };
+    }
+
+    const { org_id: organizationIdFromAccessToken } = decodeJwt<AccessToken>(
+      session.accessToken,
+    );
+
+    try {
+      const authenticationResponse =
+        await this.userManagement.authenticateWithRefreshToken({
+          clientId: this.userManagement.clientId as string,
+          refreshToken: session.refreshToken,
+          organizationId:
+            options.organizationId ?? organizationIdFromAccessToken,
+          session: {
+            // We want to store the new sealed session here, so this always needs to be true
+            sealSession: true,
+            cookiePassword: options.cookiePassword ?? this.cookiePassword,
+          },
+        });
+
+      if (options.sealed) this.cookiePassword = options.cookiePassword;
+      this.sessionData = authenticationResponse.sealedSession as string;
+
+      return {
+        authenticated: true,
+        session: options.sealed
+          ? (authenticationResponse.sealedSession as string)
+          : (authenticationResponse as AuthenticationResponse),
+      };
+    } catch (error) {
+      if (
+        error instanceof OauthException &&
+        // TODO: Add additional known errors and remove re-throw
+        (error.error === RefreshAndSealSessionDataFailureReason.INVALID_GRANT ||
+          error.error ===
+            RefreshAndSealSessionDataFailureReason.MFA_ENROLLMENT ||
+          error.error === RefreshAndSealSessionDataFailureReason.SSO_REQUIRED)
+      ) {
+        return {
+          authenticated: false,
+          reason: error.error,
+        };
+      }
+
+      throw error;
+    }
+  }
+
+  async getLogoutUrl() {
+    const authenticationResponse = await this.authenticate();
+
+    if (!authenticationResponse.authenticated) {
+      const { reason } = authenticationResponse;
+      throw new Error(`Failed to extract session ID for logout URL: ${reason}`);
+    }
+
+    return this.userManagement.getLogoutUrl({
+      sessionId: authenticationResponse.sessionId,
+    });
+  }
+
+  private async isValidJwt(accessToken: string): Promise<boolean> {
+    if (!this.jwks) {
+      throw new Error('Must provide clientId to initialize JWKS');
+    }
+
+    try {
+      await jwtVerify(accessToken, this.jwks);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+}

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -126,10 +126,6 @@ export class Session {
       };
     }
 
-    const { org_id: organizationIdFromAccessToken } = decodeJwt<AccessToken>(
-      session.accessToken,
-    );
-
     try {
       const cookiePassword = options.cookiePassword ?? this.cookiePassword;
 
@@ -137,8 +133,7 @@ export class Session {
         await this.userManagement.authenticateWithRefreshToken({
           clientId: this.userManagement.clientId as string,
           refreshToken: session.refreshToken,
-          organizationId:
-            options.organizationId ?? organizationIdFromAccessToken,
+          organizationId: options.organizationId ?? undefined,
           session: {
             // We want to store the new sealed session in this class instance, so this always needs to be true
             sealSession: true,

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -46,6 +46,11 @@ export class Session {
       : undefined;
   }
 
+  /**
+   * Authenticates a user with a session cookie.
+   *
+   * @returns An object indicating whether the authentication was successful or not. If successful, it will include the user's session data.
+   */
   async authenticate(): Promise<
     | AuthenticateWithSessionCookieSuccessResponse
     | AuthenticateWithSessionCookieFailedResponse
@@ -108,6 +113,14 @@ export class Session {
     };
   }
 
+  /**
+   * Refreshes the user's session.
+   *
+   * @param options - Optional options for refreshing the session.
+   * @param options.cookiePassword - The password to use for the new session cookie.
+   * @param options.organizationId - The organization ID to use for the new session cookie.
+   * @returns An object indicating whether the refresh was successful or not. If successful, it will include the new sealed session data.
+   */
   async refresh(
     options: RefreshOptions = {},
   ): Promise<RefreshAndSealSessionDataResponse> {
@@ -172,6 +185,11 @@ export class Session {
     }
   }
 
+  /**
+   * Gets the URL to redirect the user to for logging out.
+   *
+   * @returns The URL to redirect the user to for logging out.
+   */
   async getLogoutUrl() {
     const authenticationResponse = await this.authenticate();
 

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -15,12 +15,12 @@ import {
 
 type RefreshOptions =
   | {
-      sealed: true;
+      sealSession: true;
       cookiePassword: string;
       organizationId?: string;
     }
   | {
-      sealed: false;
+      sealSession: false;
       cookiePassword?: string;
       organizationId?: string;
     };
@@ -109,7 +109,7 @@ export class Session {
   async refresh(
     options: RefreshOptions,
   ): Promise<RefreshAndSealSessionDataResponse> {
-    if (options.sealed && !options.cookiePassword) {
+    if (options.sealSession && !options.cookiePassword) {
       throw new Error('Cookie password is required for sealed sessions');
     }
 
@@ -146,12 +146,12 @@ export class Session {
           },
         });
 
-      if (options.sealed) this.cookiePassword = options.cookiePassword;
+      if (options.sealSession) this.cookiePassword = options.cookiePassword;
       this.sessionData = authenticationResponse.sealedSession as string;
 
       return {
         authenticated: true,
-        session: options.sealed
+        session: options.sealSession
           ? (authenticationResponse.sealedSession as string)
           : (authenticationResponse as AuthenticationResponse),
       };

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -46,10 +46,10 @@ export class Session {
     this.cookiePassword = cookiePassword;
     this.sessionData = sessionData;
 
-    const { clientId, getJwksUrl } = this.userManagement;
+    const { clientId } = this.userManagement;
 
     this.jwks = clientId
-      ? createRemoteJWKSet(new URL(getJwksUrl(clientId)))
+      ? createRemoteJWKSet(new URL(userManagement.getJwksUrl(clientId)))
       : undefined;
   }
 
@@ -101,6 +101,8 @@ export class Session {
       organizationId,
       role,
       permissions,
+      user: session.user,
+      impersonator: session.impersonator,
     };
   }
 
@@ -138,7 +140,7 @@ export class Session {
           organizationId:
             options.organizationId ?? organizationIdFromAccessToken,
           session: {
-            // We want to store the new sealed session here, so this always needs to be true
+            // We want to store the new sealed session in this class instance, so this always needs to be true
             sealSession: true,
             cookiePassword: options.cookiePassword ?? this.cookiePassword,
           },

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -913,7 +913,7 @@ describe('UserManagement', () => {
           cookiePassword,
         }),
       ).resolves.toEqual({
-        session: expect.any(String),
+        sealedSession: expect.any(String),
         authenticated: true,
       });
     });

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -913,7 +913,7 @@ describe('UserManagement', () => {
           cookiePassword,
         }),
       ).resolves.toEqual({
-        sealedSession: expect.any(String),
+        session: expect.any(String),
         authenticated: true,
       });
     });

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -850,6 +850,9 @@ describe('UserManagement', () => {
         organizationId: 'org_123',
         role: 'member',
         permissions: ['posts:create', 'posts:delete'],
+        user: expect.objectContaining({
+          email: 'test@example.com',
+        }),
       });
     });
   });

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -480,14 +480,14 @@ export class UserManagement {
     );
 
     try {
-      const authenticationResponse = await this.authenticateWithRefreshToken({
+      const { sealedSession } = await this.authenticateWithRefreshToken({
         clientId: this.workos.clientId as string,
         refreshToken: session.refreshToken,
         organizationId: organizationId ?? organizationIdFromAccessToken,
         session: { sealSession: true, cookiePassword },
       });
 
-      if (!authenticationResponse.sealedSession) {
+      if (!sealedSession) {
         return {
           authenticated: false,
           reason: RefreshAndSealSessionDataFailureReason.INVALID_SESSION_COOKIE,
@@ -496,7 +496,7 @@ export class UserManagement {
 
       return {
         authenticated: true,
-        session: authenticationResponse.sealedSession,
+        session: sealedSession,
       };
     } catch (error) {
       if (

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -1009,6 +1009,7 @@ export class UserManagement {
     if (!clientId) {
       throw TypeError('clientId must be a valid clientId');
     }
+
     return `${this.workos.baseURL}/sso/jwks/${clientId}`;
   }
 }

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -174,8 +174,11 @@ export class UserManagement {
       : undefined;
   }
 
-  session(sessionData: string, cookiePassword: string): Session {
-    return new Session(this, sessionData, cookiePassword);
+  loadSealedSession(options: {
+    sessionData: string;
+    cookiePassword: string;
+  }): Session {
+    return new Session(this, options.sessionData, options.cookiePassword);
   }
 
   async getUser(userId: string): Promise<User> {

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -429,6 +429,7 @@ export class UserManagement {
       sessionId,
       organizationId,
       role,
+      user: session.user,
       permissions,
     };
   }

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -456,7 +456,8 @@ export class UserManagement {
   }
 
   /**
-   * @deprecated This method is deprecated and will be removed in future versions. Please use the new `loadSealedSession` and its corresponding methods instead.
+   * @deprecated This method is deprecated and will be removed in a future major version.
+   * Please use the new `loadSealedSession` helper and its corresponding methods instead.
    */
   async refreshAndSealSessionData({
     sessionData,
@@ -644,7 +645,8 @@ export class UserManagement {
   }
 
   /**
-   * @deprecated Please use `createMagicAuth` instead. This method will be removed in a future major version.
+   * @deprecated Please use `createMagicAuth` instead.
+   * This method will be removed in a future major version.
    */
   async sendMagicAuthCode(options: SendMagicAuthCodeOptions): Promise<void> {
     await this.workos.post<any, SerializedSendMagicAuthCodeOptions>(
@@ -1003,7 +1005,8 @@ export class UserManagement {
   }
 
   /**
-   * @deprecated This method is deprecated and will be removed in future versions. Please use `loadSealedSession` and its `getLogoutUrl` method instead.
+   * @deprecated This method is deprecated and will be removed in a future major version.
+   * Please use the `loadSealedSession` helper and its `getLogoutUrl` method instead.
    *
    * getLogoutUrlFromSessionCookie takes in session cookie data, unseals the cookie, decodes the JWT claims,
    * and uses the session ID to generate the logout URL.

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -496,7 +496,7 @@ export class UserManagement {
 
       return {
         authenticated: true,
-        session: sealedSession,
+        sealedSession,
       };
     } catch (error) {
       if (

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -174,6 +174,14 @@ export class UserManagement {
       : undefined;
   }
 
+  /**
+   * Loads a sealed session using the provided session data and cookie password.
+   *
+   * @param options - The options for loading the sealed session.
+   * @param options.sessionData - The sealed session data.
+   * @param options.cookiePassword - The password used to encrypt the session data.
+   * @returns The session class.
+   */
   loadSealedSession(options: {
     sessionData: string;
     cookiePassword: string;
@@ -447,6 +455,9 @@ export class UserManagement {
     }
   }
 
+  /**
+   * @deprecated This method is deprecated and will be removed in future versions. Please use the new `loadSealedSession` and its corresponding methods instead.
+   */
   async refreshAndSealSessionData({
     sessionData,
     organizationId,
@@ -992,6 +1003,8 @@ export class UserManagement {
   }
 
   /**
+   * @deprecated This method is deprecated and will be removed in future versions. Please use `loadSealedSession` and its `getLogoutUrl` method instead.
+   *
    * getLogoutUrlFromSessionCookie takes in session cookie data, unseals the cookie, decodes the JWT claims,
    * and uses the session ID to generate the logout URL.
    *


### PR DESCRIPTION
## Description

Refactors the session helpers to add a new session class. The old helper methods will stay put, but we'll likely add a deprecation comment and remove them in a future major version.

See this [gist](https://gist.github.com/PaulAsjes/e1f80d5451f988db2acdf6ee894fcc46) as an example of how this would work in practise. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
