### PR TITLE
Add organization domain events

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -504,6 +504,16 @@ export interface RoleDeletedEventResponse extends EventResponseBase {
   data: RoleEventResponse;
 }
 
+export interface RoleUpdatedEvent extends EventBase {
+  event: 'role.updated';
+  data: RoleEvent;
+}
+
+export interface RoleUpdatedEventResponse extends EventResponseBase {
+  event: 'role.updated';
+  data: RoleEventResponse;
+}
+
 export interface SessionCreatedEvent extends EventBase {
   event: 'session.created';
   data: Session;
@@ -575,6 +585,7 @@ export type Event =
   | OrganizationMembershipRemoved
   | RoleCreatedEvent
   | RoleDeletedEvent
+  | RoleUpdatedEvent
   | SessionCreatedEvent
   | OrganizationCreatedEvent
   | OrganizationUpdatedEvent
@@ -621,6 +632,7 @@ export type EventResponse =
   | OrganizationMembershipRemovedResponse
   | RoleCreatedEventResponse
   | RoleDeletedEventResponse
+  | RoleUpdatedEventResponse
   | SessionCreatedEventResponse
   | OrganizationCreatedResponse
   | OrganizationUpdatedResponse

--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -579,7 +579,8 @@ export type Event =
   | OrganizationCreatedEvent
   | OrganizationUpdatedEvent
   | OrganizationDeletedEvent
-  | OrganizationDomainVerifiedEvent;
+  | OrganizationDomainVerifiedEvent
+  | OrganizationDomainVerificationFailedEvent;
 
 export type EventResponse =
   | AuthenticationEmailVerificationSucceededEventResponse
@@ -624,6 +625,7 @@ export type EventResponse =
   | OrganizationCreatedResponse
   | OrganizationUpdatedResponse
   | OrganizationDeletedResponse
-  | OrganizationDomainVerifiedEventResponse;
+  | OrganizationDomainVerifiedEventResponse
+  | OrganizationDomainVerificationFailedEventResponse;
 
 export type EventName = Event['event'];

--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -35,6 +35,10 @@ import {
   RoleEvent,
   RoleEventResponse,
 } from '../../roles/interfaces/role.interface';
+import {
+  OrganizationDomain,
+  OrganizationDomainResponse,
+} from '../../organization-domains/interfaces';
 
 export interface EventBase {
   id: string;
@@ -510,6 +514,28 @@ export interface SessionCreatedEventResponse extends EventResponseBase {
   data: SessionResponse;
 }
 
+export interface OrganizationDomainVerifiedEvent extends EventBase {
+  event: 'organization_domain.verified';
+  data: OrganizationDomain;
+}
+
+export interface OrganizationDomainVerifiedEventResponse
+  extends EventResponseBase {
+  event: 'organization_domain.verified';
+  data: OrganizationDomainResponse;
+}
+
+export interface OrganizationDomainVerificationFailedEvent extends EventBase {
+  event: 'organization_domain.verification_failed';
+  data: OrganizationDomain;
+}
+
+export interface OrganizationDomainVerificationFailedEventResponse
+  extends EventResponseBase {
+  event: 'organization_domain.verification_failed';
+  data: OrganizationDomainResponse;
+}
+
 export type Event =
   | AuthenticationEmailVerificationSucceededEvent
   | AuthenticationMfaSucceededEvent
@@ -552,7 +578,8 @@ export type Event =
   | SessionCreatedEvent
   | OrganizationCreatedEvent
   | OrganizationUpdatedEvent
-  | OrganizationDeletedEvent;
+  | OrganizationDeletedEvent
+  | OrganizationDomainVerifiedEvent;
 
 export type EventResponse =
   | AuthenticationEmailVerificationSucceededEventResponse
@@ -596,6 +623,7 @@ export type EventResponse =
   | SessionCreatedEventResponse
   | OrganizationCreatedResponse
   | OrganizationUpdatedResponse
-  | OrganizationDeletedResponse;
+  | OrganizationDeletedResponse
+  | OrganizationDomainVerifiedEventResponse;
 
 export type EventName = Event['event'];

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -16,6 +16,7 @@ import {
   deserializePasswordResetEvent,
   deserializeUser,
 } from '../../user-management/serializers';
+import { deserializeOrganizationDomain } from '../../organization-domains/serializers/organization-domain.serializer';
 import { deserializeOrganizationMembership } from '../../user-management/serializers/organization-membership.serializer';
 import { deserializeRole } from '../../user-management/serializers/role.serializer';
 import { deserializeSession } from '../../user-management/serializers/session.serializer';
@@ -163,6 +164,13 @@ export const deserializeEvent = (event: EventResponse): Event => {
         ...eventBase,
         event: event.event,
         data: deserializeOrganization(event.data),
+      };
+    case 'organization_domain.verified':
+    case 'organization_domain.verification_failed':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeOrganizationDomain(event.data),
       };
   }
 };

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -146,6 +146,7 @@ export const deserializeEvent = (event: EventResponse): Event => {
       };
     case 'role.created':
     case 'role.deleted':
+    case 'role.updated':
       return {
         ...eventBase,
         event: event.event,


### PR DESCRIPTION
## Description
Adds the `organization_domain.verified` and `organization_domain.verification_failed` events.


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
