### PR TITLE
Use a non-default ttl with iron-session

### DIFF
--- a/src/common/iron-session/edge-iron-session-provider.ts
+++ b/src/common/iron-session/edge-iron-session-provider.ts
@@ -25,17 +25,6 @@ export class EdgeIronSessionProvider extends IronSessionProvider {
     seal: string,
     options: SealDataOptions,
   ): Promise<T> {
-    try {
-      const sealOptions = {
-        ...options,
-        ttl: 0,
-      };
-      return unsealData<T>(seal, sealOptions);
-    } catch (e) {
-      // Older sessions might still have the ttl set to the default of 14 days, in which case the unsealing fails.
-      // This is a fallback to try unsealing with the default ttl of 14 days.
-      // In a future major version we can remove this fallback as all sessions should have been updated to use the ttl of 0.
-      return unsealData<T>(seal, options);
-    }
+    return unsealData<T>(seal, options);
   }
 }

--- a/src/common/iron-session/edge-iron-session-provider.ts
+++ b/src/common/iron-session/edge-iron-session-provider.ts
@@ -11,7 +11,13 @@ import {
 export class EdgeIronSessionProvider extends IronSessionProvider {
   /** @override */
   async sealData(data: unknown, options: SealDataOptions): Promise<string> {
-    return sealData(data, options);
+    // The iron-session default ttl is 14 days, which can be problematic if the WorkOS session is configured to be > 14 days.
+    // In that case the session expires and can't be refreshed, so we set the ttl to 0 to set it to the max possible value.
+    const sealOptions = {
+      ...options,
+      ttl: 0,
+    };
+    return sealData(data, sealOptions);
   }
 
   /** @override */
@@ -19,6 +25,17 @@ export class EdgeIronSessionProvider extends IronSessionProvider {
     seal: string,
     options: SealDataOptions,
   ): Promise<T> {
-    return unsealData<T>(seal, options);
+    try {
+      const sealOptions = {
+        ...options,
+        ttl: 0,
+      };
+      return unsealData<T>(seal, sealOptions);
+    } catch (e) {
+      // Older sessions might still have the ttl set to the default of 14 days, in which case the unsealing fails.
+      // This is a fallback to try unsealing with the default ttl of 14 days.
+      // In a future major version we can remove this fallback as all sessions should have been updated to use the ttl of 0.
+      return unsealData<T>(seal, options);
+    }
   }
 }

--- a/src/common/iron-session/web-iron-session-provider.ts
+++ b/src/common/iron-session/web-iron-session-provider.ts
@@ -25,17 +25,6 @@ export class WebIronSessionProvider extends IronSessionProvider {
     seal: string,
     options: SealDataOptions,
   ): Promise<T> {
-    try {
-      const sealOptions = {
-        ...options,
-        ttl: 0,
-      };
-      return unsealData<T>(seal, sealOptions);
-    } catch (e) {
-      // Older sessions might still have the ttl set to the default of 14 days, in which case the unsealing fails.
-      // This is a fallback to try unsealing with the default ttl of 14 days.
-      // In a future major version we can remove this fallback as all sessions should have been updated to use the ttl of 0.
-      return unsealData<T>(seal, options);
-    }
+    return unsealData<T>(seal, options);
   }
 }


### PR DESCRIPTION
## Description
iron-session has a default ttl of 14 days, which is problematic in the edge case where a user has set their WorkOS sessions to expire > 14 days. In that scenario, iron-session will expire first, making unsealing impossible which means you can't refresh the session.

This fix changes the default ttl to 0, which sets it to the max of ~10 years.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
