### PR TITLE
Add failed auth events for SSO and OAuth

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -91,6 +91,17 @@ export interface AuthenticationMfaSucceededEventResponse
   data: AuthenticationEventResponse;
 }
 
+export interface AuthenticationOAuthFailedEvent extends EventBase {
+  event: 'authentication.oauth_failed';
+  data: AuthenticationEvent;
+}
+
+export interface AuthenticationOAuthFailedEventResponse
+  extends EventResponseBase {
+  event: 'authentication.oauth_failed';
+  data: AuthenticationEventResponse;
+}
+
 export interface AuthenticationOAuthSucceededEvent extends EventBase {
   event: 'authentication.oauth_succeeded';
   data: AuthenticationEvent;
@@ -121,6 +132,17 @@ export interface AuthenticationPasswordSucceededEvent extends EventBase {
 export interface AuthenticationPasswordSucceededEventResponse
   extends EventResponseBase {
   event: 'authentication.password_succeeded';
+  data: AuthenticationEventResponse;
+}
+
+export interface AuthenticationSSOFailedEvent extends EventBase {
+  event: 'authentication.sso_failed';
+  data: AuthenticationEvent;
+}
+
+export interface AuthenticationSSOFailedEventResponse
+  extends EventResponseBase {
+  event: 'authentication.sso_failed';
   data: AuthenticationEventResponse;
 }
 
@@ -491,7 +513,9 @@ export interface SessionCreatedEventResponse extends EventResponseBase {
 export type Event =
   | AuthenticationEmailVerificationSucceededEvent
   | AuthenticationMfaSucceededEvent
+  | AuthenticationOAuthFailedEvent
   | AuthenticationOAuthSucceededEvent
+  | AuthenticationSSOFailedEvent
   | AuthenticationSSOSucceededEvent
   | AuthenticationPasswordFailedEvent
   | AuthenticationPasswordSucceededEvent
@@ -535,9 +559,11 @@ export type EventResponse =
   | AuthenticationMagicAuthFailedEventResponse
   | AuthenticationMagicAuthSucceededEventResponse
   | AuthenticationMfaSucceededEventResponse
+  | AuthenticationOAuthFailedEventResponse
   | AuthenticationOAuthSucceededEventResponse
   | AuthenticationPasswordFailedEventResponse
   | AuthenticationPasswordSucceededEventResponse
+  | AuthenticationSSOFailedEventResponse
   | AuthenticationSSOSucceededEventResponse
   | ConnectionActivatedEventResponse
   | ConnectionDeactivatedEventResponse

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -32,9 +32,11 @@ export const deserializeEvent = (event: EventResponse): Event => {
     case 'authentication.magic_auth_failed':
     case 'authentication.magic_auth_succeeded':
     case 'authentication.mfa_succeeded':
+    case 'authentication.oauth_failed':
     case 'authentication.oauth_succeeded':
     case 'authentication.password_failed':
     case 'authentication.password_succeeded':
+    case 'authentication.sso_failed':
     case 'authentication.sso_succeeded':
       return {
         ...eventBase,


### PR DESCRIPTION
## Description

Adds failed authentication events for SSO and OAuth

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
