### PR TITLE
fix: Update session.refresh to correctly maintain previous orgId

### DIFF
--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -141,6 +141,10 @@ export class Session {
       };
     }
 
+    const { org_id: organizationIdFromAccessToken } = decodeJwt<AccessToken>(
+      session.accessToken,
+    );
+
     try {
       const cookiePassword = options.cookiePassword ?? this.cookiePassword;
 
@@ -148,7 +152,8 @@ export class Session {
         await this.userManagement.authenticateWithRefreshToken({
           clientId: this.userManagement.clientId as string,
           refreshToken: session.refreshToken,
-          organizationId: options.organizationId ?? undefined,
+          organizationId:
+            options.organizationId ?? organizationIdFromAccessToken,
           session: {
             // We want to store the new sealed session in this class instance, so this always needs to be true
             sealSession: true,


### PR DESCRIPTION
## Description

Fixes issue where:
- If you create a new session without an org
- Then refresh with an orgId 
- Then on the next refresh it no longer maintains the orgId

This was an issue in the old refreshAndSealSessionData and was fixed https://github.com/workos/workos-node/blob/08ab75f210b11371fa4de78eb97f35d2deb90a5c/src/user-management/user-management.ts#L504

Note: Having a deeper think about this, its weird that this is not required when a session is initiated with an orgId from the start which makes me think potentially there is an issue that when an refresh with orgId is sent to the workOs backend the orgId isn't actually persisted which breaks the normal refresh flow. This theory potentially also explains why in the scenario above after the switch org happens the workos portal still doesn't show the organization id on the session.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
