### PR TITLE
Update TS target and provide better error messagins for http errors

### DIFF
--- a/src/workos.ts
+++ b/src/workos.ts
@@ -233,7 +233,7 @@ export class WorkOS {
 
   private handleHttpError({ path, error }: { path: string; error: unknown }) {
     if (!(error instanceof HttpClientError)) {
-      throw new Error(`Unexpected error: ${error}`);
+      throw new Error(`Unexpected error: ${error}`, { cause: error });
     }
 
     const { response } = error as HttpClientError<WorkOSResponseError>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "declaration": true,
     "outDir": "lib",
     "strict": true,
-    "lib": ["dom", "es2019"],
+    "lib": ["dom", "es2022"],
     "types": ["jest", "jest-environment-miniflare/globals"]
   },
   "include": ["src"]


### PR DESCRIPTION
## Description
Fixes https://github.com/workos/workos-node/issues/1149

Had to target a more recent version of ES to make TypeScript recognize the `options` argument of the [Error constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error).

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
