### PR TITLE
Expose the `warrant_token` attribute returned by the FGA check endpoint to the caller

### DIFF
--- a/src/fga/fga.spec.ts
+++ b/src/fga/fga.spec.ts
@@ -20,6 +20,7 @@ describe('FGA', () => {
       fetchOnce({
         result: 'authorized',
         is_implicit: false,
+        warrant_token: 'abc',
       });
       const checkResult = await workos.fga.check({
         checks: [
@@ -40,6 +41,7 @@ describe('FGA', () => {
       expect(checkResult).toMatchObject({
         result: 'authorized',
         isImplicit: false,
+        warrantToken: 'abc',
       });
     });
   });

--- a/src/fga/interfaces/check.interface.ts
+++ b/src/fga/interfaces/check.interface.ts
@@ -47,6 +47,7 @@ export interface SerializedCheckBatchOptions {
 export interface CheckResultResponse {
   result: string;
   is_implicit: boolean;
+  warrant_token: string;
   debug_info?: DebugInfoResponse;
 }
 
@@ -79,17 +80,20 @@ export interface DecisionTreeNodeResponse {
 export interface CheckResultInterface {
   result: string;
   isImplicit: boolean;
+  warrantToken: string;
   debugInfo?: DebugInfo;
 }
 
 export class CheckResult implements CheckResultInterface {
   public result: string;
   public isImplicit: boolean;
+  public warrantToken: string;
   public debugInfo?: DebugInfo;
 
   constructor(json: CheckResultResponse) {
     this.result = json.result;
     this.isImplicit = json.is_implicit;
+    this.warrantToken = json.warrant_token;
     this.debugInfo = json.debug_info
       ? {
           processingTime: json.debug_info.processing_time,


### PR DESCRIPTION
## Description
Now that the [FGA Check endpoint](https://workos.com/docs/reference/fga/check) returns the [Warrant Token](https://workos.com/docs/fga/warrant-tokens) that was used during evaluation of the check, this PR updates the Node SDK to expose the newly returned value to the caller.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
https://github.com/workos/workos/pull/34558