### PR TITLE
Upgrade to latest iron-session

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
-    "iron-session": "~6.3.1",
+    "iron-session": "~8.0.1",
     "jose": "~5.6.3",
     "pluralize": "8.0.0"
   },

--- a/src/common/iron-session/edge-iron-session-provider.ts
+++ b/src/common/iron-session/edge-iron-session-provider.ts
@@ -1,4 +1,4 @@
-import { sealData, unsealData } from 'iron-session/edge';
+import { sealData, unsealData } from 'iron-session';
 import {
   IronSessionProvider,
   SealDataOptions,


### PR DESCRIPTION
## Description

This PR upgrades the `iron-session` dependency from v6.3.1 to v8.0.1, for a few reasons:

1. v6.3.1 was published October 2022, over two years ago
2. v6.3.1 defines a peer dependency on `next`, which pulls in Next.js as a dependency in projects using `@workos-inc/node`, which generates GitHub vulnerability alerts for Next, even for non-Next projects

The main change to upgrade from v6 to v8 is updating the import of `iron-session/edge` to just `iron-session`, as now `iron-session` [uses the same top-level entry point](https://github.com/vvo/iron-session/releases/tag/v8.0.0) for everything. Otherwise the maintainers state that the data format should remain the same, e.g. existing sealed data should be able to be unsealed by v8.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
