### PR TITLE
Update README.md import statement to match API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ WORKOS_API_KEY="sk_1234"
 Or, you can set it on your own before your application starts:
 
 ```ts
-import WorkOS from '@workos-inc/node';
+import { WorkOS } from '@workos-inc/node';
 
 const workos = new WorkOS('sk_1234');
 ```


### PR DESCRIPTION
## Description
Updates the README to match the package import shown here https://workos.com/docs/reference/api-keys:
![CleanShot 2024-09-13 at 09 35 52@2x](https://github.com/user-attachments/assets/71509301-e3fa-4949-94a0-efa4c5202107)


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
