### PR TITLE
Fix organization domain interface

### DIFF
--- a/src/organization-domains/interfaces/organization-domain.interface.ts
+++ b/src/organization-domains/interfaces/organization-domain.interface.ts
@@ -18,7 +18,7 @@ export interface OrganizationDomain {
   id: string;
   domain: string;
   state: OrganizationDomainState;
-  verificationToken: string;
+  verificationToken?: string;
   verificationStrategy: OrganizationDomainVerificationStrategy;
 }
 
@@ -27,6 +27,6 @@ export interface OrganizationDomainResponse {
   id: string;
   domain: string;
   state: OrganizationDomainState;
-  verification_token: string;
+  verification_token?: string;
   verification_strategy: OrganizationDomainVerificationStrategy;
 }

--- a/src/organizations/fixtures/get-organization.json
+++ b/src/organizations/fixtures/get-organization.json
@@ -7,7 +7,10 @@
     {
       "domain": "example.com",
       "object": "organization_domain",
-      "id": "org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8"
+      "id": "org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8",
+      "state": "verified",
+      "verification_strategy": "dns",
+      "verification_token": "xB8SeACdKJQP9DP4CahU4YuQZ"
     }
   ]
 }

--- a/src/organizations/interfaces/organization.interface.ts
+++ b/src/organizations/interfaces/organization.interface.ts
@@ -1,4 +1,7 @@
-import { OrganizationDomain } from '../../organization-domains/interfaces/organization-domain.interface';
+import {
+  OrganizationDomain,
+  OrganizationDomainResponse,
+} from '../../organization-domains/interfaces/organization-domain.interface';
 
 export interface Organization {
   object: 'organization';
@@ -15,7 +18,7 @@ export interface OrganizationResponse {
   id: string;
   name: string;
   allow_profiles_outside_organization: boolean;
-  domains: OrganizationDomain[];
+  domains: OrganizationDomainResponse[];
   created_at: string;
   updated_at: string;
 }

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -223,7 +223,15 @@ describe('Organizations', () => {
       expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
       expect(subject.name).toEqual('Test Organization 3');
       expect(subject.allowProfilesOutsideOrganization).toEqual(false);
-      expect(subject.domains).toHaveLength(1);
+      expect(subject.domains).toEqual([
+        {
+          id: 'org_domain_01EHT88Z8J8795GZNQ4ZP1J81T',
+          domain: 'example.com',
+          state: 'verified',
+          verificationStrategy: 'dns',
+          verificationToken: '',
+        },
+      ]);
     });
   });
 

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -225,7 +225,7 @@ describe('Organizations', () => {
       expect(subject.allowProfilesOutsideOrganization).toEqual(false);
       expect(subject.domains).toEqual([
         {
-          id: 'org_domain_01EHT88Z8J8795GZNQ4ZP1J81T',
+          id: 'org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8',
           domain: 'example.com',
           state: 'verified',
           verificationStrategy: 'dns',

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -225,11 +225,12 @@ describe('Organizations', () => {
       expect(subject.allowProfilesOutsideOrganization).toEqual(false);
       expect(subject.domains).toEqual([
         {
+          object: 'organization_domain',
           id: 'org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8',
           domain: 'example.com',
           state: 'verified',
           verificationStrategy: 'dns',
-          verificationToken: '',
+          verificationToken: 'xB8SeACdKJQP9DP4CahU4YuQZ',
         },
       ]);
     });

--- a/src/organizations/serializers/organization.serializer.ts
+++ b/src/organizations/serializers/organization.serializer.ts
@@ -1,3 +1,4 @@
+import { deserializeOrganizationDomain } from '../../organization-domains/serializers/organization-domain.serializer';
 import { Organization, OrganizationResponse } from '../interfaces';
 
 export const deserializeOrganization = (
@@ -8,7 +9,7 @@ export const deserializeOrganization = (
   name: organization.name,
   allowProfilesOutsideOrganization:
     organization.allow_profiles_outside_organization,
-  domains: organization.domains,
+  domains: organization.domains.map(deserializeOrganizationDomain),
   createdAt: organization.created_at,
   updatedAt: organization.updated_at,
 });


### PR DESCRIPTION
## Description
* Makes `verificationToken` optional (it was always optional from the API's perspective)
* Correctly deserializes `verificationToken` and `verificationStrategy` when deserializing organizations

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
