### PR TITLE
feat: Add actions support

### DIFF
--- a/src/actions/actions.spec.ts
+++ b/src/actions/actions.spec.ts
@@ -1,0 +1,100 @@
+import crypto from 'crypto';
+import { WorkOS } from '../workos';
+import mockActionContext from './fixtures/action-context.json';
+const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+import { NodeCryptoProvider } from '../common/crypto';
+
+describe('Actions', () => {
+  let secret: string;
+
+  beforeEach(() => {
+    secret = 'secret';
+  });
+
+  describe('signResponse', () => {
+    describe('type: authentication', () => {
+      it('returns a signed response', async () => {
+        const nodeCryptoProvider = new NodeCryptoProvider();
+
+        const response = await workos.actions.signResponse(
+          {
+            type: 'authentication',
+            verdict: 'Allow',
+          },
+          secret,
+        );
+
+        const signedPayload = `${response.payload.timestamp}.${JSON.stringify(
+          response.payload,
+        )}`;
+
+        const expectedSig = await nodeCryptoProvider.computeHMACSignatureAsync(
+          signedPayload,
+          secret,
+        );
+
+        expect(response.object).toEqual('authentication_action_response');
+        expect(response.payload.verdict).toEqual('Allow');
+        expect(response.payload.timestamp).toBeGreaterThan(0);
+        expect(response.signature).toEqual(expectedSig);
+      });
+    });
+
+    describe('type: user_registration', () => {
+      it('returns a signed response', async () => {
+        const nodeCryptoProvider = new NodeCryptoProvider();
+
+        const response = await workos.actions.signResponse(
+          {
+            type: 'user_registration',
+            verdict: 'Deny',
+            errorMessage: 'User already exists',
+          },
+          secret,
+        );
+
+        const signedPayload = `${response.payload.timestamp}.${JSON.stringify(
+          response.payload,
+        )}`;
+
+        const expectedSig = await nodeCryptoProvider.computeHMACSignatureAsync(
+          signedPayload,
+          secret,
+        );
+
+        expect(response.object).toEqual('user_registration_action_response');
+        expect(response.payload.verdict).toEqual('Deny');
+        expect(response.payload.timestamp).toBeGreaterThan(0);
+        expect(response.signature).toEqual(expectedSig);
+      });
+    });
+  });
+
+  describe('verifyHeader', () => {
+    it('aliases to the signature provider', async () => {
+      const spy = jest.spyOn(
+        // tslint:disable-next-line
+        workos.actions['signatureProvider'],
+        'verifyHeader',
+      );
+
+      const timestamp = Date.now() * 1000;
+      const unhashedString = `${timestamp}.${JSON.stringify(
+        mockActionContext,
+      )}`;
+      const signatureHash = crypto
+        .createHmac('sha256', secret)
+        .update(unhashedString)
+        .digest()
+        .toString('hex');
+
+      await workos.actions.verifyHeader({
+        payload: mockActionContext,
+        sigHeader: `t=${timestamp}, v1=${signatureHash}`,
+        secret,
+      });
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1,0 +1,70 @@
+import { SignatureProvider } from '../common/crypto';
+import { CryptoProvider } from '../common/crypto/crypto-provider';
+import { unreachable } from '../common/utils/unreachable';
+import {
+  AuthenticationActionResponseData,
+  ResponsePayload,
+  UserRegistrationActionResponseData,
+} from './interfaces/response-payload';
+
+export class Actions {
+  private signatureProvider: SignatureProvider;
+
+  constructor(cryptoProvider: CryptoProvider) {
+    this.signatureProvider = new SignatureProvider(cryptoProvider);
+  }
+
+  private get computeSignature() {
+    return this.signatureProvider.computeSignature.bind(this.signatureProvider);
+  }
+
+  get verifyHeader() {
+    return this.signatureProvider.verifyHeader.bind(this.signatureProvider);
+  }
+
+  serializeType(
+    type:
+      | AuthenticationActionResponseData['type']
+      | UserRegistrationActionResponseData['type'],
+  ) {
+    switch (type) {
+      case 'authentication':
+        return 'authentication_action_response';
+      case 'user_registration':
+        return 'user_registration_action_response';
+      default:
+        return unreachable(type);
+    }
+  }
+
+  async signResponse(
+    data: AuthenticationActionResponseData | UserRegistrationActionResponseData,
+    secret: string,
+  ) {
+    let errorMessage: string | undefined;
+    const { verdict, type } = data;
+
+    if (verdict === 'Deny' && data.errorMessage) {
+      errorMessage = data.errorMessage;
+    }
+
+    const responsePayload: ResponsePayload = {
+      timestamp: Date.now(),
+      verdict,
+      ...(verdict === 'Deny' &&
+        data.errorMessage && { error_message: errorMessage }),
+    };
+
+    const response = {
+      object: this.serializeType(type),
+      payload: responsePayload,
+      signature: await this.computeSignature(
+        responsePayload.timestamp,
+        responsePayload,
+        secret,
+      ),
+    };
+
+    return response;
+  }
+}

--- a/src/actions/fixtures/action-context.json
+++ b/src/actions/fixtures/action-context.json
@@ -1,0 +1,39 @@
+{
+    "user": {
+        "object": "user",
+        "id": "01JATCHZVEC5EPANDPEZVM68Y9",
+        "email": "jane@foocorp.com",
+        "first_name": "Jane",
+        "last_name": "Doe",
+        "email_verified": true,
+        "profile_picture_url": "https://example.com/jane.jpg",
+        "created_at": "2024-10-22T17:12:50.746Z",
+        "updated_at": "2024-10-22T17:12:50.746Z"
+    },
+    "ip_address": "50.141.123.10",
+    "user_agent": "Mozilla/5.0",
+    "issuer": "test",
+    "object": "authentication_action_context",
+    "organization": {
+        "object": "organization",
+        "id": "01JATCMZJY26PQ59XT9BNT0FNN",
+        "name": "Foo Corp",
+        "allow_profiles_outside_organization": false,
+        "domains": [],
+        "lookup_key": "my-key",
+        "created_at": "2024-10-22T17:12:50.746Z",
+        "updated_at": "2024-10-22T17:12:50.746Z"
+    },
+    "organization_membership": {
+        "object": "organization_membership",
+        "id": "01JATCNVYCHT1SZGENR4QTXKRK",
+        "user_id": "01JATCHZVEC5EPANDPEZVM68Y9",
+        "organization_id": "01JATCMZJY26PQ59XT9BNT0FNN",
+        "role": {
+            "slug": "member"
+        },
+        "status": "active",
+        "created_at": "2024-10-22T17:12:50.746Z",
+        "updated_at": "2024-10-22T17:12:50.746Z"
+    }
+}

--- a/src/actions/interfaces/response-payload.ts
+++ b/src/actions/interfaces/response-payload.ts
@@ -1,0 +1,22 @@
+export interface ResponsePayload {
+  timestamp: number;
+  verdict?: 'Allow' | 'Deny';
+  errorMessage?: string;
+}
+
+interface AllowResponseData {
+  verdict: 'Allow';
+}
+
+interface DenyResponseData {
+  verdict: 'Deny';
+  errorMessage?: string;
+}
+
+export type AuthenticationActionResponseData =
+  | (AllowResponseData & { type: 'authentication' })
+  | (DenyResponseData & { type: 'authentication' });
+
+export type UserRegistrationActionResponseData =
+  | (AllowResponseData & { type: 'user_registration' })
+  | (DenyResponseData & { type: 'user_registration' });

--- a/src/common/crypto/CryptoProvider.spec.ts
+++ b/src/common/crypto/CryptoProvider.spec.ts
@@ -1,0 +1,68 @@
+import crypto from 'crypto';
+import { NodeCryptoProvider } from './NodeCryptoProvider';
+import { SubtleCryptoProvider } from './SubtleCryptoProvider';
+import mockWebhook from '../../webhooks/fixtures/webhook.json';
+import { SignatureProvider } from './SignatureProvider';
+
+describe('CryptoProvider', () => {
+  let payload: any;
+  let secret: string;
+  let timestamp: number;
+  let signatureHash: string;
+
+  beforeEach(() => {
+    payload = mockWebhook;
+    secret = 'secret';
+    timestamp = Date.now() * 1000;
+    const unhashedString = `${timestamp}.${JSON.stringify(payload)}`;
+    signatureHash = crypto
+      .createHmac('sha256', secret)
+      .update(unhashedString)
+      .digest()
+      .toString('hex');
+  });
+
+  describe('when computing HMAC signature', () => {
+    it('returns the same for the Node crypto and Web Crypto versions', async () => {
+      const nodeCryptoProvider = new NodeCryptoProvider();
+      const subtleCryptoProvider = new SubtleCryptoProvider();
+
+      const stringifiedPayload = JSON.stringify(payload);
+      const payloadHMAC = `${timestamp}.${stringifiedPayload}`;
+
+      const nodeCompare = await nodeCryptoProvider.computeHMACSignatureAsync(
+        payloadHMAC,
+        secret,
+      );
+      const subtleCompare =
+        await subtleCryptoProvider.computeHMACSignatureAsync(
+          payloadHMAC,
+          secret,
+        );
+
+      expect(nodeCompare).toEqual(subtleCompare);
+    });
+  });
+
+  describe('when securely comparing', () => {
+    it('returns the same for the Node crypto and Web Crypto versions', async () => {
+      const nodeCryptoProvider = new NodeCryptoProvider();
+      const subtleCryptoProvider = new SubtleCryptoProvider();
+      const signatureProvider = new SignatureProvider(subtleCryptoProvider);
+
+      const signature = await signatureProvider.computeSignature(
+        timestamp,
+        payload,
+        secret,
+      );
+
+      expect(
+        nodeCryptoProvider.secureCompare(signature, signatureHash),
+      ).toEqual(subtleCryptoProvider.secureCompare(signature, signatureHash));
+
+      expect(nodeCryptoProvider.secureCompare(signature, 'foo')).toEqual(
+        subtleCryptoProvider.secureCompare(signature, 'foo'),
+      );
+    });
+  });
+});

--- a/src/common/crypto/SignatureProvider.spec.ts
+++ b/src/common/crypto/SignatureProvider.spec.ts
@@ -1,0 +1,67 @@
+import crypto from 'crypto';
+import { SubtleCryptoProvider } from './SubtleCryptoProvider';
+import mockWebhook from '../../webhooks/fixtures/webhook.json';
+import { SignatureProvider } from './SignatureProvider';
+
+describe('SignatureProvider', () => {
+  let payload: any;
+  let secret: string;
+  let timestamp: number;
+  let signatureHash: string;
+  const signatureProvider = new SignatureProvider(new SubtleCryptoProvider());
+
+  beforeEach(() => {
+    payload = mockWebhook;
+    secret = 'secret';
+    timestamp = Date.now() * 1000;
+    const unhashedString = `${timestamp}.${JSON.stringify(payload)}`;
+    signatureHash = crypto
+      .createHmac('sha256', secret)
+      .update(unhashedString)
+      .digest()
+      .toString('hex');
+  });
+
+  describe('verifyHeader', () => {
+    it('returns true when the signature is valid', async () => {
+      const sigHeader = `t=${timestamp}, v1=${signatureHash}`;
+      const options = { payload, sigHeader, secret };
+      const result = await signatureProvider.verifyHeader(options);
+      expect(result).toBeTruthy();
+    });
+  });
+
+  describe('getTimestampAndSignatureHash', () => {
+    it('returns the timestamp and signature when the signature is valid', () => {
+      const sigHeader = `t=${timestamp}, v1=${signatureHash}`;
+      const timestampAndSignature =
+        signatureProvider.getTimestampAndSignatureHash(sigHeader);
+
+      expect(timestampAndSignature).toEqual([
+        timestamp.toString(),
+        signatureHash,
+      ]);
+    });
+  });
+
+  describe('computeSignature', () => {
+    it('returns the computed signature', async () => {
+      const signature = await signatureProvider.computeSignature(
+        timestamp,
+        payload,
+        secret,
+      );
+
+      expect(signature).toEqual(signatureHash);
+    });
+  });
+
+  describe('when in an environment that supports SubtleCrypto', () => {
+    it('automatically uses the subtle crypto library', () => {
+      // tslint:disable-next-line
+      expect(signatureProvider['cryptoProvider']).toBeInstanceOf(
+        SubtleCryptoProvider,
+      );
+    });
+  });
+});

--- a/src/common/crypto/SignatureProvider.ts
+++ b/src/common/crypto/SignatureProvider.ts
@@ -1,0 +1,76 @@
+import { SignatureVerificationException } from '../exceptions';
+import { CryptoProvider } from './CryptoProvider';
+
+export class SignatureProvider {
+  private cryptoProvider: CryptoProvider;
+
+  constructor(cryptoProvider: CryptoProvider) {
+    this.cryptoProvider = cryptoProvider;
+  }
+
+  async verifyHeader({
+    payload,
+    sigHeader,
+    secret,
+    tolerance = 180000,
+  }: {
+    payload: any;
+    sigHeader: string;
+    secret: string;
+    tolerance?: number;
+  }): Promise<boolean> {
+    const [timestamp, signatureHash] =
+      this.getTimestampAndSignatureHash(sigHeader);
+
+    if (!signatureHash || Object.keys(signatureHash).length === 0) {
+      throw new SignatureVerificationException(
+        'No signature hash found with expected scheme v1',
+      );
+    }
+
+    if (parseInt(timestamp, 10) < Date.now() - tolerance) {
+      throw new SignatureVerificationException(
+        'Timestamp outside the tolerance zone',
+      );
+    }
+
+    const expectedSig = await this.computeSignature(timestamp, payload, secret);
+    if (
+      (await this.cryptoProvider.secureCompare(expectedSig, signatureHash)) ===
+      false
+    ) {
+      throw new SignatureVerificationException(
+        'Signature hash does not match the expected signature hash for payload',
+      );
+    }
+    return true;
+  }
+
+  getTimestampAndSignatureHash(sigHeader: string): [string, string] {
+    const signature = sigHeader;
+    const [t, v1] = signature.split(',');
+    if (typeof t === 'undefined' || typeof v1 === 'undefined') {
+      throw new SignatureVerificationException(
+        'Signature or timestamp missing',
+      );
+    }
+    const { 1: timestamp } = t.split('=');
+    const { 1: signatureHash } = v1.split('=');
+
+    return [timestamp, signatureHash];
+  }
+
+  async computeSignature(
+    timestamp: any,
+    payload: any,
+    secret: string,
+  ): Promise<string> {
+    payload = JSON.stringify(payload);
+    const signedPayload = `${timestamp}.${payload}`;
+
+    return await this.cryptoProvider.computeHMACSignatureAsync(
+      signedPayload,
+      secret,
+    );
+  }
+}

--- a/src/common/crypto/index.ts
+++ b/src/common/crypto/index.ts
@@ -1,3 +1,4 @@
 export * from './NodeCryptoProvider';
 export * from './SubtleCryptoProvider';
 export * from './CryptoProvider';
+export * from './SignatureProvider';

--- a/src/common/utils/unreachable.ts
+++ b/src/common/utils/unreachable.ts
@@ -1,0 +1,16 @@
+/**
+ * Indicates that code is unreachable.
+ *
+ * This can be used for exhaustiveness checks in situations where the compiler
+ * would not otherwise check for exhaustiveness.
+ *
+ * If the determination that the code is unreachable proves incorrect, an
+ * exception is thrown.
+ */
+export const unreachable = (
+  condition: never,
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+  message = `Entered unreachable code. Received '${condition}'.`,
+): never => {
+  throw new TypeError(message);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { HttpClient } from './common/net/http-client';
 import { FetchHttpClient } from './common/net/fetch-client';
 import { NodeHttpClient } from './common/net/node-client';
 
+import { Actions } from './actions/actions';
 import { Webhooks } from './webhooks/webhooks';
 import { WorkOS } from './workos';
 import { WorkOSOptions } from './common/interfaces';
@@ -60,6 +61,19 @@ class WorkOSNode extends WorkOS {
     }
 
     return new Webhooks(cryptoProvider);
+  }
+
+  /** @override */
+  createActionsClient(): Actions {
+    let cryptoProvider: CryptoProvider;
+
+    if (typeof crypto !== 'undefined' && typeof crypto.subtle !== 'undefined') {
+      cryptoProvider = new SubtleCryptoProvider();
+    } else {
+      cryptoProvider = new NodeCryptoProvider();
+    }
+
+    return new Actions(cryptoProvider);
   }
 
   /** @override */

--- a/src/index.worker.ts
+++ b/src/index.worker.ts
@@ -1,3 +1,4 @@
+import { Actions } from './actions/actions';
 import { SubtleCryptoProvider } from './common/crypto/subtle-crypto-provider';
 import { EdgeIronSessionProvider } from './common/iron-session/edge-iron-session-provider';
 import { IronSessionProvider } from './common/iron-session/iron-session-provider';
@@ -38,6 +39,13 @@ class WorkOSWorker extends WorkOS {
     const cryptoProvider = new SubtleCryptoProvider();
 
     return new Webhooks(cryptoProvider);
+  }
+
+  /** @override */
+  createActionsClient(): Actions {
+    const cryptoProvider = new SubtleCryptoProvider();
+
+    return new Actions(cryptoProvider);
   }
 
   /** @override */

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -1,13 +1,27 @@
-import { SignatureVerificationException } from '../common/exceptions';
 import { deserializeEvent } from '../common/serializers';
 import { Event, EventResponse } from '../common/interfaces';
+import { SignatureProvider } from '../common/crypto/SignatureProvider';
 import { CryptoProvider } from '../common/crypto/crypto-provider';
 
 export class Webhooks {
-  private cryptoProvider: CryptoProvider;
+  private signatureProvider: SignatureProvider;
 
   constructor(cryptoProvider: CryptoProvider) {
-    this.cryptoProvider = cryptoProvider;
+    this.signatureProvider = new SignatureProvider(cryptoProvider);
+  }
+
+  get verifyHeader() {
+    return this.signatureProvider.verifyHeader.bind(this.signatureProvider);
+  }
+
+  get computeSignature() {
+    return this.signatureProvider.computeSignature.bind(this.signatureProvider);
+  }
+
+  get getTimestampAndSignatureHash() {
+    return this.signatureProvider.getTimestampAndSignatureHash.bind(
+      this.signatureProvider,
+    );
   }
 
   async constructEvent({
@@ -27,71 +41,5 @@ export class Webhooks {
     const webhookPayload = payload as EventResponse;
 
     return deserializeEvent(webhookPayload);
-  }
-
-  async verifyHeader({
-    payload,
-    sigHeader,
-    secret,
-    tolerance = 180000,
-  }: {
-    payload: any;
-    sigHeader: string;
-    secret: string;
-    tolerance?: number;
-  }): Promise<boolean> {
-    const [timestamp, signatureHash] =
-      this.getTimestampAndSignatureHash(sigHeader);
-
-    if (!signatureHash || Object.keys(signatureHash).length === 0) {
-      throw new SignatureVerificationException(
-        'No signature hash found with expected scheme v1',
-      );
-    }
-
-    if (parseInt(timestamp, 10) < Date.now() - tolerance) {
-      throw new SignatureVerificationException(
-        'Timestamp outside the tolerance zone',
-      );
-    }
-
-    const expectedSig = await this.computeSignature(timestamp, payload, secret);
-    if (
-      (await this.cryptoProvider.secureCompare(expectedSig, signatureHash)) ===
-      false
-    ) {
-      throw new SignatureVerificationException(
-        'Signature hash does not match the expected signature hash for payload',
-      );
-    }
-    return true;
-  }
-
-  getTimestampAndSignatureHash(sigHeader: string): [string, string] {
-    const signature = sigHeader;
-    const [t, v1] = signature.split(',');
-    if (typeof t === 'undefined' || typeof v1 === 'undefined') {
-      throw new SignatureVerificationException(
-        'Signature or timestamp missing',
-      );
-    }
-    const { 1: timestamp } = t.split('=');
-    const { 1: signatureHash } = v1.split('=');
-
-    return [timestamp, signatureHash];
-  }
-
-  async computeSignature(
-    timestamp: any,
-    payload: any,
-    secret: string,
-  ): Promise<string> {
-    payload = JSON.stringify(payload);
-    const signedPayload = `${timestamp}.${payload}`;
-
-    return await this.cryptoProvider.computeHMACSignatureAsync(
-      signedPayload,
-      secret,
-    );
   }
 }

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -346,10 +346,15 @@ describe('WorkOS', () => {
       // tslint:disable-next-line
       expect(workos['client']).toBeInstanceOf(FetchHttpClient);
 
-      // tslint:disable-next-line
-      expect(workos.webhooks['cryptoProvider']).toBeInstanceOf(
-        SubtleCryptoProvider,
-      );
+      expect(
+        // tslint:disable-next-line
+        workos.webhooks['signatureProvider']['cryptoProvider'],
+      ).toBeInstanceOf(SubtleCryptoProvider);
+
+      expect(
+        // tslint:disable-next-line
+        workos.actions['signatureProvider']['cryptoProvider'],
+      ).toBeInstanceOf(SubtleCryptoProvider);
     });
 
     it('uses console.warn to emit warnings', () => {

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -33,6 +33,7 @@ import { SubtleCryptoProvider } from './common/crypto/subtle-crypto-provider';
 import { FetchHttpClient } from './common/net/fetch-client';
 import { IronSessionProvider } from './common/iron-session/iron-session-provider';
 import { Widgets } from './widgets/widgets';
+import { Actions } from './actions/actions';
 
 const VERSION = '7.30.1';
 
@@ -47,6 +48,7 @@ export class WorkOS {
   readonly client: HttpClient;
   readonly clientId?: string;
 
+  readonly actions: Actions;
   readonly auditLogs = new AuditLogs(this);
   readonly directorySync = new DirectorySync(this);
   readonly organizations = new Organizations(this);
@@ -101,6 +103,7 @@ export class WorkOS {
     }
 
     this.webhooks = this.createWebhookClient();
+    this.actions = this.createActionsClient();
 
     // Must initialize UserManagement after baseURL is configured
     this.userManagement = new UserManagement(
@@ -113,6 +116,10 @@ export class WorkOS {
 
   createWebhookClient() {
     return new Webhooks(new SubtleCryptoProvider());
+  }
+
+  createActionsClient() {
+    return new Actions(new SubtleCryptoProvider());
   }
 
   createHttpClient(options: WorkOSOptions, userAgent: string) {


### PR DESCRIPTION
## Description
Introduce new methods for Actions:
- `signResponse`: Supports forming and signing actions responses from an actions endpoint
- `verifyHeader`: Supports incoming requests from WorkOS reaching actions endpoints  

Example usage:
```typescript
app.post("/registration-action", async (req, res) => {
  const context = req.body;

  // Verify incoming workos-signature 
  try {
    await workos.actions.verifyHeader({
      payload: context,
      sigHeader: req.headers["workos-signature"] as string,
      secret: env.ACTIONS_SECRET,
    });
  } catch (err) {
    return res.status(400).json({ error: "Invalid signature" });
  }

  let verdict: "allow" | "deny";

  if (context.user_data.email.split("@")[1] === "gmail.com") {
    verdict = "deny";
  } else {
    verdict = "allow";
  }

  // Sign the outgoing response using the actions secret 
  const response = await workos.actions.signResponse({
    type: "user_registration",
    verdict,
    ...(verdict === "deny" && {
      errorMessage: "Please use a work email address",
    }),
    secret: env.ACTIONS_SECRET,
  });

  return res.json(response);
});
```

## Documentation
Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
