### PR TITLE
Add `role` to profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yarn-error.log
 lib/
 package-lock.json
 .DS_Store
+yarn.lock

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -48,6 +48,9 @@ exports[`SSO SSO getProfileAndToken with all information provided sends a reques
     ],
     "last_name": "bar",
   },
+  "role": {
+    "slug": "admin",
+  },
 }
 `;
 
@@ -77,6 +80,9 @@ exports[`SSO SSO getProfileAndToken without a groups attribute sends a request t
     "email": "foo@test.com",
     "first_name": "foo",
     "last_name": "bar",
+  },
+  "role": {
+    "slug": "admin",
   },
 }
 `;

--- a/src/sso/interfaces/profile.interface.ts
+++ b/src/sso/interfaces/profile.interface.ts
@@ -1,3 +1,4 @@
+import { RoleResponse } from '../../roles/interfaces';
 import { ConnectionType } from './connection-type.enum';
 
 export interface Profile {
@@ -9,6 +10,7 @@ export interface Profile {
   email: string;
   firstName?: string;
   lastName?: string;
+  role?: RoleResponse;
   groups?: string[];
   rawAttributes?: { [key: string]: any };
 }
@@ -22,6 +24,7 @@ export interface ProfileResponse {
   email: string;
   first_name?: string;
   last_name?: string;
+  role?: RoleResponse;
   groups?: string[];
   raw_attributes?: { [key: string]: any };
 }

--- a/src/sso/serializers/profile.serializer.ts
+++ b/src/sso/serializers/profile.serializer.ts
@@ -9,6 +9,7 @@ export const deserializeProfile = (profile: ProfileResponse): Profile => ({
   email: profile.email,
   firstName: profile.first_name,
   lastName: profile.last_name,
+  role: profile.role,
   groups: profile.groups,
   rawAttributes: profile.raw_attributes,
 });

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -209,6 +209,9 @@ describe('SSO', () => {
               email: 'foo@test.com',
               first_name: 'foo',
               last_name: 'bar',
+              role: {
+                slug: 'admin',
+              },
               groups: ['Admins', 'Developers'],
               raw_attributes: {
                 email: 'foo@test.com',
@@ -247,6 +250,9 @@ describe('SSO', () => {
               email: 'foo@test.com',
               first_name: 'foo',
               last_name: 'bar',
+              role: {
+                slug: 'admin',
+              },
               raw_attributes: {
                 email: 'foo@test.com',
                 first_name: 'foo',
@@ -282,6 +288,9 @@ describe('SSO', () => {
           email: 'foo@test.com',
           first_name: 'foo',
           last_name: 'bar',
+          role: {
+            slug: 'admin',
+          },
           groups: ['Admins', 'Developers'],
           raw_attributes: {
             email: 'foo@test.com',


### PR DESCRIPTION
## Description

Adds `role` attribute to the profile object.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

[Docs PR](https://github.com/workos/workos/pull/31033)

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
