### PR TITLE
add lastSignInAt to user

### DIFF
--- a/src/user-management/fixtures/list-users.json
+++ b/src/user-management/fixtures/list-users.json
@@ -9,7 +9,9 @@
       "last_name": "User",
       "created_at": "2023-07-18T02:07:19.911Z",
       "updated_at": "2023-07-18T02:07:19.911Z",
-      "email_verified_at": "2023-07-17T20:07:20.055Z"
+      "email_verified": true,
+      "profile_picture_url": "https://example.com/profile_picture.jpg",
+      "last_sign_in_at": "2023-07-18T02:07:19.911Z"
     }
   ],
   "list_metadata": {

--- a/src/user-management/fixtures/user.json
+++ b/src/user-management/fixtures/user.json
@@ -7,5 +7,6 @@
   "created_at": "2023-07-18T02:07:19.911Z",
   "updated_at": "2023-07-18T02:07:19.911Z",
   "email_verified": true,
-  "profile_picture_url": "https://example.com/profile_picture.jpg"
+  "profile_picture_url": "https://example.com/profile_picture.jpg",
+  "last_sign_in_at": "2023-07-18T02:07:19.911Z"
 }

--- a/src/user-management/interfaces/user.interface.ts
+++ b/src/user-management/interfaces/user.interface.ts
@@ -6,6 +6,7 @@ export interface User {
   profilePictureUrl: string | null;
   firstName: string | null;
   lastName: string | null;
+  lastSignInAt: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -18,6 +19,7 @@ export interface UserResponse {
   profile_picture_url: string | null;
   first_name: string | null;
   last_name: string | null;
+  last_sign_in_at: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/user-management/serializers/user.serializer.ts
+++ b/src/user-management/serializers/user.serializer.ts
@@ -8,6 +8,7 @@ export const deserializeUser = (user: UserResponse): User => ({
   firstName: user.first_name,
   profilePictureUrl: user.profile_picture_url,
   lastName: user.last_name,
+  lastSignInAt: user.last_sign_in_at,
   createdAt: user.created_at,
   updatedAt: user.updated_at,
 });

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -54,6 +54,7 @@ describe('UserManagement', () => {
         firstName: 'Test 01',
         lastName: 'User',
         emailVerified: true,
+        lastSignInAt: '2023-07-18T02:07:19.911Z',
       });
     });
   });


### PR DESCRIPTION
## Description
https://linear.app/workos/issue/AUTH-4131/update-workos-node-sdk-for-last-sign-in-at

adds `lastSignInAt` to user

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

docs PR: https://github.com/workos/workos/pull/35170