### PR TITLE
Add entitlements to parsed access-token results

### DIFF
--- a/src/user-management/interfaces/authenticate-with-session-cookie.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-session-cookie.interface.ts
@@ -12,6 +12,7 @@ export interface AccessToken {
   org_id?: string;
   role?: string;
   permissions?: string[];
+  entitlements?: string[];
 }
 
 export type SessionCookieData = Pick<
@@ -36,6 +37,7 @@ export type AuthenticateWithSessionCookieSuccessResponse = {
   organizationId?: string;
   role?: string;
   permissions?: string[];
+  entitlements?: string[];
   user: User;
   impersonator?: Impersonator;
 };

--- a/src/user-management/session.spec.ts
+++ b/src/user-management/session.spec.ts
@@ -108,7 +108,7 @@ describe('Session', () => {
       const sessionData = await sealData(
         {
           accessToken:
-            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJpbXBlcnNvbmF0b3IiOnsiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSIsInJlYXNvbiI6InRlc3QifSwic2lkIjoic2Vzc2lvbl8xMjMiLCJvcmdfaWQiOiJvcmdfMTIzIiwicm9sZSI6Im1lbWJlciIsInBlcm1pc3Npb25zIjpbInBvc3RzOmNyZWF0ZSIsInBvc3RzOmRlbGV0ZSJdLCJlbnRpdGxlbWVudHMiOlsiYXVkaXQtbG9ncyJdLCJ1c2VyIjp7Im9iamVjdCI6InVzZXIiLCJpZCI6InVzZXJfMDFINUpRRFY3UjdBVEVZWkRFRzBXNVBSWVMiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20ifX0.A8mDST4wtq_0vId6ALg7k2Ukr7FXrszZtdJ_6dfXeAc',
           refreshToken: 'def456',
           impersonator: {
             email: 'admin@example.com',
@@ -138,6 +138,7 @@ describe('Session', () => {
         organizationId: 'org_123',
         role: 'member',
         permissions: ['posts:create', 'posts:delete'],
+        entitlements: ['audit-logs'],
         user: {
           object: 'user',
           id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -100,6 +100,7 @@ export class Session {
       org_id: organizationId,
       role,
       permissions,
+      entitlements,
     } = decodeJwt<AccessToken>(session.accessToken);
 
     return {
@@ -108,6 +109,7 @@ export class Session {
       organizationId,
       role,
       permissions,
+      entitlements,
       user: session.user,
       impersonator: session.impersonator,
     };

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -828,7 +828,7 @@ describe('UserManagement', () => {
       const sessionData = await sealData(
         {
           accessToken:
-            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJpbXBlcnNvbmF0b3IiOnsiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSIsInJlYXNvbiI6InRlc3QifSwic2lkIjoic2Vzc2lvbl8xMjMiLCJvcmdfaWQiOiJvcmdfMTIzIiwicm9sZSI6Im1lbWJlciIsInBlcm1pc3Npb25zIjpbInBvc3RzOmNyZWF0ZSIsInBvc3RzOmRlbGV0ZSJdLCJlbnRpdGxlbWVudHMiOlsiYXVkaXQtbG9ncyJdLCJ1c2VyIjp7Im9iamVjdCI6InVzZXIiLCJpZCI6InVzZXJfMDFINUpRRFY3UjdBVEVZWkRFRzBXNVBSWVMiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20ifX0.A8mDST4wtq_0vId6ALg7k2Ukr7FXrszZtdJ_6dfXeAc',
           refreshToken: 'def456',
           user: {
             object: 'user',
@@ -850,6 +850,7 @@ describe('UserManagement', () => {
         organizationId: 'org_123',
         role: 'member',
         permissions: ['posts:create', 'posts:delete'],
+        entitlements: ['audit-logs'],
         user: expect.objectContaining({
           email: 'test@example.com',
         }),

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -430,6 +430,7 @@ export class UserManagement {
       org_id: organizationId,
       role,
       permissions,
+      entitlements,
     } = decodeJwt<AccessToken>(session.accessToken);
 
     return {
@@ -439,6 +440,7 @@ export class UserManagement {
       role,
       user: session.user,
       permissions,
+      entitlements,
     };
   }
 


### PR DESCRIPTION
## Description

Pulls the entitlements claim out of the JWT if it's there.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
