### PR TITLE
Fix library compatibility with workers environment

### DIFF
--- a/src/actions/actions.spec.ts
+++ b/src/actions/actions.spec.ts
@@ -3,7 +3,7 @@ import { WorkOS } from '../workos';
 import mockAuthActionContext from './fixtures/authentication-action-context.json';
 import mockUserRegistrationActionContext from './fixtures/user-registration-action-context.json';
 const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
-import { NodeCryptoProvider } from '../common/crypto';
+import { NodeCryptoProvider } from '../common/crypto/NodeCryptoProvider';
 
 describe('Actions', () => {
   let secret: string;

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1,4 +1,4 @@
-import { SignatureProvider } from '../common/crypto';
+import { SignatureProvider } from '../common/crypto/SignatureProvider';
 import { CryptoProvider } from '../common/crypto/crypto-provider';
 import { unreachable } from '../common/utils/unreachable';
 import { ActionContext, ActionPayload } from './interfaces/action.interface';

--- a/src/common/crypto/index.ts
+++ b/src/common/crypto/index.ts
@@ -1,4 +1,0 @@
-export * from './NodeCryptoProvider';
-export * from './SubtleCryptoProvider';
-export * from './CryptoProvider';
-export * from './SignatureProvider';


### PR DESCRIPTION
## Description

Remove a barrel file that was importing Node-specific libraries, unnecessarily causing compatibility issues with this library when running from Cloudflare workers.

This issue first appeared in workos/authkit-nextjs#187.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.


## Testing

This wasn't caught by the `npm run test:worker` test. Manually testing with wrangler, I can see that the code fails when the `NodeCryptoProvider` is imported (via the barrel file):

![capture_20250121_140633](https://github.com/user-attachments/assets/baef7c36-1174-4f5f-b1a1-1690938985a7)

With this change, there are no errors when running `wrangler dev`.

![capture_20250121_142155](https://github.com/user-attachments/assets/d79767b1-5f15-4bfe-85d8-30e512ebeb93)


