### PR TITLE
Testing new iron-session package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
-    "iron-session": "~6.3.1",
+    "@types/cookie": "^0.6.0",
+    "iron-session": "~8.0.3",
     "jose": "~5.6.3",
     "pluralize": "8.0.0"
   },

--- a/src/common/iron-session/edge-iron-session-provider.ts
+++ b/src/common/iron-session/edge-iron-session-provider.ts
@@ -1,4 +1,4 @@
-import { sealData, unsealData } from 'iron-session/edge';
+import { sealData, unsealData } from 'iron-session';
 import {
   IronSessionProvider,
   SealDataOptions,


### PR DESCRIPTION
## Description

Related to https://github.com/workos/workos-node/issues/1130

Passes all tests, however finding errors on building the final package (using current projects typescript version). As iron-session built package specifies one of their types to be a generic. 

```
node_modules/.pnpm/iron-session@8.0.3/node_modules/iron-session/dist/index.d.cts:112:77 - error TS2315: Type 'ServerResponse' is not generic.

112     <T extends object>(req: http.IncomingMessage | Request, res: Response | http.ServerResponse<http.IncomingMessage>, sessionOptions: SessionOptions): Promise<IronSession<T>>;
                                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I did manually remove the offending type from the created file, built/packaged/released on my account: https://www.npmjs.com/package/@fforres/workos-inc-node and from my tests on a monorepo, seems to be working.

If this helps moving


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
