### PR TITLE
Add externalId support to user

### DIFF
--- a/src/actions/actions.spec.ts
+++ b/src/actions/actions.spec.ts
@@ -126,6 +126,7 @@ describe('Actions', () => {
           profilePictureUrl: 'https://example.com/jane.jpg',
           createdAt: '2024-10-22T17:12:50.746Z',
           updatedAt: '2024-10-22T17:12:50.746Z',
+          externalId: null,
         },
         ipAddress: '50.141.123.10',
         userAgent: 'Mozilla/5.0',

--- a/src/user-management/interfaces/create-user-options.interface.ts
+++ b/src/user-management/interfaces/create-user-options.interface.ts
@@ -8,6 +8,7 @@ export interface CreateUserOptions {
   firstName?: string;
   lastName?: string;
   emailVerified?: boolean;
+  externalId?: string;
 }
 
 export interface SerializedCreateUserOptions {
@@ -18,4 +19,5 @@ export interface SerializedCreateUserOptions {
   first_name?: string;
   last_name?: string;
   email_verified?: boolean;
+  external_id?: string;
 }

--- a/src/user-management/interfaces/update-user-options.interface.ts
+++ b/src/user-management/interfaces/update-user-options.interface.ts
@@ -8,6 +8,7 @@ export interface UpdateUserOptions {
   password?: string;
   passwordHash?: string;
   passwordHashType?: PasswordHashType;
+  externalId?: string;
 }
 
 export interface SerializedUpdateUserOptions {
@@ -17,4 +18,5 @@ export interface SerializedUpdateUserOptions {
   password?: string;
   password_hash?: string;
   password_hash_type?: PasswordHashType;
+  external_id?: string;
 }

--- a/src/user-management/interfaces/user.interface.ts
+++ b/src/user-management/interfaces/user.interface.ts
@@ -9,6 +9,7 @@ export interface User {
   lastSignInAt: string | null;
   createdAt: string;
   updatedAt: string;
+  externalId: string | null;
 }
 
 export interface UserResponse {
@@ -22,4 +23,5 @@ export interface UserResponse {
   last_sign_in_at: string | null;
   created_at: string;
   updated_at: string;
+  external_id?: string;
 }

--- a/src/user-management/serializers/create-user-options.serializer.ts
+++ b/src/user-management/serializers/create-user-options.serializer.ts
@@ -10,4 +10,5 @@ export const serializeCreateUserOptions = (
   first_name: options.firstName,
   last_name: options.lastName,
   email_verified: options.emailVerified,
+  external_id: options.externalId,
 });

--- a/src/user-management/serializers/update-user-options.serializer.ts
+++ b/src/user-management/serializers/update-user-options.serializer.ts
@@ -9,4 +9,5 @@ export const serializeUpdateUserOptions = (
   password: options.password,
   password_hash: options.passwordHash,
   password_hash_type: options.passwordHashType,
+  external_id: options.externalId,
 });

--- a/src/user-management/serializers/user.serializer.ts
+++ b/src/user-management/serializers/user.serializer.ts
@@ -11,4 +11,5 @@ export const deserializeUser = (user: UserResponse): User => ({
   lastSignInAt: user.last_sign_in_at,
   createdAt: user.created_at,
   updatedAt: user.updated_at,
+  externalId: user.external_id ?? null,
 });


### PR DESCRIPTION
Allows adding one during create and update and includes the externalId in the user object.

## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

^ docs are coming but looking to get this out in a preview release ahead of time.
