### PR TITLE
Make emitWarning safe for workers

### DIFF
--- a/src/common/net/http-client.ts
+++ b/src/common/net/http-client.ts
@@ -9,7 +9,7 @@ import {
 export abstract class HttpClient implements HttpClientInterface {
   constructor(readonly baseURL: string, readonly options?: RequestInit) {}
 
-  /** The HTTP client name used for diagnotics */
+  /** The HTTP client name used for diagnostics */
   getClientName(): string {
     throw new Error('getClientName not implemented');
   }

--- a/src/index.worker.ts
+++ b/src/index.worker.ts
@@ -44,6 +44,12 @@ class WorkOSWorker extends WorkOS {
   createIronSessionProvider(): IronSessionProvider {
     return new EdgeIronSessionProvider();
   }
+
+  /** @override */
+  emitWarning(warning: string): void {
+    // tslint:disable-next-line:no-console
+    return console.warn(`WorkOS: ${warning}`);
+  }
 }
 
 export { WorkOSWorker as WorkOS };

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -351,5 +351,25 @@ describe('WorkOS', () => {
         SubtleCryptoProvider,
       );
     });
+
+    it('uses console.warn to emit warnings', () => {
+      const workos = new WorkOSWorker('sk_test_key');
+      const warnSpy = jest.spyOn(console, 'warn');
+
+      workos.emitWarning('foo');
+
+      expect(warnSpy).toHaveBeenCalledWith('WorkOS: foo');
+    });
+  });
+
+  describe('when in a node environment', () => {
+    it('uses process.emitWarning to emit warnings', () => {
+      const workos = new WorkOS('sk_test_key');
+      const warnSpy = jest.spyOn(process, 'emitWarning');
+
+      workos.emitWarning('foo');
+
+      expect(warnSpy).toHaveBeenCalledWith('foo', 'WorkOS');
+    });
   });
 });

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -227,12 +227,6 @@ export class WorkOS {
   }
 
   emitWarning(warning: string) {
-    // process might be undefined in some environments
-    if (typeof process?.emitWarning !== 'function') {
-      //  tslint:disable:no-console
-      return console.warn(`WorkOS: ${warning}`);
-    }
-
     return process.emitWarning(warning, 'WorkOS');
   }
 


### PR DESCRIPTION
## Description
If you currently try to build a next project that uses workos-node you get the following error:
```
./node_modules/@workos-inc/node/lib/workos.js
A Node.js API is used (process.emitWarning at line: 178) which is not supported in the Edge Runtime.
```

This is because despite the fact that we have an if/else statement checking for whether `process` exists, the Next build step just sees a call to `process.emitWarning` and spits out that error. This moves the definition of `emitWarning` to the worker index.ts to prevent that error.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
