### PR TITLE
Audit logs create schema

### DIFF
--- a/src/audit-logs/audit-logs.ts
+++ b/src/audit-logs/audit-logs.ts
@@ -9,9 +9,17 @@ import {
   AuditLogExportResponse,
 } from './interfaces/audit-log-export.interface';
 import {
+  AuditLogSchema,
+  CreateAuditLogSchemaOptions,
+  CreateAuditLogSchemaRequestOptions,
+  CreateAuditLogSchemaResponse,
+} from './interfaces/create-audit-log-schema-options.interface';
+import {
   deserializeAuditLogExport,
   serializeAuditLogExportOptions,
   serializeCreateAuditLogEventOptions,
+  serializeCreateAuditLogSchemaOptions,
+  deserializeAuditLogSchema,
 } from './serializers';
 
 export class AuditLogs {
@@ -47,5 +55,18 @@ export class AuditLogs {
     );
 
     return deserializeAuditLogExport(data);
+  }
+
+  async createSchema(
+    schema: CreateAuditLogSchemaOptions,
+    options: CreateAuditLogSchemaRequestOptions = {},
+  ): Promise<AuditLogSchema> {
+    const { data } = await this.workos.post<CreateAuditLogSchemaResponse>(
+      `/audit_logs/actions/${schema.action}/schemas`,
+      serializeCreateAuditLogSchemaOptions(schema),
+      options,
+    );
+
+    return deserializeAuditLogSchema(data);
   }
 }

--- a/src/audit-logs/interfaces/create-audit-log-schema-options.interface.ts
+++ b/src/audit-logs/interfaces/create-audit-log-schema-options.interface.ts
@@ -1,0 +1,70 @@
+import { PostOptions } from '../../common/interfaces';
+
+export interface AuditLogSchema {
+  object: 'audit_log_schema';
+  version: number;
+  targets: AuditLogTargetSchema[];
+  actor: AuditLogActorSchema;
+  metadata: Record<string, string> | undefined;
+  createdAt: string;
+}
+
+export interface AuditLogActorSchema {
+  metadata: Record<string, string> | undefined;
+}
+
+export interface AuditLogTargetSchema {
+  type: string;
+  metadata?: Record<string, string> | undefined;
+}
+
+export interface CreateAuditLogSchemaOptions {
+  action: string;
+  targets: AuditLogTargetSchema[];
+  actor?: AuditLogActorSchema;
+  metadata?: Record<string, string>;
+}
+
+interface SerializedAuditLogTargetSchema {
+  type: string;
+  metadata?: {
+    type: 'object';
+    properties: Record<string, { type: string }>;
+  };
+}
+
+export interface SerializedCreateAuditLogSchemaOptions {
+  targets: SerializedAuditLogTargetSchema[];
+  actor?: {
+    metadata: {
+      type: 'object';
+      properties: Record<string, { type: string }> | undefined;
+    };
+  };
+  metadata?: {
+    type: 'object';
+    properties: Record<string, { type: string }> | undefined;
+  };
+}
+
+export interface CreateAuditLogSchemaResponse {
+  object: 'audit_log_schema';
+  version: number;
+  targets: SerializedAuditLogTargetSchema[];
+  actor: {
+    metadata: {
+      type: 'object';
+      properties: Record<string, { type: string }> | undefined;
+    };
+  };
+  metadata: {
+    type: 'object';
+    properties: Record<string, { type: string }> | undefined;
+  };
+  created_at: string;
+}
+
+export type CreateAuditLogSchemaRequestOptions = Pick<
+  PostOptions,
+  'idempotencyKey'
+>;

--- a/src/audit-logs/interfaces/create-audit-log-schema-options.interface.ts
+++ b/src/audit-logs/interfaces/create-audit-log-schema-options.interface.ts
@@ -14,7 +14,7 @@ export interface AuditLogSchema {
 }
 
 export interface AuditLogActorSchema {
-  metadata: Record<string, string | boolean | number> | undefined;
+  metadata: Record<string, string | boolean | number>;
 }
 
 export interface AuditLogTargetSchema {

--- a/src/audit-logs/interfaces/create-audit-log-schema-options.interface.ts
+++ b/src/audit-logs/interfaces/create-audit-log-schema-options.interface.ts
@@ -1,5 +1,9 @@
 import { PostOptions } from '../../common/interfaces';
 
+export type AuditLogSchemaMetadata =
+  | Record<string, { type: 'string' | 'boolean' | 'number' }>
+  | undefined;
+
 export interface AuditLogSchema {
   object: 'audit_log_schema';
   version: number;
@@ -38,12 +42,12 @@ export interface SerializedCreateAuditLogSchemaOptions {
   actor?: {
     metadata: {
       type: 'object';
-      properties: Record<string, { type: string }> | undefined;
+      properties: AuditLogSchemaMetadata;
     };
   };
   metadata?: {
     type: 'object';
-    properties: Record<string, { type: string }> | undefined;
+    properties: AuditLogSchemaMetadata;
   };
 }
 
@@ -54,12 +58,12 @@ export interface CreateAuditLogSchemaResponse {
   actor: {
     metadata: {
       type: 'object';
-      properties: Record<string, { type: string }> | undefined;
+      properties: AuditLogSchemaMetadata;
     };
   };
   metadata: {
     type: 'object';
-    properties: Record<string, { type: string }> | undefined;
+    properties: AuditLogSchemaMetadata;
   };
   created_at: string;
 }

--- a/src/audit-logs/interfaces/create-audit-log-schema-options.interface.ts
+++ b/src/audit-logs/interfaces/create-audit-log-schema-options.interface.ts
@@ -9,31 +9,31 @@ export interface AuditLogSchema {
   version: number;
   targets: AuditLogTargetSchema[];
   actor: AuditLogActorSchema;
-  metadata: Record<string, string> | undefined;
+  metadata: Record<string, string | boolean | number> | undefined;
   createdAt: string;
 }
 
 export interface AuditLogActorSchema {
-  metadata: Record<string, string> | undefined;
+  metadata: Record<string, string | boolean | number> | undefined;
 }
 
 export interface AuditLogTargetSchema {
   type: string;
-  metadata?: Record<string, string> | undefined;
+  metadata?: Record<string, string | boolean | number> | undefined;
 }
 
 export interface CreateAuditLogSchemaOptions {
   action: string;
   targets: AuditLogTargetSchema[];
   actor?: AuditLogActorSchema;
-  metadata?: Record<string, string>;
+  metadata?: Record<string, string | boolean | number>;
 }
 
 interface SerializedAuditLogTargetSchema {
   type: string;
   metadata?: {
     type: 'object';
-    properties: Record<string, { type: string }>;
+    properties: AuditLogSchemaMetadata;
   };
 }
 

--- a/src/audit-logs/interfaces/index.ts
+++ b/src/audit-logs/interfaces/index.ts
@@ -1,3 +1,4 @@
 export * from './audit-log-export-options.interface';
 export * from './audit-log-export.interface';
 export * from './create-audit-log-event-options.interface';
+export * from './create-audit-log-schema-options.interface';

--- a/src/audit-logs/serializers/create-audit-log-schema-options.serializer.ts
+++ b/src/audit-logs/serializers/create-audit-log-schema-options.serializer.ts
@@ -4,7 +4,7 @@ import {
   SerializedCreateAuditLogSchemaOptions,
 } from '../interfaces';
 
-function serializeMetadata(metadata: Record<string, string> | undefined) {
+function serializeMetadata(metadata: Record<string, string | number | boolean> | undefined) {
   if (!metadata) {
     return {};
   }

--- a/src/audit-logs/serializers/create-audit-log-schema-options.serializer.ts
+++ b/src/audit-logs/serializers/create-audit-log-schema-options.serializer.ts
@@ -1,4 +1,5 @@
 import {
+  AuditLogSchemaMetadata,
   CreateAuditLogSchemaOptions,
   SerializedCreateAuditLogSchemaOptions,
 } from '../interfaces';
@@ -8,11 +9,11 @@ function serializeMetadata(metadata: Record<string, string> | undefined) {
     return {};
   }
 
-  const serializedMetadata: Record<string, { type: string }> = {};
+  const serializedMetadata: AuditLogSchemaMetadata = {};
 
   Object.keys(metadata).forEach((key) => {
     serializedMetadata[key] = {
-      type: metadata[key],
+      type: metadata[key] as 'string' | 'number' | 'boolean',
     };
   });
 

--- a/src/audit-logs/serializers/create-audit-log-schema-options.serializer.ts
+++ b/src/audit-logs/serializers/create-audit-log-schema-options.serializer.ts
@@ -4,7 +4,9 @@ import {
   SerializedCreateAuditLogSchemaOptions,
 } from '../interfaces';
 
-function serializeMetadata(metadata: Record<string, string | number | boolean> | undefined) {
+function serializeMetadata(
+  metadata: Record<string, string | number | boolean> | undefined,
+) {
   if (!metadata) {
     return {};
   }

--- a/src/audit-logs/serializers/create-audit-log-schema-options.serializer.ts
+++ b/src/audit-logs/serializers/create-audit-log-schema-options.serializer.ts
@@ -1,0 +1,46 @@
+import {
+  CreateAuditLogSchemaOptions,
+  SerializedCreateAuditLogSchemaOptions,
+} from '../interfaces';
+
+function serializeMetadata(metadata: Record<string, string> | undefined) {
+  if (!metadata) {
+    return {};
+  }
+
+  const serializedMetadata: Record<string, { type: string }> = {};
+
+  Object.keys(metadata).forEach((key) => {
+    serializedMetadata[key] = {
+      type: metadata[key],
+    };
+  });
+
+  return serializedMetadata;
+}
+
+export const serializeCreateAuditLogSchemaOptions = (
+  schema: CreateAuditLogSchemaOptions,
+): SerializedCreateAuditLogSchemaOptions => ({
+  actor: {
+    metadata: {
+      type: 'object',
+      properties: serializeMetadata(schema.actor?.metadata),
+    },
+  },
+  targets: schema.targets.map((target) => {
+    return {
+      type: target.type,
+      metadata: target.metadata
+        ? {
+            type: 'object',
+            properties: serializeMetadata(target.metadata),
+          }
+        : undefined,
+    };
+  }),
+  metadata: {
+    type: 'object',
+    properties: serializeMetadata(schema.metadata),
+  },
+});

--- a/src/audit-logs/serializers/create-audit-log-schema.serializer.ts
+++ b/src/audit-logs/serializers/create-audit-log-schema.serializer.ts
@@ -1,0 +1,39 @@
+import { AuditLogSchema, CreateAuditLogSchemaResponse } from '../interfaces';
+
+function deserializeMetadata(metadata: {
+  properties?: Record<string, { type: string }>;
+}): Record<string, string> {
+  if (!metadata || !metadata.properties) {
+    return {};
+  }
+
+  const deserializedMetadata: Record<string, string> = {};
+
+  Object.keys(metadata.properties).forEach((key) => {
+    if (metadata.properties) {
+      deserializedMetadata[key] = metadata.properties[key].type;
+    }
+  });
+
+  return deserializedMetadata;
+}
+
+export const deserializeAuditLogSchema = (
+  auditLogSchema: CreateAuditLogSchemaResponse,
+): AuditLogSchema => ({
+  object: auditLogSchema.object,
+  version: auditLogSchema.version,
+  targets: auditLogSchema.targets.map((target) => {
+    return {
+      type: target.type,
+      metadata: target.metadata
+        ? deserializeMetadata(target.metadata)
+        : undefined,
+    };
+  }),
+  actor: {
+    metadata: deserializeMetadata(auditLogSchema.actor?.metadata),
+  },
+  metadata: deserializeMetadata(auditLogSchema.metadata),
+  createdAt: auditLogSchema.created_at,
+});

--- a/src/audit-logs/serializers/create-audit-log-schema.serializer.ts
+++ b/src/audit-logs/serializers/create-audit-log-schema.serializer.ts
@@ -1,13 +1,13 @@
 import { AuditLogSchema, CreateAuditLogSchemaResponse } from '../interfaces';
 
 function deserializeMetadata(metadata: {
-  properties?: Record<string, { type: string }>;
+  properties?: Record<string, { type: string | number | boolean, nullable: boolean }>;
 }): Record<string, string> {
   if (!metadata || !metadata.properties) {
     return {};
   }
 
-  const deserializedMetadata: Record<string, string> = {};
+  const deserializedMetadata: Record<string, string | number | boolean> = {};
 
   Object.keys(metadata.properties).forEach((key) => {
     if (metadata.properties) {

--- a/src/audit-logs/serializers/create-audit-log-schema.serializer.ts
+++ b/src/audit-logs/serializers/create-audit-log-schema.serializer.ts
@@ -1,8 +1,8 @@
 import { AuditLogSchema, CreateAuditLogSchemaResponse } from '../interfaces';
 
 function deserializeMetadata(metadata: {
-  properties?: Record<string, { type: string | number | boolean, nullable: boolean }>;
-}): Record<string, string> {
+  properties?: Record<string, { type: string | number | boolean }>;
+}): Record<string, string | number | boolean> {
   if (!metadata || !metadata.properties) {
     return {};
   }

--- a/src/audit-logs/serializers/index.ts
+++ b/src/audit-logs/serializers/index.ts
@@ -1,3 +1,5 @@
 export * from './audit-log-export.serializer';
 export * from './audit-log-export-options.serializer';
 export * from './create-audit-log-event-options.serializer';
+export * from './create-audit-log-schema-options.serializer';
+export * from './create-audit-log-schema.serializer';


### PR DESCRIPTION
## Description
Adds a `createSchema` method. Example use:

```ts
const schema = await workos.auditLogs.createSchema({
  action: 'user.deleted',
  actor: {
    metadata: {
      actor_id: 'string',
    },
  },
  targets: [
    {
      type: 'user',
      metadata: {
        user_id: 'string',
      },
    },
  ],
  metadata: {
    foo: 'number',
    baz: 'boolean',
  },
});

console.log('schema created:', schema);
```

The above logs:
```ts
schema created: {
  object: 'audit_log_schema',
  version: 1,
  targets: [ { type: 'user', metadata: [Object] } ],
  actor: { metadata: { actor_id: 'string' } },
  metadata: { baz: 'boolean', foo: 'number' },
  createdAt: '2024-10-14T15:09:44.537Z'
}
```

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
