### PR TITLE
Serialize BatchWriteResourcesOptions before making request

### DIFF
--- a/src/fga/fga-live-test.spec.ts
+++ b/src/fga/fga-live-test.spec.ts
@@ -1,7 +1,7 @@
 import { disableFetchMocks, enableFetchMocks } from 'jest-fetch-mock';
 
 import { WorkOS } from '../workos';
-import { CheckOp, WarrantOp } from './interfaces';
+import { CheckOp, ResourceOp, WarrantOp } from './interfaces';
 
 describe.skip('FGA Live Test', () => {
   let workos: WorkOS;
@@ -1133,4 +1133,59 @@ describe.skip('FGA Live Test', () => {
     await workos.fga.deleteResource(userA);
     await workos.fga.deleteResource(userB);
   });
+
+  it('batch write resources', async () => {
+    const objects = await workos.fga.batchWriteResources({
+      op: ResourceOp.Create,
+      resources: [
+        { 
+          resource: {
+            resourceType: 'user',
+            resourceId: 'user1',
+          },
+        },
+        { 
+          resource: {
+            resourceType: 'user',
+            resourceId: 'user2',
+          },
+        },
+        { 
+          resource: {
+            resourceType: 'tenant',
+            resourceId: 'tenantA',
+          },
+          meta: {
+            name: "Tenant A",
+          }
+        }
+      ]
+    });
+    expect(objects.length).toEqual(3);
+    expect(objects[0].resourceType).toEqual('user');
+    expect(objects[0].resourceId).toEqual('user1');
+    expect(objects[1].resourceType).toEqual('user');
+    expect(objects[1].resourceId).toEqual('user2');
+    expect(objects[2].resourceType).toEqual('tenant');
+    expect(objects[2].resourceId).toEqual('tenantA');
+    expect(objects[2].meta).toEqual({ name: 'Tenant A' });
+
+    await workos.fga.batchWriteResources({
+      op: ResourceOp.Delete,
+      resources: [
+        { 
+          resourceType: 'user',
+          resourceId: 'user1',
+        },
+        { 
+          resourceType: 'user',
+          resourceId: 'user2',
+        },
+        { 
+          resourceType: 'tenant',
+          resourceId: 'tenantA',
+        }
+      ]
+    });
+  })
 });

--- a/src/fga/fga-live-test.spec.ts
+++ b/src/fga/fga-live-test.spec.ts
@@ -1138,28 +1138,28 @@ describe.skip('FGA Live Test', () => {
     const objects = await workos.fga.batchWriteResources({
       op: ResourceOp.Create,
       resources: [
-        { 
+        {
           resource: {
             resourceType: 'user',
             resourceId: 'user1',
           },
         },
-        { 
+        {
           resource: {
             resourceType: 'user',
             resourceId: 'user2',
           },
         },
-        { 
+        {
           resource: {
             resourceType: 'tenant',
             resourceId: 'tenantA',
           },
           meta: {
-            name: "Tenant A",
-          }
-        }
-      ]
+            name: 'Tenant A',
+          },
+        },
+      ],
     });
     expect(objects.length).toEqual(3);
     expect(objects[0].resourceType).toEqual('user');
@@ -1173,19 +1173,19 @@ describe.skip('FGA Live Test', () => {
     await workos.fga.batchWriteResources({
       op: ResourceOp.Delete,
       resources: [
-        { 
+        {
           resourceType: 'user',
           resourceId: 'user1',
         },
-        { 
+        {
           resourceType: 'user',
           resourceId: 'user2',
         },
-        { 
+        {
           resourceType: 'tenant',
           resourceId: 'tenantA',
-        }
-      ]
+        },
+      ],
     });
-  })
+  });
 });

--- a/src/fga/fga.ts
+++ b/src/fga/fga.ts
@@ -33,6 +33,7 @@ import {
   deserializeResource,
   deserializeWarrant,
   deserializeWarrantToken,
+  serializeBatchWriteResourcesOptions,
   serializeCheckBatchOptions,
   serializeCheckOptions,
   serializeCreateResourceOptions,
@@ -46,7 +47,7 @@ import { AutoPaginatable } from '../common/utils/pagination';
 import { fetchAndDeserialize } from '../common/utils/fetch-and-deserialize';
 
 export class FGA {
-  constructor(private readonly workos: WorkOS) {}
+  constructor(private readonly workos: WorkOS) { }
 
   async check(
     checkOptions: CheckOptions,
@@ -155,7 +156,7 @@ export class FGA {
   ): Promise<Resource[]> {
     const { data } = await this.workos.post<BatchWriteResourcesResponse>(
       '/fga/v1/resources/batch',
-      options,
+      serializeBatchWriteResourcesOptions(options),
     );
     return deserializeBatchWriteResourcesResponse(data);
   }

--- a/src/fga/fga.ts
+++ b/src/fga/fga.ts
@@ -47,7 +47,7 @@ import { AutoPaginatable } from '../common/utils/pagination';
 import { fetchAndDeserialize } from '../common/utils/fetch-and-deserialize';
 
 export class FGA {
-  constructor(private readonly workos: WorkOS) { }
+  constructor(private readonly workos: WorkOS) {}
 
   async check(
     checkOptions: CheckOptions,

--- a/src/fga/interfaces/resource.interface.ts
+++ b/src/fga/interfaces/resource.interface.ts
@@ -68,6 +68,11 @@ export interface BatchWriteResourcesOptions {
   resources: CreateResourceOptions[] | DeleteResourceOptions[];
 }
 
+export interface SerializedBatchWriteResourcesOptions {
+  op: string;
+  resources: SerializedCreateResourceOptions[] | SerializedDeleteResourceOptions[];
+}
+
 export interface BatchWriteResourcesResponse {
   data: ResourceResponse[];
 }

--- a/src/fga/interfaces/resource.interface.ts
+++ b/src/fga/interfaces/resource.interface.ts
@@ -70,7 +70,9 @@ export interface BatchWriteResourcesOptions {
 
 export interface SerializedBatchWriteResourcesOptions {
   op: string;
-  resources: SerializedCreateResourceOptions[] | SerializedDeleteResourceOptions[];
+  resources:
+    | SerializedCreateResourceOptions[]
+    | SerializedDeleteResourceOptions[];
 }
 
 export interface BatchWriteResourcesResponse {

--- a/src/fga/serializers/batch-write-resources-options.serializer.ts
+++ b/src/fga/serializers/batch-write-resources-options.serializer.ts
@@ -13,13 +13,19 @@ import { serializeDeleteResourceOptions } from './delete-resource-options.serial
 export const serializeBatchWriteResourcesOptions = (
   options: BatchWriteResourcesOptions,
 ): SerializedBatchWriteResourcesOptions => {
-  let serializedResources: SerializedCreateResourceOptions[] | SerializedDeleteResourceOptions[] = [];
+  let serializedResources:
+    | SerializedCreateResourceOptions[]
+    | SerializedDeleteResourceOptions[] = [];
   if (options.op === ResourceOp.Create) {
     const resources = options.resources as CreateResourceOptions[];
-    serializedResources = resources.map((options: CreateResourceOptions) => serializeCreateResourceOptions(options));
+    serializedResources = resources.map((options: CreateResourceOptions) =>
+      serializeCreateResourceOptions(options),
+    );
   } else if (options.op === ResourceOp.Delete) {
     const resources = options.resources as DeleteResourceOptions[];
-    serializedResources = resources.map((options: DeleteResourceOptions) => serializeDeleteResourceOptions(options));
+    serializedResources = resources.map((options: DeleteResourceOptions) =>
+      serializeDeleteResourceOptions(options),
+    );
   }
 
   return {

--- a/src/fga/serializers/batch-write-resources-options.serializer.ts
+++ b/src/fga/serializers/batch-write-resources-options.serializer.ts
@@ -1,0 +1,29 @@
+import {
+  BatchWriteResourcesOptions,
+  CreateResourceOptions,
+  DeleteResourceOptions,
+  ResourceOp,
+  SerializedBatchWriteResourcesOptions,
+  SerializedCreateResourceOptions,
+  SerializedDeleteResourceOptions,
+} from '../interfaces';
+import { serializeCreateResourceOptions } from './create-resource-options.serializer';
+import { serializeDeleteResourceOptions } from './delete-resource-options.serializer';
+
+export const serializeBatchWriteResourcesOptions = (
+  options: BatchWriteResourcesOptions,
+): SerializedBatchWriteResourcesOptions => {
+  let serializedResources: SerializedCreateResourceOptions[] | SerializedDeleteResourceOptions[] = [];
+  if (options.op === ResourceOp.Create) {
+    const resources = options.resources as CreateResourceOptions[];
+    serializedResources = resources.map((options: CreateResourceOptions) => serializeCreateResourceOptions(options));
+  } else if (options.op === ResourceOp.Delete) {
+    const resources = options.resources as DeleteResourceOptions[];
+    serializedResources = resources.map((options: DeleteResourceOptions) => serializeDeleteResourceOptions(options));
+  }
+
+  return {
+    op: options.op,
+    resources: serializedResources,
+  };
+};

--- a/src/fga/serializers/index.ts
+++ b/src/fga/serializers/index.ts
@@ -1,4 +1,5 @@
 export * from './check-options.serializer';
+export * from './batch-write-resources-options.serializer';
 export * from './create-resource-options.serializer';
 export * from './delete-resource-options.serializer';
 export * from './list-resources-options.serializer';


### PR DESCRIPTION
## Description

- Adds a serializer for `BatchWriteResourcesOptions` to properly serialize options before making a request to `/fga/v1/resources/batch`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
