### PR TITLE
Add `Passkey` to `AuthenticationMethod` union

### DIFF
--- a/src/user-management/interfaces/authentication-response.interface.ts
+++ b/src/user-management/interfaces/authentication-response.interface.ts
@@ -5,12 +5,14 @@ import { User, UserResponse } from './user.interface';
 type AuthenticationMethod =
   | 'SSO'
   | 'Password'
+  | 'Passkey'
   | 'AppleOAuth'
   | 'GitHubOAuth'
   | 'GoogleOAuth'
   | 'MicrosoftOAuth'
   | 'MagicAuth'
   | 'Impersonation';
+
 export interface AuthenticationResponse {
   user: User;
   organizationId?: string;


### PR DESCRIPTION
## Description

Adds `'Passkey'` as a possible value of `AuthenticationMethod`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
