### PR TITLE
Update Session#refresh() to return all JWT claims

### DIFF
--- a/src/user-management/interfaces/refresh-and-seal-session-data.interface.ts
+++ b/src/user-management/interfaces/refresh-and-seal-session-data.interface.ts
@@ -1,3 +1,4 @@
+import { AuthenticateWithSessionCookieSuccessResponse } from './authenticate-with-session-cookie.interface';
 import { AuthenticationResponse } from './authentication-response.interface';
 
 export enum RefreshAndSealSessionDataFailureReason {
@@ -18,12 +19,14 @@ export enum RefreshAndSealSessionDataFailureReason {
   ORGANIZATION_NOT_AUTHORIZED = 'organization_not_authorized',
 }
 
-// TODO: These should be renamed since it's possible to have an unsealed session
-type RefreshAndSealSessionDataFailedResponse = {
+type RefreshSessionFailedResponse = {
   authenticated: false;
   reason: RefreshAndSealSessionDataFailureReason;
 };
 
+/**
+ * @deprecated To be removed in a future major version along with `refreshAndSealSessionData`.
+ */
 type RefreshAndSealSessionDataSuccessResponse = {
   authenticated: true;
   session?: AuthenticationResponse;
@@ -31,5 +34,20 @@ type RefreshAndSealSessionDataSuccessResponse = {
 };
 
 export type RefreshAndSealSessionDataResponse =
-  | RefreshAndSealSessionDataFailedResponse
+  | RefreshSessionFailedResponse
   | RefreshAndSealSessionDataSuccessResponse;
+
+type RefreshSessionSuccessResponse = Omit<
+  AuthenticateWithSessionCookieSuccessResponse,
+  // accessToken is available in the session object and with session
+  // helpers isn't necessarily useful to return top level
+  'accessToken'
+> & {
+  authenticated: true;
+  session?: AuthenticationResponse;
+  sealedSession?: string;
+};
+
+export type RefreshSessionResponse =
+  | RefreshSessionFailedResponse
+  | RefreshSessionSuccessResponse;

--- a/src/user-management/session.spec.ts
+++ b/src/user-management/session.spec.ts
@@ -208,17 +208,26 @@ describe('Session', () => {
 
         expect(response).toEqual({
           authenticated: true,
-          accessToken: undefined,
-          authenticationMethod: undefined,
-          impersonator: undefined,
-          organizationId: undefined,
-          refreshToken: undefined,
+          impersonator: {
+            email: 'admin@example.com',
+            reason: 'test',
+          },
+          organizationId: 'org_123',
           sealedSession: expect.any(String),
           session: expect.objectContaining({
             sealedSession: expect.any(String),
             user: expect.objectContaining({
               email: 'test01@example.com',
             }),
+          }),
+          entitlements: undefined,
+          permissions: ['posts:create', 'posts:delete'],
+          role: 'member',
+          sessionId: 'session_123',
+          user: expect.objectContaining({
+            email: 'test01@example.com',
+            id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+            object: 'user',
           }),
         });
       });


### PR DESCRIPTION
## Description
Update Session#refresh() to return all JWT claims.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes (API reference)
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
