### PR TITLE
Add GET /organization/:orgId/roles support

### DIFF
--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -18,7 +18,7 @@ import {
 } from '../../user-management/serializers';
 import { deserializeOrganizationDomain } from '../../organization-domains/serializers/organization-domain.serializer';
 import { deserializeOrganizationMembership } from '../../user-management/serializers/organization-membership.serializer';
-import { deserializeRole } from '../../user-management/serializers/role.serializer';
+import { deserializeRoleEvent } from '../../user-management/serializers/role.serializer';
 import { deserializeSession } from '../../user-management/serializers/session.serializer';
 import { Event, EventBase, EventResponse } from '../interfaces';
 
@@ -150,7 +150,7 @@ export const deserializeEvent = (event: EventResponse): Event => {
       return {
         ...eventBase,
         event: event.event,
-        data: deserializeRole(event.data),
+        data: deserializeRoleEvent(event.data),
       };
     case 'session.created':
       return {

--- a/src/organizations/fixtures/list-organization-roles.json
+++ b/src/organizations/fixtures/list-organization-roles.json
@@ -1,0 +1,35 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "role",
+      "id": "role_01EHQMYV6MBK39QC5PZXHY59C5",
+      "name": "Admin",
+      "slug": "admin",
+      "description": null,
+      "type": "EnvironmentRole",
+      "created_at": "2024-01-01T00:00:00.000Z",
+      "updated_at": "2024-01-01T00:00:00.000Z"
+    },
+    {
+      "object": "role",
+      "id": "role_01EHQMYV6MBK39QC5PZXHY59C3",
+      "name": "Member",
+      "slug": "member",
+      "description": null,
+      "type": "EnvironmentRole",
+      "created_at": "2024-01-01T00:00:00.000Z",
+      "updated_at": "2024-01-01T00:00:00.000Z"
+    },
+    {
+      "object": "role",
+      "id": "role_01EHQMYV6MBK39QC5PZXHY59C3",
+      "name": "OrganizationMember",
+      "slug": "org-member",
+      "description": null,
+      "type": "OrganizationRole",
+      "created_at": "2024-01-01T00:00:00.000Z",
+      "updated_at": "2024-01-01T00:00:00.000Z"
+    }
+  ]
+}

--- a/src/organizations/interfaces/list-organization-roles-options.interface.ts
+++ b/src/organizations/interfaces/list-organization-roles-options.interface.ts
@@ -1,0 +1,3 @@
+export interface ListOrganizationRolesOptions {
+  organizationId: string;
+}

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -12,6 +12,7 @@ import createOrganizationInvalid from './fixtures/create-organization-invalid.js
 import createOrganization from './fixtures/create-organization.json';
 import getOrganization from './fixtures/get-organization.json';
 import listOrganizationsFixture from './fixtures/list-organizations.json';
+import listOrganizationRolesFixture from './fixtures/list-organization-roles.json';
 import updateOrganization from './fixtures/update-organization.json';
 import setStripeCustomerId from './fixtures/set-stripe-customer-id.json';
 import setStripeCustomerIdDisabled from './fixtures/set-stripe-customer-id-disabled.json';
@@ -346,6 +347,25 @@ describe('Organizations', () => {
           });
         });
       });
+    });
+  });
+
+  describe('listOrganizationRoles', () => {
+    it('returns roles for the organization', async () => {
+      fetchOnce(listOrganizationRolesFixture);
+
+      const { data, object } = await workos.organizations.listOrganizationRoles(
+        {
+          organizationId: 'org_01EHT88Z8J8795GZNQ4ZP1J81T',
+        },
+      );
+
+      expect(fetchURL()).toContain(
+        '/organizations/org_01EHT88Z8J8795GZNQ4ZP1J81T/roles',
+      );
+
+      expect(object).toEqual('list');
+      expect(data).toHaveLength(3);
     });
   });
 });

--- a/src/organizations/organizations.ts
+++ b/src/organizations/organizations.ts
@@ -15,6 +15,9 @@ import {
 } from './serializers';
 
 import { fetchAndDeserialize } from '../common/utils/fetch-and-deserialize';
+import { ListOrganizationRolesResponse, RoleList } from '../roles/interfaces';
+import { deserializeRole } from '../roles/serializers/role.serializer';
+import { ListOrganizationRolesOptions } from './interfaces/list-organization-roles-options.interface';
 
 export class Organizations {
   constructor(private readonly workos: WorkOS) {}
@@ -76,5 +79,21 @@ export class Organizations {
     );
 
     return deserializeOrganization(data);
+  }
+
+  async listOrganizationRoles(
+    options: ListOrganizationRolesOptions,
+  ): Promise<RoleList> {
+    const { organizationId } = options;
+
+    const { data: response } =
+      await this.workos.get<ListOrganizationRolesResponse>(
+        `/organizations/${organizationId}/roles`,
+      );
+
+    return {
+      object: 'list',
+      data: response.data.map((role) => deserializeRole(role)),
+    };
   }
 }

--- a/src/roles/interfaces/role.interface.ts
+++ b/src/roles/interfaces/role.interface.ts
@@ -11,3 +11,35 @@ export interface RoleEventResponse {
   object: 'role';
   slug: string;
 }
+
+export interface ListOrganizationRolesResponse {
+  object: 'list';
+  data: OrganizationRoleResponse[];
+}
+
+export interface OrganizationRoleResponse {
+  object: 'role';
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  type: 'EnvironmentRole' | 'OrganizationRole';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Role {
+  object: 'role';
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  type: 'EnvironmentRole' | 'OrganizationRole';
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RoleList {
+  object: 'list';
+  data: Role[];
+}

--- a/src/roles/serializers/role.serializer.ts
+++ b/src/roles/serializers/role.serializer.ts
@@ -1,0 +1,12 @@
+import { OrganizationRoleResponse, Role } from '../interfaces';
+
+export const deserializeRole = (role: OrganizationRoleResponse): Role => ({
+  object: role.object,
+  id: role.id,
+  name: role.name,
+  slug: role.slug,
+  description: role.description,
+  type: role.type,
+  createdAt: role.created_at,
+  updatedAt: role.updated_at,
+});

--- a/src/user-management/serializers/role.serializer.ts
+++ b/src/user-management/serializers/role.serializer.ts
@@ -1,6 +1,6 @@
 import { RoleEvent, RoleEventResponse } from '../../roles/interfaces';
 
-export const deserializeRole = (role: RoleEventResponse): RoleEvent => ({
+export const deserializeRoleEvent = (role: RoleEventResponse): RoleEvent => ({
   object: 'role',
   slug: role.slug,
 });


### PR DESCRIPTION
## Description
Add GET /organization/:orgId/roles support.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
