### PR TITLE
feat: introduce typed actions.deserialize

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -2,6 +2,11 @@ import { SignatureProvider } from '../common/crypto';
 import { CryptoProvider } from '../common/crypto/crypto-provider';
 import { unreachable } from '../common/utils/unreachable';
 import {
+  ActionPayload,
+  AuthenticationActionPayload,
+  UserRegistrationActionPayload,
+} from './interfaces/action-payload';
+import {
   AuthenticationActionResponseData,
   ResponsePayload,
   UserRegistrationActionResponseData,
@@ -66,5 +71,52 @@ export class Actions {
     };
 
     return response;
+  }
+
+  async deserialize({
+    payload,
+    sigHeader,
+    secret,
+    type,
+  }: {
+    payload: ActionPayload;
+    sigHeader: string;
+    secret: string;
+    type: 'authentication';
+  }): Promise<AuthenticationActionPayload>;
+
+  async deserialize({
+    payload,
+    sigHeader,
+    secret,
+    type,
+  }: {
+    payload: ActionPayload;
+    sigHeader: string;
+    secret: string;
+    type: 'user_registration';
+  }): Promise<UserRegistrationActionPayload>;
+
+  async deserialize({
+    payload,
+    sigHeader,
+    secret,
+    type,
+  }: {
+    payload: ActionPayload;
+    sigHeader: string;
+    secret: string;
+    type: 'authentication' | 'user_registration';
+  }) {
+    await this.verifyHeader({ payload, sigHeader, secret });
+
+    switch (type) {
+      case 'authentication':
+        return payload as AuthenticationActionPayload;
+      case 'user_registration':
+        return payload as UserRegistrationActionPayload;
+      default:
+        return unreachable(type);
+    }
   }
 }

--- a/src/actions/fixtures/action-context.ts
+++ b/src/actions/fixtures/action-context.ts
@@ -1,0 +1,41 @@
+import { AuthenticationActionPayload } from '../interfaces';
+
+export const mockActionContext: AuthenticationActionPayload = {
+  user: {
+    object: 'user',
+    id: '01JATCHZVEC5EPANDPEZVM68Y9',
+    email: 'jane@foocorp.com',
+    first_name: 'Jane',
+    last_name: 'Doe',
+    email_verified: true,
+    profile_picture_url: 'https://example.com/jane.jpg',
+    created_at: '2024-10-22T17:12:50.746Z',
+    updated_at: '2024-10-22T17:12:50.746Z',
+  },
+  ip_address: '50.141.123.10',
+  user_agent: 'Mozilla/5.0',
+  issuer: 'test',
+  object: 'authentication_action_context',
+  organization: {
+    object: 'organization',
+    id: '01JATCMZJY26PQ59XT9BNT0FNN',
+    name: 'Foo Corp',
+    allow_profiles_outside_organization: false,
+    domains: [],
+    lookup_key: 'my-key',
+    created_at: '2024-10-22T17:12:50.746Z',
+    updated_at: '2024-10-22T17:12:50.746Z',
+  },
+  organization_membership: {
+    object: 'organization_membership',
+    id: '01JATCNVYCHT1SZGENR4QTXKRK',
+    user_id: '01JATCHZVEC5EPANDPEZVM68Y9',
+    organization_id: '01JATCMZJY26PQ59XT9BNT0FNN',
+    role: {
+      slug: 'member',
+    },
+    status: 'active',
+    created_at: '2024-10-22T17:12:50.746Z',
+    updated_at: '2024-10-22T17:12:50.746Z',
+  },
+};

--- a/src/actions/interfaces/action-payload.ts
+++ b/src/actions/interfaces/action-payload.ts
@@ -1,0 +1,87 @@
+interface User {
+  object: 'user';
+  id: string;
+  email: string;
+  first_name: string | null;
+  last_name: string | null;
+  email_verified: boolean;
+  profile_picture_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface OrganizationDomain {
+  object: 'organization_domain';
+  id: string;
+  organization_id: string;
+  domain: string;
+  state?: 'failed' | 'legacy_verified' | 'pending' | 'unverified' | 'verified';
+  verification_token?: string;
+  verification_strategy?: 'dns' | 'manual';
+}
+
+interface Organization {
+  object: 'organization';
+  id: string;
+  name: string;
+  allow_profiles_outside_organization: boolean;
+  stripe_customer_id?: string;
+  domains: OrganizationDomain[];
+  lookup_key?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface OrganizationMembership {
+  object: 'organization_membership';
+  id: string;
+  user_id: string;
+  organization_id: string;
+  role: {
+    slug: string;
+  };
+  status: 'active' | 'inactive' | 'pending';
+  created_at: string;
+  updated_at: string;
+}
+
+interface ActionPayloadCommon {
+  ip_address?: string;
+  user_agent?: string;
+}
+
+interface Invite {
+  object: 'invitation';
+  id: string;
+  email: string;
+  inviter_user_id?: string;
+  organization_id?: string;
+  accepted_at: string | null;
+  revoked_at: string | null;
+  expires_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UserRegistrationActionPayload extends ActionPayloadCommon {
+  object: 'user_registration_action_context';
+  invitation?: Invite;
+  user_data: {
+    object: 'user_data';
+    email: string;
+    first_name: string | null;
+    last_name: string | null;
+  };
+}
+
+export interface AuthenticationActionPayload extends ActionPayloadCommon {
+  object: 'authentication_action_context';
+  user: User;
+  organization?: Organization;
+  organization_membership?: OrganizationMembership;
+  issuer?: string;
+}
+
+export type ActionPayload =
+  | AuthenticationActionPayload
+  | UserRegistrationActionPayload;

--- a/src/actions/interfaces/index.ts
+++ b/src/actions/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './action-payload';
+export * from './response-payload';


### PR DESCRIPTION
## Description
- Introduces typed `actions.deserialize` method 
- Export actions payload types

Usage:
```javascript

app.post("/registration-action", async (req, res) => {
  const payload = req.body;
  const sigHeader = req.headers["workos-signature"] as string;

  try {
    // context is now typed 
    const context = await workos.actions.deserialize({
      payload,
      secret: env.ACTIONS_SECRET,
      sigHeader,
      type: "user_registration",
    });

    let verdict: "Allow" | "Deny";

    if (context.user_data.email.split("@")[1] === "gmail.com") {
      verdict = "Deny";
    } else {
      verdict = "Allow";
    }

    const response = await workos.actions.signResponse(
      {
        type: "user_registration",
        verdict,
        ...(verdict === "Deny" && {
          errorMessage: "Please use a work email address",
        }),
      },
      env.ACTIONS_SECRET
    );

    return res.json(response);
  } catch (err) {
    if (err instanceof SignatureVerificationException) {
      const response = await workos.actions.signResponse(
        {
          type: "user_registration",
          verdict: "Deny",
          errorMessage: "Invalid signature",
        },
        env.ACTIONS_SECRET
      );

      return res.json(response);
    }

    const response = await workos.actions.signResponse(
      {
        type: "user_registration",
        verdict: "Deny",
        errorMessage: "An error occurred",
      },
      env.ACTIONS_SECRET
    );

    return res.json(response);
  }
});
```

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
