### PR TITLE
Add `returnTo` option to `userManagement.getLogoutUrl`

### DIFF
--- a/src/user-management/session.spec.ts
+++ b/src/user-management/session.spec.ts
@@ -318,5 +318,42 @@ describe('Session', () => {
         'Failed to extract session ID for logout URL: no_session_cookie_provided',
       );
     });
+
+    describe('when a returnTo URL is provided', () => {
+      it('returns a logout URL for the user', async () => {
+        jest
+          .spyOn(jose, 'jwtVerify')
+          .mockResolvedValue({} as jose.JWTVerifyResult & jose.ResolvedKey);
+
+        const cookiePassword = 'alongcookiesecretmadefortestingsessions';
+
+        const sessionData = await sealData(
+          {
+            accessToken:
+              'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJzdWIiOiAiMTIzNDU2Nzg5MCIsCiAgIm5hbWUiOiAiSm9obiBEb2UiLAogICJpYXQiOiAxNTE2MjM5MDIyLAogICJzaWQiOiAic2Vzc2lvbl8xMjMiLAogICJvcmdfaWQiOiAib3JnXzEyMyIsCiAgInJvbGUiOiAibWVtYmVyIiwKICAicGVybWlzc2lvbnMiOiBbInBvc3RzOmNyZWF0ZSIsICJwb3N0czpkZWxldGUiXQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+            refreshToken: 'def456',
+            user: {
+              object: 'user',
+              id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+              email: 'test01@example.com',
+            },
+          },
+          { password: cookiePassword },
+        );
+
+        const session = workos.userManagement.loadSealedSession({
+          sessionData,
+          cookiePassword,
+        });
+
+        const url = await session.getLogoutUrl({
+          returnTo: 'https://example.com/signed-out',
+        });
+
+        expect(url).toBe(
+          'https://api.workos.com/user_management/sessions/logout?session_id=session_123&return_to=https%3A%2F%2Fexample.com%2Fsigned-out',
+        );
+      });
+    });
   });
 });

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -198,7 +198,9 @@ export class Session {
    *
    * @returns The URL to redirect the user to for logging out.
    */
-  async getLogoutUrl() {
+  async getLogoutUrl({
+    returnTo,
+  }: { returnTo?: string } = {}): Promise<string> {
     const authenticationResponse = await this.authenticate();
 
     if (!authenticationResponse.authenticated) {
@@ -208,6 +210,7 @@ export class Session {
 
     return this.userManagement.getLogoutUrl({
       sessionId: authenticationResponse.sessionId,
+      returnTo,
     });
   }
 

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -1961,7 +1961,7 @@ describe('UserManagement', () => {
         });
 
         expect(url).toBe(
-          'https://api.workos.com/user_management/sessions/logout?session_id=123456&returnTo=https%3A%2F%2Fyour-app.com%2Fsigned-out',
+          'https://api.workos.com/user_management/sessions/logout?session_id=123456&return_to=https%3A%2F%2Fyour-app.com%2Fsigned-out',
         );
       });
     });

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -1950,6 +1950,21 @@ describe('UserManagement', () => {
         'https://api.workos.com/user_management/sessions/logout?session_id=123456',
       );
     });
+
+    describe('when a `returnTo` is given', () => {
+      it('includes a `return_to` in the URL', () => {
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        const url = workos.userManagement.getLogoutUrl({
+          sessionId: '123456',
+          returnTo: 'https://your-app.com/signed-out',
+        });
+
+        expect(url).toBe(
+          'https://api.workos.com/user_management/sessions/logout?session_id=123456&returnTo=https%3A%2F%2Fyour-app.com%2Fsigned-out',
+        );
+      });
+    });
   });
 
   describe('getLogoutUrlFromSessionCookie', () => {

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -1030,7 +1030,7 @@ export class UserManagement {
 
     url.searchParams.set('session_id', sessionId);
     if (returnTo) {
-      url.searchParams.set('returnTo', returnTo);
+      url.searchParams.set('return_to', returnTo);
     }
 
     return url.toString();

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -1012,12 +1012,28 @@ export class UserManagement {
     return `${this.workos.baseURL}/user_management/authorize?${query}`;
   }
 
-  getLogoutUrl({ sessionId }: { sessionId: string }): string {
+  getLogoutUrl({
+    sessionId,
+    returnTo,
+  }: {
+    sessionId: string;
+    returnTo?: string;
+  }): string {
     if (!sessionId) {
       throw new TypeError(`Incomplete arguments. Need to specify 'sessionId'.`);
     }
 
-    return `${this.workos.baseURL}/user_management/sessions/logout?session_id=${sessionId}`;
+    const url = new URL(
+      '/user_management/sessions/logout',
+      this.workos.baseURL,
+    );
+
+    url.searchParams.set('session_id', sessionId);
+    if (returnTo) {
+      url.searchParams.set('returnTo', returnTo);
+    }
+
+    return url.toString();
   }
 
   /**


### PR DESCRIPTION
## Description

Adds a new optional `returnTo` option to `userManagement.getLogoutUrl` to support the upcoming Logout URIs feature.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
