### PR TITLE
set JWKS cache duration to 5 minutes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.36.0",
+  "version": "7.36.1",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",
@@ -73,3 +73,4 @@
     }
   }
 }
+

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`SSO SSO getProfileAndToken with all information provided sends a reques
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/7.36.0/fetch",
+  "User-Agent": "workos-node/7.36.1/fetch",
 }
 `;
 
@@ -61,7 +61,7 @@ exports[`SSO SSO getProfileAndToken without a groups attribute sends a request t
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/7.36.0/fetch",
+  "User-Agent": "workos-node/7.36.1/fetch",
 }
 `;
 

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -170,7 +170,9 @@ export class UserManagement {
 
     // Set the JWKS URL. This is used to verify if the JWT is still valid
     this.jwks = clientId
-      ? createRemoteJWKSet(new URL(this.getJwksUrl(clientId)))
+      ? createRemoteJWKSet(new URL(this.getJwksUrl(clientId)), {
+          cooldownDuration: 1000 * 60 * 5,
+        })
       : undefined;
   }
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -35,7 +35,7 @@ import { IronSessionProvider } from './common/iron-session/iron-session-provider
 import { Widgets } from './widgets/widgets';
 import { Actions } from './actions/actions';
 
-const VERSION = '7.36.0';
+const VERSION = '7.36.1';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
 


### PR DESCRIPTION
## Description

By default, jose sets a `cooldownDuration` to 30 seconds for JWKS cache. This PR changes it to 5 minutes.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
