### PR TITLE
Reject non-retryable error in node http client

### DIFF
--- a/src/common/net/node-client.ts
+++ b/src/common/net/node-client.ts
@@ -290,6 +290,8 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
             await this.sleep(retryAttempts);
             return makeRequest().then(resolve).catch(reject);
           }
+
+          reject(new Error(err.message));
         });
 
         if (body) {


### PR DESCRIPTION
## Description

In the `NodeHttpClient`, `TypeError`s are considered retryable. However, if we get any other errors, we should reject with the given error.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
