### PR TITLE
Reuse user-management JWKS in sessions

### DIFF
--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -39,11 +39,7 @@ export class Session {
     this.cookiePassword = cookiePassword;
     this.sessionData = sessionData;
 
-    const { clientId } = this.userManagement;
-
-    this.jwks = clientId
-      ? createRemoteJWKSet(new URL(userManagement.getJwksUrl(clientId)))
-      : undefined;
+    this.jwks = this.userManagement.jwks;
   }
 
   /**

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -155,7 +155,7 @@ const toQueryString = (options: Record<string, string | undefined>): string => {
 };
 
 export class UserManagement {
-  private jwks: ReturnType<typeof createRemoteJWKSet> | undefined;
+  private _jwks: ReturnType<typeof createRemoteJWKSet> | undefined;
   public clientId: string | undefined;
   public ironSessionProvider: IronSessionProvider;
 
@@ -167,13 +167,19 @@ export class UserManagement {
 
     this.clientId = clientId;
     this.ironSessionProvider = ironSessionProvider;
+  }
+
+  get jwks(): ReturnType<typeof createRemoteJWKSet> | undefined {
+    if (!this.clientId) {
+      return;
+    }
 
     // Set the JWKS URL. This is used to verify if the JWT is still valid
-    this.jwks = clientId
-      ? createRemoteJWKSet(new URL(this.getJwksUrl(clientId)), {
-          cooldownDuration: 1000 * 60 * 5,
-        })
-      : undefined;
+    this._jwks ??= createRemoteJWKSet(new URL(this.getJwksUrl(this.clientId)), {
+      cooldownDuration: 1000 * 60 * 5,
+    });
+
+    return this._jwks;
   }
 
   /**


### PR DESCRIPTION
## Description

Right now, every Session instance returned from `UserManagement.loadSealedSession` has its own JWKS loader. This change modifies it so that it uses the single JWKS loader created for the `UserManagement` instance itself.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
