### PR TITLE
Make metadata optional when creating audit log schema

### DIFF
--- a/src/audit-logs/interfaces/create-audit-log-schema-options.interface.ts
+++ b/src/audit-logs/interfaces/create-audit-log-schema-options.interface.ts
@@ -61,7 +61,7 @@ export interface CreateAuditLogSchemaResponse {
       properties: AuditLogSchemaMetadata;
     };
   };
-  metadata: {
+  metadata?: {
     type: 'object';
     properties: AuditLogSchemaMetadata;
   };

--- a/src/audit-logs/serializers/create-audit-log-schema-options.serializer.ts
+++ b/src/audit-logs/serializers/create-audit-log-schema-options.serializer.ts
@@ -42,8 +42,10 @@ export const serializeCreateAuditLogSchemaOptions = (
         : undefined,
     };
   }),
-  metadata: {
-    type: 'object',
-    properties: serializeMetadata(schema.metadata),
-  },
+  metadata: schema.metadata
+    ? {
+        type: 'object',
+        properties: serializeMetadata(schema.metadata),
+      }
+    : undefined,
 });

--- a/src/audit-logs/serializers/create-audit-log-schema.serializer.ts
+++ b/src/audit-logs/serializers/create-audit-log-schema.serializer.ts
@@ -34,6 +34,8 @@ export const deserializeAuditLogSchema = (
   actor: {
     metadata: deserializeMetadata(auditLogSchema.actor?.metadata),
   },
-  metadata: deserializeMetadata(auditLogSchema.metadata),
+  metadata: auditLogSchema.metadata
+    ? deserializeMetadata(auditLogSchema.metadata)
+    : undefined,
   createdAt: auditLogSchema.created_at,
 });


### PR DESCRIPTION
## Description
Make metadata optional when creating audit log schema.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
