### PR TITLE
Add network retries for FGA endpoints 

### DIFF
--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -208,10 +208,11 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
     headers?: RequestHeaders,
   ): Promise<HttpClientResponseInterface> {
     let response: HttpClientResponseInterface;
-    let requestError: any = null;
     let retryAttempts = 1;
 
     const makeRequest = async (): Promise<HttpClientResponseInterface> => {
+      let requestError: any = null;
+
       try {
         response = await this.fetchRequest(url, method, body, headers);
       } catch (e) {

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -45,7 +45,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (resourceURL.includes('fga/')) {
+    if (path.startsWith('/fga/')) {
       return await this.fetchRequestWithRetry(
         resourceURL,
         'GET',
@@ -68,7 +68,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (resourceURL.includes('fga/')) {
+    if (path.startsWith('/fga/')) {
       return await this.fetchRequestWithRetry(
         resourceURL,
         'POST',
@@ -102,7 +102,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (resourceURL.includes('fga/')) {
+    if (path.startsWith('/fga/')) {
       return await this.fetchRequestWithRetry(
         resourceURL,
         'PUT',
@@ -135,7 +135,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (resourceURL.includes('fga/')) {
+    if (path.startsWith('/fga/')) {
       return await this.fetchRequestWithRetry(
         resourceURL,
         'DELETE',

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -235,10 +235,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
     return makeRequest();
   }
 
-  private shouldRetryRequest(
-    requestError: any,
-    retryAttempt: number,
-  ): boolean {
+  private shouldRetryRequest(requestError: any, retryAttempt: number): boolean {
     if (retryAttempt > MAX_RETRY_ATTEMPTS) {
       return false;
     }
@@ -248,7 +245,10 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
         return true;
       }
 
-      if (requestError instanceof HttpClientError && RETRY_STATUS_CODES.includes(requestError.response.status)) {
+      if (
+        requestError instanceof HttpClientError &&
+        RETRY_STATUS_CODES.includes(requestError.response.status)
+      ) {
         return true;
       }
     }
@@ -267,7 +267,8 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
 // tslint:disable-next-line
 export class FetchHttpClientResponse
   extends HttpClientResponse
-  implements HttpClientResponseInterface {
+  implements HttpClientResponseInterface
+{
   _res: Response;
 
   constructor(res: Response) {

--- a/src/common/net/http-client.ts
+++ b/src/common/net/http-client.ts
@@ -9,7 +9,7 @@ import {
 export abstract class HttpClient implements HttpClientInterface {
   readonly MAX_RETRY_ATTEMPTS = 3;
   readonly BACKOFF_MULTIPLIER = 1.5;
-  readonly MINIMUM_SLEEP_TIME = 500;
+  readonly MINIMUM_SLEEP_TIME_IN_MILLISECONDS = 500;
   readonly RETRY_STATUS_CODES = [500, 502, 504];
 
   constructor(readonly baseURL: string, readonly options?: RequestInit) {}
@@ -88,16 +88,17 @@ export abstract class HttpClient implements HttpClientInterface {
     return JSON.stringify(entity);
   }
 
-  private getSleepTime(retryAttempt: number): number {
+  private getSleepTimeInMilliseconds(retryAttempt: number): number {
     const sleepTime =
-      this.MINIMUM_SLEEP_TIME * Math.pow(this.BACKOFF_MULTIPLIER, retryAttempt);
+      this.MINIMUM_SLEEP_TIME_IN_MILLISECONDS *
+      Math.pow(this.BACKOFF_MULTIPLIER, retryAttempt);
     const jitter = Math.random() + 0.5;
     return sleepTime * jitter;
   }
 
   sleep = (retryAttempt: number) =>
     new Promise((resolve) =>
-      setTimeout(resolve, this.getSleepTime(retryAttempt)),
+      setTimeout(resolve, this.getSleepTimeInMilliseconds(retryAttempt)),
     );
 }
 

--- a/src/common/net/http-client.ts
+++ b/src/common/net/http-client.ts
@@ -12,7 +12,7 @@ export abstract class HttpClient implements HttpClientInterface {
   readonly MINIMUM_SLEEP_TIME = 500;
   readonly RETRY_STATUS_CODES = [500, 502, 504];
 
-  constructor(readonly baseURL: string, readonly options?: RequestInit) { }
+  constructor(readonly baseURL: string, readonly options?: RequestInit) {}
 
   /** The HTTP client name used for diagnostics */
   getClientName(): string {
@@ -95,12 +95,16 @@ export abstract class HttpClient implements HttpClientInterface {
     return sleepTime * jitter;
   }
 
-  sleep = (retryAttempt: number) => new Promise((resolve) => setTimeout(resolve, this.getSleepTime(retryAttempt)));
+  sleep = (retryAttempt: number) =>
+    new Promise((resolve) =>
+      setTimeout(resolve, this.getSleepTime(retryAttempt)),
+    );
 }
 
 // tslint:disable-next-line
 export abstract class HttpClientResponse
-  implements HttpClientResponseInterface {
+  implements HttpClientResponseInterface
+{
   _statusCode: number;
   _headers: ResponseHeaders;
 

--- a/src/common/net/node-client.ts
+++ b/src/common/net/node-client.ts
@@ -322,7 +322,7 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
   }
 
   private getSleepTime(retryAttempt: number): number {
-    let sleepTime =
+    const sleepTime =
       MINIMUM_SLEEP_TIME * Math.pow(BACKOFF_MULTIPLIER, retryAttempt);
     const jitter = Math.random() + 0.5;
     return sleepTime * jitter;

--- a/src/common/net/node-client.ts
+++ b/src/common/net/node-client.ts
@@ -307,7 +307,10 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
       return false;
     }
 
-    if (response != null && this.RETRY_STATUS_CODES.includes(response.statusCode)) {
+    if (
+      response != null &&
+      this.RETRY_STATUS_CODES.includes(response.statusCode)
+    ) {
       return true;
     }
 

--- a/src/common/net/node-client.ts
+++ b/src/common/net/node-client.ts
@@ -332,7 +332,8 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
 // tslint:disable-next-line
 export class NodeHttpClientResponse
   extends HttpClientResponse
-  implements HttpClientResponseInterface {
+  implements HttpClientResponseInterface
+{
   _res: http_.IncomingMessage;
 
   constructor(res: http_.IncomingMessage) {

--- a/src/common/net/node-client.ts
+++ b/src/common/net/node-client.ts
@@ -62,7 +62,7 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (resourceURL.includes('fga/')) {
+    if (path.startsWith('/fga/')) {
       return await this.nodeRequestWithRetry(
         resourceURL,
         'GET',
@@ -85,7 +85,7 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (resourceURL.includes('fga/')) {
+    if (path.startsWith('/fga/')) {
       return await this.nodeRequestWithRetry(
         resourceURL,
         'POST',
@@ -119,7 +119,7 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (resourceURL.includes('fga/')) {
+    if (path.startsWith('/fga/')) {
       return await this.nodeRequestWithRetry(
         resourceURL,
         'PUT',
@@ -152,7 +152,7 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (resourceURL.includes('fga/')) {
+    if (path.startsWith('/fga/')) {
       return await this.nodeRequestWithRetry(
         resourceURL,
         'DELETE',

--- a/src/fga/fga.spec.ts
+++ b/src/fga/fga.spec.ts
@@ -9,6 +9,7 @@ import {
 
 import { WorkOS } from '../workos';
 import { ResourceOp, WarrantOp } from './interfaces';
+import { GenericServerException } from '../common/exceptions';
 
 const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
@@ -42,6 +43,68 @@ describe('FGA', () => {
         isImplicit: false,
       });
     });
+
+    it('makes check request after one retry', async () => {
+      fetchOnce(
+        {},
+        {
+          status: 500,
+        },
+      );
+      fetchOnce({
+        result: 'authorized',
+        is_implicit: false,
+      });
+      const checkResult = await workos.fga.check({
+        checks: [
+          {
+            resource: {
+              resourceType: 'role',
+              resourceId: 'admin',
+            },
+            relation: 'member',
+            subject: {
+              resourceType: 'user',
+              resourceId: 'user_123',
+            },
+          },
+        ],
+      });
+      expect(fetchURL()).toContain('/fga/v1/check');
+      expect(checkResult).toMatchObject({
+        result: 'authorized',
+        isImplicit: false,
+      });
+    });
+
+    it('fails check request after max retries', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          message: 'Internal Server Error',
+        }),
+        { status: 500 },
+      );
+
+      try {
+        await workos.fga.check({
+          checks: [
+            {
+              resource: {
+                resourceType: 'role',
+                resourceId: 'admin',
+              },
+              relation: 'member',
+              subject: {
+                resourceType: 'user',
+                resourceId: 'user_123',
+              },
+            },
+          ],
+        });
+      } catch (e) {
+        expect(e).toBeInstanceOf(GenericServerException);
+      }
+    }, 8000);
   });
 
   describe('createResource', () => {
@@ -62,6 +125,50 @@ describe('FGA', () => {
         resourceId: 'admin',
       });
     });
+
+    it('creates resource after one retry', async () => {
+      fetchOnce(
+        {},
+        {
+          status: 502,
+        },
+      );
+      fetchOnce({
+        resource_type: 'role',
+        resource_id: 'admin',
+      });
+      const resource = await workos.fga.createResource({
+        resource: {
+          resourceType: 'role',
+          resourceId: 'admin',
+        },
+      });
+      expect(fetchURL()).toContain('/fga/v1/resources');
+      expect(resource).toMatchObject({
+        resourceType: 'role',
+        resourceId: 'admin',
+      });
+    });
+
+    it('fails to creates resource after max retries', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          message: 'Internal Server Error',
+        }),
+        { status: 500 },
+      );
+
+      try {
+        await workos.fga.createResource({
+          resource: {
+            resourceType: 'role',
+            resourceId: 'admin',
+          },
+        });
+      } catch (e) {
+        expect(e).toBeInstanceOf(GenericServerException);
+      }
+    }, 8000);
 
     it('creates resource with metadata', async () => {
       fetchOnce({
@@ -107,6 +214,46 @@ describe('FGA', () => {
         resourceId: 'admin',
       });
     });
+
+    it('gets resource after one retry', async () => {
+      fetchOnce(
+        {},
+        {
+          status: 504,
+        },
+      );
+      fetchOnce({
+        resource_type: 'role',
+        resource_id: 'admin',
+      });
+      const resource = await workos.fga.getResource({
+        resourceType: 'role',
+        resourceId: 'admin',
+      });
+      expect(fetchURL()).toContain('/fga/v1/resources/role/admin');
+      expect(resource).toMatchObject({
+        resourceType: 'role',
+        resourceId: 'admin',
+      });
+    });
+
+    it('fails to get resource after max retries', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          message: 'Internal Server Error',
+        }),
+        { status: 500 },
+      );
+
+      try {
+        await workos.fga.getResource({
+          resourceType: 'role',
+          resourceId: 'admin',
+        });
+      } catch (e) {
+        expect(e).toBeInstanceOf(GenericServerException);
+      }
+    }, 8000);
   });
 
   describe('listResources', () => {
@@ -140,6 +287,64 @@ describe('FGA', () => {
         },
       ]);
     });
+
+    it('lists resources after two retries', async () => {
+      fetchOnce(
+        {},
+        {
+          status: 502,
+        },
+      );
+      fetchOnce(
+        {},
+        {
+          status: 500,
+        },
+      );
+      fetchOnce({
+        data: [
+          {
+            resource_type: 'role',
+            resource_id: 'admin',
+          },
+          {
+            resource_type: 'role',
+            resource_id: 'manager',
+          },
+        ],
+        list_metadata: {
+          before: null,
+          after: null,
+        },
+      });
+      const { data: resources } = await workos.fga.listResources();
+      expect(fetchURL()).toContain('/fga/v1/resources');
+      expect(resources).toMatchObject([
+        {
+          resourceType: 'role',
+          resourceId: 'admin',
+        },
+        {
+          resourceType: 'role',
+          resourceId: 'manager',
+        },
+      ]);
+    });
+
+    it('fails to list resources after max retries', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          message: 'Internal Server Error',
+        }),
+        { status: 500 },
+      );
+
+      try {
+        await workos.fga.listResources();
+      } catch (e) {
+        expect(e).toBeInstanceOf(GenericServerException);
+      }
+    }, 8000);
 
     it('sends correct params when filtering', async () => {
       fetchOnce({
@@ -179,6 +384,40 @@ describe('FGA', () => {
       expect(fetchURL()).toContain('/fga/v1/resources/role/admin');
       expect(response).toBeUndefined();
     });
+
+    it('should delete resource after one retry', async () => {
+      fetchOnce(
+        {},
+        {
+          status: 500,
+        },
+      );
+      fetchOnce();
+      const response = await workos.fga.deleteResource({
+        resourceType: 'role',
+        resourceId: 'admin',
+      });
+      expect(fetchURL()).toContain('/fga/v1/resources/role/admin');
+      expect(response).toBeUndefined();
+    });
+
+    it('fails to delete resource after max retries', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          message: 'Internal Server Error',
+        }),
+        { status: 500 },
+      );
+
+      try {
+        await workos.fga.deleteResource({
+          resourceType: 'role',
+          resourceId: 'admin',
+        });
+      } catch (e) {
+        expect(e).toBeInstanceOf(GenericServerException);
+      }
+    }, 8000);
   });
 
   describe('batchWriteResources', () => {
@@ -247,6 +486,118 @@ describe('FGA', () => {
         },
       ]);
     });
+
+    it('batch create resources after one retry', async () => {
+      fetchOnce(
+        {},
+        {
+          status: 500,
+        },
+      );
+      fetchOnce({
+        data: [
+          {
+            resource_type: 'role',
+            resource_id: 'admin',
+            meta: {
+              description: 'The admin role',
+            },
+          },
+          {
+            resource_type: 'role',
+            resource_id: 'manager',
+          },
+          {
+            resource_type: 'role',
+            resource_id: 'employee',
+          },
+        ],
+      });
+      const createdResources = await workos.fga.batchWriteResources({
+        op: ResourceOp.Create,
+        resources: [
+          {
+            resource: {
+              resourceType: 'role',
+              resourceId: 'admin',
+            },
+            meta: {
+              description: 'The admin role',
+            },
+          },
+          {
+            resource: {
+              resourceType: 'role',
+              resourceId: 'manager',
+            },
+          },
+          {
+            resource: {
+              resourceType: 'role',
+              resourceId: 'employee',
+            },
+          },
+        ],
+      });
+      expect(fetchURL()).toContain('/fga/v1/resources/batch');
+      expect(createdResources).toMatchObject([
+        {
+          resourceType: 'role',
+          resourceId: 'admin',
+          meta: {
+            description: 'The admin role',
+          },
+        },
+        {
+          resourceType: 'role',
+          resourceId: 'manager',
+        },
+        {
+          resourceType: 'role',
+          resourceId: 'employee',
+        },
+      ]);
+    });
+
+    it('fails to batch create resources after max retries', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          message: 'Internal Server Error',
+        }),
+        { status: 500 },
+      );
+
+      try {
+        await workos.fga.batchWriteResources({
+          op: ResourceOp.Create,
+          resources: [
+            {
+              resource: {
+                resourceType: 'role',
+                resourceId: 'admin',
+              },
+              meta: {
+                description: 'The admin role',
+              },
+            },
+            {
+              resource: {
+                resourceType: 'role',
+                resourceId: 'manager',
+              },
+            },
+            {
+              resource: {
+                resourceType: 'role',
+                resourceId: 'employee',
+              },
+            },
+          ],
+        });
+      } catch (e) {
+        expect(e).toBeInstanceOf(GenericServerException);
+      }
+    }, 8000);
 
     it('batch delete resources', async () => {
       fetchOnce({
@@ -372,6 +723,70 @@ describe('FGA', () => {
       });
     });
 
+    it('should create warrant after one retry', async () => {
+      fetchOnce(
+        {},
+        {
+          status: 500,
+        },
+      );
+      fetchOnce({
+        warrant_token: 'some_token',
+      });
+      const warrantToken = await workos.fga.writeWarrant({
+        op: WarrantOp.Create,
+        resource: {
+          resourceType: 'role',
+          resourceId: 'admin',
+        },
+        relation: 'member',
+        subject: {
+          resourceType: 'user',
+          resourceId: 'user_123',
+        },
+      });
+      expect(fetchURL()).toContain('/fga/v1/warrants');
+      expect(fetchBody()).toEqual({
+        op: 'create',
+        resource_type: 'role',
+        resource_id: 'admin',
+        relation: 'member',
+        subject: {
+          resource_type: 'user',
+          resource_id: 'user_123',
+        },
+      });
+      expect(warrantToken).toMatchObject({
+        warrantToken: 'some_token',
+      });
+    });
+
+    it('fails to create warrant after max retries', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          message: 'Internal Server Error',
+        }),
+        { status: 500 },
+      );
+
+      try {
+        await workos.fga.writeWarrant({
+          op: WarrantOp.Create,
+          resource: {
+            resourceType: 'role',
+            resourceId: 'admin',
+          },
+          relation: 'member',
+          subject: {
+            resourceType: 'user',
+            resourceId: 'user_123',
+          },
+        });
+      } catch (e) {
+        expect(e).toBeInstanceOf(GenericServerException);
+      }
+    }, 8000);
+
     it('should delete warrant with delete op', async () => {
       fetchOnce({
         warrant_token: 'some_token',
@@ -483,6 +898,141 @@ describe('FGA', () => {
         warrantToken: 'some_token',
       });
     });
+
+    it('should batch write warrants after one retry', async () => {
+      fetchOnce(
+        {},
+        {
+          status: 500,
+        },
+      );
+      fetchOnce({
+        warrant_token: 'some_token',
+      });
+      const warrantToken = await workos.fga.batchWriteWarrants([
+        {
+          resource: {
+            resourceType: 'role',
+            resourceId: 'admin',
+          },
+          relation: 'member',
+          subject: {
+            resourceType: 'user',
+            resourceId: 'user_123',
+          },
+        },
+        {
+          op: WarrantOp.Create,
+          resource: {
+            resourceType: 'role',
+            resourceId: 'admin',
+          },
+          relation: 'member',
+          subject: {
+            resourceType: 'user',
+            resourceId: 'user_124',
+          },
+        },
+        {
+          op: WarrantOp.Delete,
+          resource: {
+            resourceType: 'role',
+            resourceId: 'admin',
+          },
+          relation: 'member',
+          subject: {
+            resourceType: 'user',
+            resourceId: 'user_125',
+          },
+        },
+      ]);
+      expect(fetchURL()).toContain('/fga/v1/warrants');
+      expect(fetchBody()).toEqual([
+        {
+          resource_type: 'role',
+          resource_id: 'admin',
+          relation: 'member',
+          subject: {
+            resource_type: 'user',
+            resource_id: 'user_123',
+          },
+        },
+        {
+          op: 'create',
+          resource_type: 'role',
+          resource_id: 'admin',
+          relation: 'member',
+          subject: {
+            resource_type: 'user',
+            resource_id: 'user_124',
+          },
+        },
+        {
+          op: 'delete',
+          resource_type: 'role',
+          resource_id: 'admin',
+          relation: 'member',
+          subject: {
+            resource_type: 'user',
+            resource_id: 'user_125',
+          },
+        },
+      ]);
+      expect(warrantToken).toMatchObject({
+        warrantToken: 'some_token',
+      });
+    });
+
+    it('fails to batch write warrants after max retries', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          message: 'Internal Server Error',
+        }),
+        { status: 500 },
+      );
+
+      try {
+        await workos.fga.batchWriteWarrants([
+          {
+            resource: {
+              resourceType: 'role',
+              resourceId: 'admin',
+            },
+            relation: 'member',
+            subject: {
+              resourceType: 'user',
+              resourceId: 'user_123',
+            },
+          },
+          {
+            op: WarrantOp.Create,
+            resource: {
+              resourceType: 'role',
+              resourceId: 'admin',
+            },
+            relation: 'member',
+            subject: {
+              resourceType: 'user',
+              resourceId: 'user_124',
+            },
+          },
+          {
+            op: WarrantOp.Delete,
+            resource: {
+              resourceType: 'role',
+              resourceId: 'admin',
+            },
+            relation: 'member',
+            subject: {
+              resourceType: 'user',
+              resourceId: 'user_125',
+            },
+          },
+        ]);
+      } catch (e) {
+        expect(e).toBeInstanceOf(GenericServerException);
+      }
+    }, 8000);
   });
 
   describe('listWarrants', () => {
@@ -538,6 +1088,80 @@ describe('FGA', () => {
         },
       ]);
     });
+
+    it('should list warrants after one retry', async () => {
+      fetchOnce(
+        {},
+        {
+          status: 500,
+        },
+      );
+      fetchOnce({
+        data: [
+          {
+            resource_type: 'role',
+            resource_id: 'admin',
+            relation: 'member',
+            subject: {
+              resource_type: 'user',
+              resource_id: 'user_123',
+            },
+          },
+          {
+            resource_type: 'role',
+            resource_id: 'admin',
+            relation: 'member',
+            subject: {
+              resource_type: 'user',
+              resource_id: 'user_124',
+            },
+            policy: 'region == "us"',
+          },
+        ],
+        list_metadata: {
+          before: null,
+          after: null,
+        },
+      });
+      const { data: warrants } = await workos.fga.listWarrants();
+      expect(fetchURL()).toContain('/fga/v1/warrants');
+      expect(warrants).toMatchObject([
+        {
+          resourceType: 'role',
+          resourceId: 'admin',
+          relation: 'member',
+          subject: {
+            resourceType: 'user',
+            resourceId: 'user_123',
+          },
+        },
+        {
+          resourceType: 'role',
+          resourceId: 'admin',
+          relation: 'member',
+          subject: {
+            resourceType: 'user',
+            resourceId: 'user_124',
+          },
+          policy: 'region == "us"',
+        },
+      ]);
+    });
+
+    it('fails to list warrants after max retries', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          message: 'Internal Server Error',
+        }),
+        { status: 500 },
+      );
+
+      try {
+        await workos.fga.listWarrants();
+      } catch (e) {
+        expect(e).toBeInstanceOf(GenericServerException);
+      }
+    }, 8000);
 
     it('sends correct params when filtering', async () => {
       fetchOnce({
@@ -615,6 +1239,74 @@ describe('FGA', () => {
         },
       ]);
     });
+
+    it('makes query request after one retry', async () => {
+      fetchOnce(
+        {},
+        {
+          status: 500,
+        },
+      );
+      fetchOnce({
+        data: [
+          {
+            resource_type: 'role',
+            resource_id: 'admin',
+            warrant: {
+              resource_type: 'role',
+              resource_id: 'admin',
+              relation: 'member',
+              subject: {
+                resource_type: 'user',
+                resource_id: 'user_123',
+              },
+            },
+            is_implicit: false,
+          },
+        ],
+        list_metadata: {
+          before: null,
+          after: null,
+        },
+      });
+      const { data: queryResults } = await workos.fga.query({
+        q: 'select role where user:user_123 is member',
+      });
+      expect(fetchURL()).toContain('/fga/v1/query');
+      expect(queryResults).toMatchObject([
+        {
+          resourceType: 'role',
+          resourceId: 'admin',
+          warrant: {
+            resourceType: 'role',
+            resourceId: 'admin',
+            relation: 'member',
+            subject: {
+              resourceType: 'user',
+              resourceId: 'user_123',
+            },
+          },
+          isImplicit: false,
+        },
+      ]);
+    });
+
+    it('fails to make query after max retries', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          message: 'Internal Server Error',
+        }),
+        { status: 500 },
+      );
+
+      try {
+        await workos.fga.query({
+          q: 'select role where user:user_123 is member',
+        });
+      } catch (e) {
+        expect(e).toBeInstanceOf(GenericServerException);
+      }
+    }, 8000);
 
     it('sends correct params and options', async () => {
       fetchOnce({


### PR DESCRIPTION
## Description

- Adds network retries for FGA endpoints to `FetchHttpClient`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
