### PR TITLE
Add batch write resources method

### DIFF
--- a/src/fga/fga.spec.ts
+++ b/src/fga/fga.spec.ts
@@ -189,8 +189,8 @@ describe('FGA', () => {
             resource_type: 'role',
             resource_id: 'admin',
             meta: {
-              description: "The admin role",
-            }
+              description: 'The admin role',
+            },
           },
           {
             resource_type: 'role',
@@ -211,8 +211,8 @@ describe('FGA', () => {
               resourceId: 'admin',
             },
             meta: {
-              description: "The admin role",
-            }
+              description: 'The admin role',
+            },
           },
           {
             resource: {
@@ -234,8 +234,8 @@ describe('FGA', () => {
           resourceType: 'role',
           resourceId: 'admin',
           meta: {
-            description: "The admin role",
-          }
+            description: 'The admin role',
+          },
         },
         {
           resourceType: 'role',
@@ -274,8 +274,8 @@ describe('FGA', () => {
               resourceId: 'admin',
             },
             meta: {
-              description: "The admin role",
-            }
+              description: 'The admin role',
+            },
           },
           {
             resource: {

--- a/src/fga/fga.spec.ts
+++ b/src/fga/fga.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '../common/utils/test-utils';
 
 import { WorkOS } from '../workos';
-import { WarrantOp } from './interfaces';
+import { ResourceOp, WarrantOp } from './interfaces';
 
 const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
@@ -178,6 +178,134 @@ describe('FGA', () => {
       });
       expect(fetchURL()).toContain('/fga/v1/resources/role/admin');
       expect(response).toBeUndefined();
+    });
+  });
+
+  describe('batchWriteResources', () => {
+    it('batch create resources', async () => {
+      fetchOnce({
+        data: [
+          {
+            resource_type: 'role',
+            resource_id: 'admin',
+            meta: {
+              description: "The admin role",
+            }
+          },
+          {
+            resource_type: 'role',
+            resource_id: 'manager',
+          },
+          {
+            resource_type: 'role',
+            resource_id: 'employee',
+          },
+        ],
+      });
+      const createdResources = await workos.fga.batchWriteResources({
+        op: ResourceOp.Create,
+        resources: [
+          {
+            resource: {
+              resourceType: 'role',
+              resourceId: 'admin',
+            },
+            meta: {
+              description: "The admin role",
+            }
+          },
+          {
+            resource: {
+              resourceType: 'role',
+              resourceId: 'manager',
+            },
+          },
+          {
+            resource: {
+              resourceType: 'role',
+              resourceId: 'employee',
+            },
+          },
+        ],
+      });
+      expect(fetchURL()).toContain('/fga/v1/resources/batch');
+      expect(createdResources).toMatchObject([
+        {
+          resourceType: 'role',
+          resourceId: 'admin',
+          meta: {
+            description: "The admin role",
+          }
+        },
+        {
+          resourceType: 'role',
+          resourceId: 'manager',
+        },
+        {
+          resourceType: 'role',
+          resourceId: 'employee',
+        },
+      ]);
+    });
+
+    it('batch delete resources', async () => {
+      fetchOnce({
+        data: [
+          {
+            resource_type: 'role',
+            resource_id: 'admin',
+          },
+          {
+            resource_type: 'role',
+            resource_id: 'manager',
+          },
+          {
+            resource_type: 'role',
+            resource_id: 'employee',
+          },
+        ],
+      });
+      const deletedResources = await workos.fga.batchWriteResources({
+        op: ResourceOp.Delete,
+        resources: [
+          {
+            resource: {
+              resourceType: 'role',
+              resourceId: 'admin',
+            },
+            meta: {
+              description: "The admin role",
+            }
+          },
+          {
+            resource: {
+              resourceType: 'role',
+              resourceId: 'manager',
+            },
+          },
+          {
+            resource: {
+              resourceType: 'role',
+              resourceId: 'employee',
+            },
+          },
+        ],
+      });
+      expect(fetchURL()).toContain('/fga/v1/resources/batch');
+      expect(deletedResources).toMatchObject([
+        {
+          resourceType: 'role',
+          resourceId: 'admin',
+        },
+        {
+          resourceType: 'role',
+          resourceId: 'manager',
+        },
+        {
+          resourceType: 'role',
+          resourceId: 'employee',
+        },
+      ]);
     });
   });
 

--- a/src/fga/fga.ts
+++ b/src/fga/fga.ts
@@ -46,7 +46,7 @@ import { AutoPaginatable } from '../common/utils/pagination';
 import { fetchAndDeserialize } from '../common/utils/fetch-and-deserialize';
 
 export class FGA {
-  constructor(private readonly workos: WorkOS) { }
+  constructor(private readonly workos: WorkOS) {}
 
   async check(
     checkOptions: CheckOptions,
@@ -150,9 +150,14 @@ export class FGA {
     await this.workos.delete(`/fga/v1/resources/${resourceType}/${resourceId}`);
   }
 
-  async batchWriteResources(options: BatchWriteResourcesOptions): Promise<Resource[]> {
-    const { data } = await this.workos.post<BatchWriteResourcesResponse>('/fga/v1/resources/batch', options);
-    return deserializeBatchWriteResourcesResponse(data)
+  async batchWriteResources(
+    options: BatchWriteResourcesOptions,
+  ): Promise<Resource[]> {
+    const { data } = await this.workos.post<BatchWriteResourcesResponse>(
+      '/fga/v1/resources/batch',
+      options,
+    );
+    return deserializeBatchWriteResourcesResponse(data);
   }
 
   async writeWarrant(options: WriteWarrantOptions): Promise<WarrantToken> {

--- a/src/fga/fga.ts
+++ b/src/fga/fga.ts
@@ -24,8 +24,11 @@ import {
   WarrantResponse,
   WarrantToken,
   WarrantTokenResponse,
+  BatchWriteResourcesOptions,
+  BatchWriteResourcesResponse,
 } from './interfaces';
 import {
+  deserializeBatchWriteResourcesResponse,
   deserializeQueryResult,
   deserializeResource,
   deserializeWarrant,
@@ -43,7 +46,7 @@ import { AutoPaginatable } from '../common/utils/pagination';
 import { fetchAndDeserialize } from '../common/utils/fetch-and-deserialize';
 
 export class FGA {
-  constructor(private readonly workos: WorkOS) {}
+  constructor(private readonly workos: WorkOS) { }
 
   async check(
     checkOptions: CheckOptions,
@@ -145,6 +148,11 @@ export class FGA {
       : resource.resourceId;
 
     await this.workos.delete(`/fga/v1/resources/${resourceType}/${resourceId}`);
+  }
+
+  async batchWriteResources(options: BatchWriteResourcesOptions): Promise<Resource[]> {
+    const { data } = await this.workos.post<BatchWriteResourcesResponse>('/fga/v1/resources/batch', options);
+    return deserializeBatchWriteResourcesResponse(data)
   }
 
   async writeWarrant(options: WriteWarrantOptions): Promise<WarrantToken> {

--- a/src/fga/interfaces/check-op.enum.ts
+++ b/src/fga/interfaces/check-op.enum.ts
@@ -1,5 +1,4 @@
 export enum CheckOp {
   AllOf = 'all_of',
   AnyOf = 'any_of',
-  Batch = 'batch',
 }

--- a/src/fga/interfaces/check.interface.ts
+++ b/src/fga/interfaces/check.interface.ts
@@ -33,7 +33,7 @@ export interface CheckBatchOptions {
 }
 
 export interface SerializedCheckOptions {
-  op?: CheckOp;
+  op?: string;
   checks: SerializedCheckWarrantOptions[];
   debug?: boolean;
 }
@@ -86,11 +86,11 @@ export class CheckResult implements CheckResultInterface {
     this.isImplicit = json.is_implicit;
     this.debugInfo = json.debug_info
       ? {
-          processingTime: json.debug_info.processing_time,
-          decisionTree: deserializeDecisionTreeNode(
-            json.debug_info.decision_tree,
-          ),
-        }
+        processingTime: json.debug_info.processing_time,
+        decisionTree: deserializeDecisionTreeNode(
+          json.debug_info.decision_tree,
+        ),
+      }
       : undefined;
   }
 

--- a/src/fga/interfaces/check.interface.ts
+++ b/src/fga/interfaces/check.interface.ts
@@ -33,7 +33,13 @@ export interface CheckBatchOptions {
 }
 
 export interface SerializedCheckOptions {
-  op?: string;
+  op?: CheckOp;
+  checks: SerializedCheckWarrantOptions[];
+  debug?: boolean;
+}
+
+export interface SerializedCheckBatchOptions {
+  op: 'batch';
   checks: SerializedCheckWarrantOptions[];
   debug?: boolean;
 }

--- a/src/fga/interfaces/check.interface.ts
+++ b/src/fga/interfaces/check.interface.ts
@@ -86,11 +86,11 @@ export class CheckResult implements CheckResultInterface {
     this.isImplicit = json.is_implicit;
     this.debugInfo = json.debug_info
       ? {
-        processingTime: json.debug_info.processing_time,
-        decisionTree: deserializeDecisionTreeNode(
-          json.debug_info.decision_tree,
-        ),
-      }
+          processingTime: json.debug_info.processing_time,
+          decisionTree: deserializeDecisionTreeNode(
+            json.debug_info.decision_tree,
+          ),
+        }
       : undefined;
   }
 

--- a/src/fga/interfaces/index.ts
+++ b/src/fga/interfaces/index.ts
@@ -1,6 +1,7 @@
 export * from './check-op.enum';
 export * from './check.interface';
 export * from './query.interface';
+export * from './resource-op.enum';
 export * from './resource.interface';
 export * from './warrant-op.enum';
 export * from './warrant-token.interface';

--- a/src/fga/interfaces/resource-op.enum.ts
+++ b/src/fga/interfaces/resource-op.enum.ts
@@ -1,0 +1,4 @@
+export enum ResourceOp {
+  Create = 'create',
+  Delete = 'delete',
+}

--- a/src/fga/interfaces/resource.interface.ts
+++ b/src/fga/interfaces/resource.interface.ts
@@ -1,4 +1,5 @@
 import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
+import { ResourceOp } from './resource-op.enum';
 
 export interface ResourceInterface {
   getResourceType(): string;
@@ -60,4 +61,13 @@ export interface ResourceResponse {
   resource_type: string;
   resource_id: string;
   meta?: { [key: string]: any };
+}
+
+export interface BatchWriteResourcesOptions {
+  op: ResourceOp;
+  resources: CreateResourceOptions[] | DeleteResourceOptions[];
+}
+
+export interface BatchWriteResourcesResponse {
+  data: ResourceResponse[];
 }

--- a/src/fga/serializers/check-options.serializer.ts
+++ b/src/fga/serializers/check-options.serializer.ts
@@ -1,6 +1,5 @@
 import {
   CheckBatchOptions,
-  CheckOp,
   CheckOptions,
   CheckWarrantOptions,
   DecisionTreeNode,
@@ -21,7 +20,7 @@ export const serializeCheckOptions = (
 export const serializeCheckBatchOptions = (
   options: CheckBatchOptions,
 ): SerializedCheckOptions => ({
-  op: CheckOp.Batch,
+  op: 'batch',
   checks: options.checks.map(serializeCheckWarrantOptions),
   debug: options.debug,
 });

--- a/src/fga/serializers/check-options.serializer.ts
+++ b/src/fga/serializers/check-options.serializer.ts
@@ -4,6 +4,7 @@ import {
   CheckWarrantOptions,
   DecisionTreeNode,
   DecisionTreeNodeResponse,
+  SerializedCheckBatchOptions,
   SerializedCheckOptions,
   SerializedCheckWarrantOptions,
 } from '../interfaces';
@@ -19,7 +20,7 @@ export const serializeCheckOptions = (
 
 export const serializeCheckBatchOptions = (
   options: CheckBatchOptions,
-): SerializedCheckOptions => ({
+): SerializedCheckBatchOptions => ({
   op: 'batch',
   checks: options.checks.map(serializeCheckWarrantOptions),
   debug: options.debug,

--- a/src/fga/serializers/resource.serializer.ts
+++ b/src/fga/serializers/resource.serializer.ts
@@ -1,4 +1,8 @@
-import { BatchWriteResourcesResponse, Resource, ResourceResponse } from '../interfaces';
+import {
+  BatchWriteResourcesResponse,
+  Resource,
+  ResourceResponse,
+} from '../interfaces';
 
 export const deserializeResource = (response: ResourceResponse): Resource => ({
   resourceType: response.resource_type,
@@ -6,6 +10,8 @@ export const deserializeResource = (response: ResourceResponse): Resource => ({
   meta: response.meta,
 });
 
-export const deserializeBatchWriteResourcesResponse = (response: BatchWriteResourcesResponse): Resource[] => {
+export const deserializeBatchWriteResourcesResponse = (
+  response: BatchWriteResourcesResponse,
+): Resource[] => {
   return response.data.map((resource) => deserializeResource(resource));
-}
+};

--- a/src/fga/serializers/resource.serializer.ts
+++ b/src/fga/serializers/resource.serializer.ts
@@ -1,7 +1,11 @@
-import { Resource, ResourceResponse } from '../interfaces';
+import { BatchWriteResourcesResponse, Resource, ResourceResponse } from '../interfaces';
 
 export const deserializeResource = (response: ResourceResponse): Resource => ({
   resourceType: response.resource_type,
   resourceId: response.resource_id,
   meta: response.meta,
 });
+
+export const deserializeBatchWriteResourcesResponse = (response: BatchWriteResourcesResponse): Resource[] => {
+  return response.data.map((resource) => deserializeResource(resource));
+}


### PR DESCRIPTION
## Description

- Add `batchWriteResources` method to FGA module
- Removes `Batch` from `CheckOp`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/30160