### PR TITLE
Add device fingerprint to action context payloads

### DIFF
--- a/src/actions/actions.spec.ts
+++ b/src/actions/actions.spec.ts
@@ -129,6 +129,7 @@ describe('Actions', () => {
         },
         ipAddress: '50.141.123.10',
         userAgent: 'Mozilla/5.0',
+        deviceFingerprint: 'notafingerprint',
         issuer: 'test',
         object: 'authentication_action_context',
         organization: {
@@ -175,6 +176,7 @@ describe('Actions', () => {
         },
         ipAddress: '50.141.123.10',
         userAgent: 'Mozilla/5.0',
+        deviceFingerprint: 'notafingerprint',
         invitation: expect.objectContaining({
           object: 'invitation',
           id: '01JBVZWH8HJ855YZ5BWHG1WNZN',

--- a/src/actions/fixtures/authentication-action-context.json
+++ b/src/actions/fixtures/authentication-action-context.json
@@ -13,6 +13,7 @@
     },
     "ip_address": "50.141.123.10",
     "user_agent": "Mozilla/5.0",
+    "device_fingerprint": "notafingerprint",
     "issuer": "test",
     "object": "authentication_action_context",
     "organization": {

--- a/src/actions/fixtures/user-registration-action-context.json
+++ b/src/actions/fixtures/user-registration-action-context.json
@@ -8,6 +8,7 @@
     },
     "ip_address": "50.141.123.10",
     "user_agent": "Mozilla/5.0",
+    "device_fingerprint": "notafingerprint",
     "object": "user_registration_action_context",
     "invitation": {
         "object": "invitation",
@@ -20,5 +21,5 @@
         "revoked_at": null,
         "organization_id": "01JBW46BTKAA98WZN8826XQ2YP",
         "inviter_user_id": "01JBVZWAEPWAE3YYKBVT0AF81F"
-      }
+    }
 }

--- a/src/actions/interfaces/action.interface.ts
+++ b/src/actions/interfaces/action.interface.ts
@@ -1,78 +1,78 @@
 import {
-    Organization,
-    OrganizationResponse,
+  Organization,
+  OrganizationResponse,
 } from '../../organizations/interfaces';
 import {
-    Invitation,
-    InvitationResponse,
-    OrganizationMembership,
-    OrganizationMembershipResponse,
-    User,
-    UserResponse,
+  Invitation,
+  InvitationResponse,
+  OrganizationMembership,
+  OrganizationMembershipResponse,
+  User,
+  UserResponse,
 } from '../../user-management/interfaces';
 
 interface AuthenticationActionContext {
-    id: string;
-    object: 'authentication_action_context';
-    user: User;
-    organization?: Organization;
-    organizationMembership?: OrganizationMembership;
-    ipAddress?: string;
-    userAgent?: string;
-    deviceFingerprint?: string;
-    issuer?: string;
+  id: string;
+  object: 'authentication_action_context';
+  user: User;
+  organization?: Organization;
+  organizationMembership?: OrganizationMembership;
+  ipAddress?: string;
+  userAgent?: string;
+  deviceFingerprint?: string;
+  issuer?: string;
 }
 
 export interface UserData {
-    object: 'user_data';
-    email: string;
-    firstName: string;
-    lastName: string;
+  object: 'user_data';
+  email: string;
+  firstName: string;
+  lastName: string;
 }
 
 interface UserRegistrationActionContext {
-    id: string;
-    object: 'user_registration_action_context';
-    userData: UserData;
-    invitation?: Invitation;
-    ipAddress?: string;
-    userAgent?: string;
-    deviceFingerprint?: string;
+  id: string;
+  object: 'user_registration_action_context';
+  userData: UserData;
+  invitation?: Invitation;
+  ipAddress?: string;
+  userAgent?: string;
+  deviceFingerprint?: string;
 }
 
 export type ActionContext =
-    | AuthenticationActionContext
-    | UserRegistrationActionContext;
+  | AuthenticationActionContext
+  | UserRegistrationActionContext;
 
 interface AuthenticationActionPayload {
-    id: string;
-    object: 'authentication_action_context';
-    user: UserResponse;
-    organization?: OrganizationResponse;
-    organization_membership?: OrganizationMembershipResponse;
-    ip_address?: string;
-    user_agent?: string;
-    device_fingerprint?: string;
-    issuer?: string;
+  id: string;
+  object: 'authentication_action_context';
+  user: UserResponse;
+  organization?: OrganizationResponse;
+  organization_membership?: OrganizationMembershipResponse;
+  ip_address?: string;
+  user_agent?: string;
+  device_fingerprint?: string;
+  issuer?: string;
 }
 
 export interface UserDataPayload {
-    object: 'user_data';
-    email: string;
-    first_name: string;
-    last_name: string;
+  object: 'user_data';
+  email: string;
+  first_name: string;
+  last_name: string;
 }
 
 export interface UserRegistrationActionPayload {
-    id: string;
-    object: 'user_registration_action_context';
-    user_data: UserDataPayload;
-    invitation?: InvitationResponse;
-    ip_address?: string;
-    user_agent?: string;
-    device_fingerprint?: string;
+  id: string;
+  object: 'user_registration_action_context';
+  user_data: UserDataPayload;
+  invitation?: InvitationResponse;
+  ip_address?: string;
+  user_agent?: string;
+  device_fingerprint?: string;
 }
 
 export type ActionPayload =
-    | AuthenticationActionPayload
-    | UserRegistrationActionPayload;
+  | AuthenticationActionPayload
+  | UserRegistrationActionPayload;

--- a/src/actions/interfaces/action.interface.ts
+++ b/src/actions/interfaces/action.interface.ts
@@ -1,74 +1,78 @@
 import {
-  Organization,
-  OrganizationResponse,
+    Organization,
+    OrganizationResponse,
 } from '../../organizations/interfaces';
 import {
-  Invitation,
-  InvitationResponse,
-  OrganizationMembership,
-  OrganizationMembershipResponse,
-  User,
-  UserResponse,
+    Invitation,
+    InvitationResponse,
+    OrganizationMembership,
+    OrganizationMembershipResponse,
+    User,
+    UserResponse,
 } from '../../user-management/interfaces';
 
 interface AuthenticationActionContext {
-  id: string;
-  object: 'authentication_action_context';
-  user: User;
-  organization?: Organization;
-  organizationMembership?: OrganizationMembership;
-  ipAddress?: string;
-  userAgent?: string;
-  issuer?: string;
+    id: string;
+    object: 'authentication_action_context';
+    user: User;
+    organization?: Organization;
+    organizationMembership?: OrganizationMembership;
+    ipAddress?: string;
+    userAgent?: string;
+    deviceFingerprint?: string;
+    issuer?: string;
 }
 
 export interface UserData {
-  object: 'user_data';
-  email: string;
-  firstName: string;
-  lastName: string;
+    object: 'user_data';
+    email: string;
+    firstName: string;
+    lastName: string;
 }
 
 interface UserRegistrationActionContext {
-  id: string;
-  object: 'user_registration_action_context';
-  userData: UserData;
-  invitation?: Invitation;
-  ipAddress?: string;
-  userAgent?: string;
+    id: string;
+    object: 'user_registration_action_context';
+    userData: UserData;
+    invitation?: Invitation;
+    ipAddress?: string;
+    userAgent?: string;
+    deviceFingerprint?: string;
 }
 
 export type ActionContext =
-  | AuthenticationActionContext
-  | UserRegistrationActionContext;
+    | AuthenticationActionContext
+    | UserRegistrationActionContext;
 
 interface AuthenticationActionPayload {
-  id: string;
-  object: 'authentication_action_context';
-  user: UserResponse;
-  organization?: OrganizationResponse;
-  organization_membership?: OrganizationMembershipResponse;
-  ip_address?: string;
-  user_agent?: string;
-  issuer?: string;
+    id: string;
+    object: 'authentication_action_context';
+    user: UserResponse;
+    organization?: OrganizationResponse;
+    organization_membership?: OrganizationMembershipResponse;
+    ip_address?: string;
+    user_agent?: string;
+    device_fingerprint?: string;
+    issuer?: string;
 }
 
 export interface UserDataPayload {
-  object: 'user_data';
-  email: string;
-  first_name: string;
-  last_name: string;
+    object: 'user_data';
+    email: string;
+    first_name: string;
+    last_name: string;
 }
 
 export interface UserRegistrationActionPayload {
-  id: string;
-  object: 'user_registration_action_context';
-  user_data: UserDataPayload;
-  invitation?: InvitationResponse;
-  ip_address?: string;
-  user_agent?: string;
+    id: string;
+    object: 'user_registration_action_context';
+    user_data: UserDataPayload;
+    invitation?: InvitationResponse;
+    ip_address?: string;
+    user_agent?: string;
+    device_fingerprint?: string;
 }
 
 export type ActionPayload =
-  | AuthenticationActionPayload
-  | UserRegistrationActionPayload;
+    | AuthenticationActionPayload
+    | UserRegistrationActionPayload;

--- a/src/actions/serializers/action.serializer.ts
+++ b/src/actions/serializers/action.serializer.ts
@@ -35,6 +35,7 @@ export const deserializeAction = (
 
         ipAddress: actionPayload.ip_address,
         userAgent: actionPayload.user_agent,
+        deviceFingerprint: actionPayload.device_fingerprint,
       };
     case 'authentication_action_context':
       return {
@@ -51,6 +52,7 @@ export const deserializeAction = (
           : undefined,
         ipAddress: actionPayload.ip_address,
         userAgent: actionPayload.user_agent,
+        deviceFingerprint: actionPayload.device_fingerprint,
         issuer: actionPayload.issuer,
       };
   }


### PR DESCRIPTION
When Radar is enabled, the device fingerprint captured by Radar is forwarded in action request payloads. This PR adds the attribute to action interfaces.

## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
