### PR TITLE
Add permissions to roles events and API

### DIFF
--- a/src/organizations/fixtures/list-organization-roles.json
+++ b/src/organizations/fixtures/list-organization-roles.json
@@ -7,6 +7,10 @@
       "name": "Admin",
       "slug": "admin",
       "description": null,
+      "permissions": [
+        "posts:create",
+        "posts:delete"
+      ],
       "type": "EnvironmentRole",
       "created_at": "2024-01-01T00:00:00.000Z",
       "updated_at": "2024-01-01T00:00:00.000Z"
@@ -17,6 +21,7 @@
       "name": "Member",
       "slug": "member",
       "description": null,
+      "permissions": [],
       "type": "EnvironmentRole",
       "created_at": "2024-01-01T00:00:00.000Z",
       "updated_at": "2024-01-01T00:00:00.000Z"
@@ -27,6 +32,9 @@
       "name": "OrganizationMember",
       "slug": "org-member",
       "description": null,
+      "permissions": [
+        "posts:read"
+      ],
       "type": "OrganizationRole",
       "created_at": "2024-01-01T00:00:00.000Z",
       "updated_at": "2024-01-01T00:00:00.000Z"

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -350,7 +350,7 @@ describe('Organizations', () => {
     });
   });
 
-  describe.only('listOrganizationRoles', () => {
+  describe('listOrganizationRoles', () => {
     it('returns roles for the organization', async () => {
       fetchOnce(listOrganizationRolesFixture);
 

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -350,7 +350,7 @@ describe('Organizations', () => {
     });
   });
 
-  describe('listOrganizationRoles', () => {
+  describe.only('listOrganizationRoles', () => {
     it('returns roles for the organization', async () => {
       fetchOnce(listOrganizationRolesFixture);
 
@@ -366,6 +366,41 @@ describe('Organizations', () => {
 
       expect(object).toEqual('list');
       expect(data).toHaveLength(3);
+      expect(data).toEqual([
+        {
+          object: 'role',
+          id: 'role_01EHQMYV6MBK39QC5PZXHY59C5',
+          name: 'Admin',
+          slug: 'admin',
+          description: null,
+          permissions: ['posts:create', 'posts:delete'],
+          type: 'EnvironmentRole',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+        {
+          object: 'role',
+          id: 'role_01EHQMYV6MBK39QC5PZXHY59C3',
+          name: 'Member',
+          slug: 'member',
+          description: null,
+          permissions: [],
+          type: 'EnvironmentRole',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+        {
+          object: 'role',
+          id: 'role_01EHQMYV6MBK39QC5PZXHY59C3',
+          name: 'OrganizationMember',
+          slug: 'org-member',
+          description: null,
+          permissions: ['posts:read'],
+          type: 'OrganizationRole',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ]);
     });
   });
 });

--- a/src/roles/interfaces/role.interface.ts
+++ b/src/roles/interfaces/role.interface.ts
@@ -5,11 +5,17 @@ export interface RoleResponse {
 export interface RoleEvent {
   object: 'role';
   slug: string;
+  permissions: string[];
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface RoleEventResponse {
   object: 'role';
   slug: string;
+  permissions: string[];
+  created_at: string;
+  updated_at: string;
 }
 
 export interface ListOrganizationRolesResponse {

--- a/src/roles/interfaces/role.interface.ts
+++ b/src/roles/interfaces/role.interface.ts
@@ -29,6 +29,7 @@ export interface OrganizationRoleResponse {
   name: string;
   slug: string;
   description: string | null;
+  permissions: string[];
   type: 'EnvironmentRole' | 'OrganizationRole';
   created_at: string;
   updated_at: string;
@@ -40,6 +41,7 @@ export interface Role {
   name: string;
   slug: string;
   description: string | null;
+  permissions: string[];
   type: 'EnvironmentRole' | 'OrganizationRole';
   createdAt: string;
   updatedAt: string;

--- a/src/roles/serializers/role.serializer.ts
+++ b/src/roles/serializers/role.serializer.ts
@@ -6,6 +6,7 @@ export const deserializeRole = (role: OrganizationRoleResponse): Role => ({
   name: role.name,
   slug: role.slug,
   description: role.description,
+  permissions: role.permissions,
   type: role.type,
   createdAt: role.created_at,
   updatedAt: role.updated_at,

--- a/src/user-management/serializers/role.serializer.ts
+++ b/src/user-management/serializers/role.serializer.ts
@@ -3,4 +3,7 @@ import { RoleEvent, RoleEventResponse } from '../../roles/interfaces';
 export const deserializeRoleEvent = (role: RoleEventResponse): RoleEvent => ({
   object: 'role',
   slug: role.slug,
+  permissions: role.permissions,
+  createdAt: role.created_at,
+  updatedAt: role.updated_at,
 });


### PR DESCRIPTION
## Description
Deserialize missing permissions, created at, and updated at fields on role events and add permissions to org. roles API response.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes (API reference)
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
