### PR TITLE
fix: Ensure organizationId is included in SessionCookieData during sealSessionDataFromAuthenticationResponse

### DIFF
--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -142,7 +142,11 @@ describe('UserManagement', () => {
 
     describe('when sealSession = true', () => {
       beforeEach(() => {
-        fetchOnce({ user: userFixture });
+        fetchOnce({
+          user: userFixture,
+          access_token:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        });
       });
 
       describe('when the cookie password is undefined', () => {
@@ -172,7 +176,7 @@ describe('UserManagement', () => {
 
           expect(response).toEqual({
             sealedSession: expect.any(String),
-            accessToken: undefined,
+            accessToken: expect.any(String),
             authenticationMethod: undefined,
             impersonator: undefined,
             organizationId: undefined,
@@ -205,7 +209,11 @@ describe('UserManagement', () => {
 
     describe('when sealSession = true', () => {
       beforeEach(() => {
-        fetchOnce({ user: userFixture });
+        fetchOnce({
+          user: userFixture,
+          access_token:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        });
       });
 
       describe('when the cookie password is undefined', () => {
@@ -236,7 +244,7 @@ describe('UserManagement', () => {
 
           expect(response).toEqual({
             sealedSession: expect.any(String),
-            accessToken: undefined,
+            accessToken: expect.any(String),
             authenticationMethod: undefined,
             impersonator: undefined,
             organizationId: undefined,
@@ -344,7 +352,11 @@ describe('UserManagement', () => {
 
     describe('when sealSession = true', () => {
       beforeEach(() => {
-        fetchOnce({ user: userFixture });
+        fetchOnce({
+          user: userFixture,
+          access_token:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        });
       });
 
       describe('when the cookie password is undefined', () => {
@@ -371,7 +383,7 @@ describe('UserManagement', () => {
 
           expect(response).toEqual({
             sealedSession: expect.any(String),
-            accessToken: undefined,
+            accessToken: expect.any(String),
             authenticationMethod: undefined,
             impersonator: undefined,
             organizationId: undefined,
@@ -413,7 +425,11 @@ describe('UserManagement', () => {
 
     describe('when sealSession = true', () => {
       beforeEach(() => {
-        fetchOnce({ user: userFixture });
+        fetchOnce({
+          user: userFixture,
+          access_token:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        });
       });
 
       describe('when the cookie password is undefined', () => {
@@ -441,7 +457,7 @@ describe('UserManagement', () => {
 
           expect(response).toEqual({
             sealedSession: expect.any(String),
-            accessToken: undefined,
+            accessToken: expect.any(String),
             authenticationMethod: undefined,
             impersonator: undefined,
             organizationId: undefined,
@@ -485,7 +501,11 @@ describe('UserManagement', () => {
 
     describe('when sealSession = true', () => {
       beforeEach(() => {
-        fetchOnce({ user: userFixture });
+        fetchOnce({
+          user: userFixture,
+          access_token:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        });
       });
 
       describe('when the cookie password is undefined', () => {
@@ -518,7 +538,7 @@ describe('UserManagement', () => {
 
           expect(response).toEqual({
             sealedSession: expect.any(String),
-            accessToken: undefined,
+            accessToken: expect.any(String),
             authenticationMethod: undefined,
             impersonator: undefined,
             organizationId: undefined,
@@ -560,7 +580,11 @@ describe('UserManagement', () => {
 
     describe('when sealSession = true', () => {
       beforeEach(() => {
-        fetchOnce({ user: userFixture });
+        fetchOnce({
+          user: userFixture,
+          access_token:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        });
       });
 
       describe('when the cookie password is undefined', () => {
@@ -590,7 +614,7 @@ describe('UserManagement', () => {
 
           expect(response).toEqual({
             sealedSession: expect.any(String),
-            accessToken: undefined,
+            accessToken: expect.any(String),
             authenticationMethod: undefined,
             impersonator: undefined,
             organizationId: undefined,
@@ -632,7 +656,11 @@ describe('UserManagement', () => {
 
     describe('when sealSession = true', () => {
       beforeEach(() => {
-        fetchOnce({ user: userFixture });
+        fetchOnce({
+          user: userFixture,
+          access_token:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        });
       });
 
       describe('when the cookie password is undefined', () => {
@@ -662,7 +690,7 @@ describe('UserManagement', () => {
 
           expect(response).toEqual({
             sealedSession: expect.any(String),
-            accessToken: undefined,
+            accessToken: expect.any(String),
             authenticationMethod: undefined,
             impersonator: undefined,
             organizationId: undefined,
@@ -888,7 +916,8 @@ describe('UserManagement', () => {
     it('returns the sealed refreshed session cookie when provided a valid existing session cookie', async () => {
       fetchOnce({
         user: userFixture,
-        access_token: 'access_token',
+        access_token:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
         refresh_token: 'refresh_token',
       });
 

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -535,7 +535,12 @@ export class UserManagement {
       throw new Error('Cookie password is required');
     }
 
+    const { org_id: organizationIdFromAccessToken } = decodeJwt<AccessToken>(
+      authenticationResponse.accessToken,
+    );
+
     const sessionData: SessionCookieData = {
+      organizationId: organizationIdFromAccessToken,
       user: authenticationResponse.user,
       accessToken: authenticationResponse.accessToken,
       refreshToken: authenticationResponse.refreshToken,


### PR DESCRIPTION
## Description
They types were a slight lie, since you could have had a session with an org id in the access token the but the organization id in the sealed cookie data didn't include it. This required users to always decode the jwt even in cases where they were trying to abstract away using the new sealed session data. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
