### PR TITLE
Add external id support for organizations

### DIFF
--- a/src/actions/actions.spec.ts
+++ b/src/actions/actions.spec.ts
@@ -141,6 +141,7 @@ describe('Actions', () => {
           domains: [],
           createdAt: '2024-10-22T17:12:50.746Z',
           updatedAt: '2024-10-22T17:12:50.746Z',
+          externalId: null,
         },
         organizationMembership: {
           object: 'organization_membership',

--- a/src/organizations/interfaces/create-organization-options.interface.ts
+++ b/src/organizations/interfaces/create-organization-options.interface.ts
@@ -4,6 +4,7 @@ import { DomainData } from './domain-data.interface';
 export interface CreateOrganizationOptions {
   name: string;
   domainData?: DomainData[];
+  externalId?: string | null;
 
   /**
    * @deprecated If you need to allow sign-ins from any email domain, contact support@workos.com.
@@ -18,6 +19,7 @@ export interface CreateOrganizationOptions {
 export interface SerializedCreateOrganizationOptions {
   name: string;
   domain_data?: DomainData[];
+  external_id?: string | null;
 
   /**
    * @deprecated If you need to allow sign-ins from any email domain, contact support@workos.com.

--- a/src/organizations/interfaces/organization.interface.ts
+++ b/src/organizations/interfaces/organization.interface.ts
@@ -12,6 +12,7 @@ export interface Organization {
   stripeCustomerId?: string;
   createdAt: string;
   updatedAt: string;
+  externalId: string | null;
 }
 
 export interface OrganizationResponse {
@@ -23,4 +24,5 @@ export interface OrganizationResponse {
   stripe_customer_id?: string;
   created_at: string;
   updated_at: string;
+  external_id?: string | null;
 }

--- a/src/organizations/interfaces/update-organization-options.interface.ts
+++ b/src/organizations/interfaces/update-organization-options.interface.ts
@@ -5,6 +5,7 @@ export interface UpdateOrganizationOptions {
   name?: string;
   domainData?: DomainData[];
   stripeCustomerId?: string | null;
+  externalId?: string | null;
 
   /**
    * @deprecated If you need to allow sign-ins from any email domain, contact support@workos.com.
@@ -20,6 +21,7 @@ export interface SerializedUpdateOrganizationOptions {
   name?: string;
   domain_data?: DomainData[];
   stripe_customer_id?: string | null;
+  external_id?: string | null;
 
   /**
    * @deprecated If you need to allow sign-ins from any email domain, contact support@workos.com.

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -240,6 +240,26 @@ describe('Organizations', () => {
     });
   });
 
+  describe('getOrganizationByExternalId', () => {
+    it('sends request', async () => {
+      const externalId = 'user_external_id';
+      const apiResponse = {
+        ...getOrganization,
+        external_id: externalId,
+      };
+      fetchOnce(apiResponse);
+
+      const organization =
+        await workos.organizations.getOrganizationByExternalId(externalId);
+
+      expect(fetchURL()).toContain(`/organizations/external_id/${externalId}`);
+      expect(organization).toMatchObject({
+        id: apiResponse.id,
+        externalId: apiResponse.external_id,
+      });
+    });
+  });
+
   describe('deleteOrganization', () => {
     it('sends request to delete an Organization', async () => {
       fetchOnce();

--- a/src/organizations/organizations.ts
+++ b/src/organizations/organizations.ts
@@ -68,6 +68,14 @@ export class Organizations {
     return deserializeOrganization(data);
   }
 
+  async getOrganizationByExternalId(externalId: string): Promise<Organization> {
+    const { data } = await this.workos.get<OrganizationResponse>(
+      `/organizations/external_id/${externalId}`,
+    );
+
+    return deserializeOrganization(data);
+  }
+
   async updateOrganization(
     options: UpdateOrganizationOptions,
   ): Promise<Organization> {

--- a/src/organizations/serializers/create-organization-options.serializer.ts
+++ b/src/organizations/serializers/create-organization-options.serializer.ts
@@ -10,4 +10,5 @@ export const serializeCreateOrganizationOptions = (
   allow_profiles_outside_organization: options.allowProfilesOutsideOrganization,
   domain_data: options.domainData,
   domains: options.domains,
+  external_id: options.externalId,
 });

--- a/src/organizations/serializers/organization.serializer.ts
+++ b/src/organizations/serializers/organization.serializer.ts
@@ -15,4 +15,5 @@ export const deserializeOrganization = (
     : { stripeCustomerId: organization.stripe_customer_id }),
   createdAt: organization.created_at,
   updatedAt: organization.updated_at,
+  externalId: organization.external_id ?? null,
 });

--- a/src/organizations/serializers/update-organization-options.serializer.ts
+++ b/src/organizations/serializers/update-organization-options.serializer.ts
@@ -11,4 +11,5 @@ export const serializeUpdateOrganizationOptions = (
   domain_data: options.domainData,
   domains: options.domains,
   stripe_customer_id: options.stripeCustomerId,
+  external_id: options.externalId,
 });


### PR DESCRIPTION
## Description

Deserializes it from the api response, allows creating and updating organizations with an external id, and provides a
getOrganizationByExternalId function.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

Documentation coming soon
