### PR TITLE
Remove emitWarning entirely so Vercel deployments work

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,11 @@ class WorkOSNode extends WorkOS {
   createIronSessionProvider(): IronSessionProvider {
     return new WebIronSessionProvider();
   }
+
+  /** @override */
+  emitWarning(warning: string): void {
+    return process.emitWarning(warning, 'WorkOS');
+  }
 }
 
 export { WorkOSNode as WorkOS };

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -227,7 +227,7 @@ export class WorkOS {
   }
 
   emitWarning(warning: string) {
-    return process.emitWarning(warning, 'WorkOS');
+    console.warn(`WorkOS: ${warning}`);
   }
 
   private handleHttpError({ path, error }: { path: string; error: unknown }) {

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -227,6 +227,7 @@ export class WorkOS {
   }
 
   emitWarning(warning: string) {
+    // tslint:disable-next-line:no-console
     console.warn(`WorkOS: ${warning}`);
   }
 


### PR DESCRIPTION
## Description
We previously made `emitWarning` a function which could be overridden to support JS runtimes that don't support `process.emitWarning`.  Unfortunately just having the method in the code (despite being overridden with a runtime safe alternative) isn't enough to prevent errors. This fixes that by switching to `console.warn` which should be supported everywhere.

Fixes https://github.com/workos/workos-node/issues/1138

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
