### PR TITLE
Add metadata to organizations and users

### DIFF
--- a/src/actions/actions.spec.ts
+++ b/src/actions/actions.spec.ts
@@ -127,6 +127,7 @@ describe('Actions', () => {
           createdAt: '2024-10-22T17:12:50.746Z',
           updatedAt: '2024-10-22T17:12:50.746Z',
           externalId: null,
+          metadata: {},
         },
         ipAddress: '50.141.123.10',
         userAgent: 'Mozilla/5.0',
@@ -142,6 +143,7 @@ describe('Actions', () => {
           createdAt: '2024-10-22T17:12:50.746Z',
           updatedAt: '2024-10-22T17:12:50.746Z',
           externalId: null,
+          metadata: {},
         },
         organizationMembership: {
           object: 'organization_membership',

--- a/src/organizations/fixtures/get-organization.json
+++ b/src/organizations/fixtures/get-organization.json
@@ -12,5 +12,6 @@
       "verification_strategy": "dns",
       "verification_token": "xB8SeACdKJQP9DP4CahU4YuQZ"
     }
-  ]
+  ],
+  "metadata": {}
 }

--- a/src/organizations/interfaces/create-organization-options.interface.ts
+++ b/src/organizations/interfaces/create-organization-options.interface.ts
@@ -5,6 +5,7 @@ export interface CreateOrganizationOptions {
   name: string;
   domainData?: DomainData[];
   externalId?: string | null;
+  metadata?: Record<string, string>;
 
   /**
    * @deprecated If you need to allow sign-ins from any email domain, contact support@workos.com.
@@ -20,6 +21,7 @@ export interface SerializedCreateOrganizationOptions {
   name: string;
   domain_data?: DomainData[];
   external_id?: string | null;
+  metadata?: Record<string, string>;
 
   /**
    * @deprecated If you need to allow sign-ins from any email domain, contact support@workos.com.

--- a/src/organizations/interfaces/organization.interface.ts
+++ b/src/organizations/interfaces/organization.interface.ts
@@ -13,6 +13,7 @@ export interface Organization {
   createdAt: string;
   updatedAt: string;
   externalId: string | null;
+  metadata: Record<string, string>;
 }
 
 export interface OrganizationResponse {
@@ -25,4 +26,5 @@ export interface OrganizationResponse {
   created_at: string;
   updated_at: string;
   external_id?: string | null;
+  metadata?: Record<string, string>;
 }

--- a/src/organizations/interfaces/update-organization-options.interface.ts
+++ b/src/organizations/interfaces/update-organization-options.interface.ts
@@ -6,6 +6,7 @@ export interface UpdateOrganizationOptions {
   domainData?: DomainData[];
   stripeCustomerId?: string | null;
   externalId?: string | null;
+  metadata?: Record<string, string>;
 
   /**
    * @deprecated If you need to allow sign-ins from any email domain, contact support@workos.com.
@@ -22,6 +23,7 @@ export interface SerializedUpdateOrganizationOptions {
   domain_data?: DomainData[];
   stripe_customer_id?: string | null;
   external_id?: string | null;
+  metadata?: Record<string, string>;
 
   /**
    * @deprecated If you need to allow sign-ins from any email domain, contact support@workos.com.

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -187,6 +187,19 @@ describe('Organizations', () => {
           expect(subject.domains).toHaveLength(1);
         });
       });
+
+      it('adds metadata to the request', async () => {
+        fetchOnce(createOrganization, { status: 201 });
+
+        await workos.organizations.createOrganization({
+          name: 'My organization',
+          metadata: { key: 'value' },
+        });
+
+        expect(fetchBody()).toMatchObject({
+          metadata: { key: 'value' },
+        });
+      });
     });
 
     describe('with an invalid payload', () => {
@@ -314,6 +327,19 @@ describe('Organizations', () => {
           expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
           expect(subject.name).toEqual('Test Organization 2');
           expect(subject.domains).toHaveLength(1);
+        });
+      });
+
+      it('adds metadata to the request', async () => {
+        fetchOnce(updateOrganization, { status: 201 });
+
+        await workos.organizations.updateOrganization({
+          organization: 'org_01EHT88Z8J8795GZNQ4ZP1J81T',
+          metadata: { key: 'value' },
+        });
+
+        expect(fetchBody()).toEqual({
+          metadata: { key: 'value' },
         });
       });
     });

--- a/src/organizations/serializers/create-organization-options.serializer.ts
+++ b/src/organizations/serializers/create-organization-options.serializer.ts
@@ -11,4 +11,5 @@ export const serializeCreateOrganizationOptions = (
   domain_data: options.domainData,
   domains: options.domains,
   external_id: options.externalId,
+  metadata: options.metadata,
 });

--- a/src/organizations/serializers/organization.serializer.spec.ts
+++ b/src/organizations/serializers/organization.serializer.spec.ts
@@ -1,0 +1,36 @@
+import { deserializeOrganization } from './organization.serializer';
+import organizationFixture from '../fixtures/get-organization.json';
+
+const organizationResponse = {
+  ...organizationFixture,
+  object: 'organization' as const,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  domains: [],
+};
+
+describe('deserializeOrganization', () => {
+  it('includes metadata if present', () => {
+    const metadata = { key: 'value' };
+
+    expect(
+      deserializeOrganization({
+        ...organizationResponse,
+        metadata,
+      }),
+    ).toMatchObject({
+      metadata,
+    });
+  });
+
+  it('coerces missing metadata to empty object', () => {
+    const { metadata, ...organizationResponseWithoutMetadata } =
+      organizationResponse;
+
+    expect(
+      deserializeOrganization(organizationResponseWithoutMetadata),
+    ).toMatchObject({
+      metadata: {},
+    });
+  });
+});

--- a/src/organizations/serializers/organization.serializer.ts
+++ b/src/organizations/serializers/organization.serializer.ts
@@ -16,4 +16,5 @@ export const deserializeOrganization = (
   createdAt: organization.created_at,
   updatedAt: organization.updated_at,
   externalId: organization.external_id ?? null,
+  metadata: organization.metadata ?? {},
 });

--- a/src/organizations/serializers/update-organization-options.serializer.ts
+++ b/src/organizations/serializers/update-organization-options.serializer.ts
@@ -12,4 +12,5 @@ export const serializeUpdateOrganizationOptions = (
   domains: options.domains,
   stripe_customer_id: options.stripeCustomerId,
   external_id: options.externalId,
+  metadata: options.metadata,
 });

--- a/src/user-management/fixtures/user.json
+++ b/src/user-management/fixtures/user.json
@@ -8,5 +8,6 @@
   "updated_at": "2023-07-18T02:07:19.911Z",
   "email_verified": true,
   "profile_picture_url": "https://example.com/profile_picture.jpg",
-  "last_sign_in_at": "2023-07-18T02:07:19.911Z"
+  "last_sign_in_at": "2023-07-18T02:07:19.911Z",
+  "metadata": { "key": "value" }
 }

--- a/src/user-management/interfaces/create-user-options.interface.ts
+++ b/src/user-management/interfaces/create-user-options.interface.ts
@@ -9,6 +9,7 @@ export interface CreateUserOptions {
   lastName?: string;
   emailVerified?: boolean;
   externalId?: string;
+  metadata?: Record<string, string>;
 }
 
 export interface SerializedCreateUserOptions {
@@ -20,4 +21,5 @@ export interface SerializedCreateUserOptions {
   last_name?: string;
   email_verified?: boolean;
   external_id?: string;
+  metadata?: Record<string, string>;
 }

--- a/src/user-management/interfaces/update-user-options.interface.ts
+++ b/src/user-management/interfaces/update-user-options.interface.ts
@@ -9,6 +9,7 @@ export interface UpdateUserOptions {
   passwordHash?: string;
   passwordHashType?: PasswordHashType;
   externalId?: string;
+  metadata?: Record<string, string>;
 }
 
 export interface SerializedUpdateUserOptions {
@@ -19,4 +20,5 @@ export interface SerializedUpdateUserOptions {
   password_hash?: string;
   password_hash_type?: PasswordHashType;
   external_id?: string;
+  metadata?: Record<string, string>;
 }

--- a/src/user-management/interfaces/user.interface.ts
+++ b/src/user-management/interfaces/user.interface.ts
@@ -10,6 +10,7 @@ export interface User {
   createdAt: string;
   updatedAt: string;
   externalId: string | null;
+  metadata: Record<string, string>;
 }
 
 export interface UserResponse {
@@ -24,4 +25,5 @@ export interface UserResponse {
   created_at: string;
   updated_at: string;
   external_id?: string;
+  metadata?: Record<string, string>;
 }

--- a/src/user-management/serializers/create-user-options.serializer.ts
+++ b/src/user-management/serializers/create-user-options.serializer.ts
@@ -11,4 +11,5 @@ export const serializeCreateUserOptions = (
   last_name: options.lastName,
   email_verified: options.emailVerified,
   external_id: options.externalId,
+  metadata: options.metadata,
 });

--- a/src/user-management/serializers/update-user-options.serializer.ts
+++ b/src/user-management/serializers/update-user-options.serializer.ts
@@ -10,4 +10,5 @@ export const serializeUpdateUserOptions = (
   password_hash: options.passwordHash,
   password_hash_type: options.passwordHashType,
   external_id: options.externalId,
+  metadata: options.metadata,
 });

--- a/src/user-management/serializers/user.serializer.spec.ts
+++ b/src/user-management/serializers/user.serializer.spec.ts
@@ -1,0 +1,28 @@
+import { deserializeUser } from './user.serializer';
+import userFixture from '../fixtures/user.json';
+
+describe('deserializeUser', () => {
+  it('includes metadata if present', () => {
+    const metadata = { key: 'value' };
+
+    expect(
+      deserializeUser({
+        ...userFixture,
+        object: 'user',
+        metadata,
+      }),
+    ).toMatchObject({
+      metadata,
+    });
+  });
+
+  it('coerces missing metadata to empty object', () => {
+    const { metadata, ...userResponseWithoutMetadata } = userFixture;
+
+    expect(
+      deserializeUser({ ...userResponseWithoutMetadata, object: 'user' }),
+    ).toMatchObject({
+      metadata: {},
+    });
+  });
+});

--- a/src/user-management/serializers/user.serializer.ts
+++ b/src/user-management/serializers/user.serializer.ts
@@ -12,4 +12,5 @@ export const deserializeUser = (user: UserResponse): User => ({
   createdAt: user.created_at,
   updatedAt: user.updated_at,
   externalId: user.external_id ?? null,
+  metadata: user.metadata ?? {},
 });

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -144,6 +144,19 @@ describe('UserManagement', () => {
         updatedAt: '2023-07-18T02:07:19.911Z',
       });
     });
+
+    it('adds metadata to the request', async () => {
+      fetchOnce(userFixture);
+
+      await workos.userManagement.createUser({
+        email: 'test01@example.com',
+        metadata: { key: 'value' },
+      });
+
+      expect(fetchBody()).toMatchObject({
+        metadata: { key: 'value' },
+      });
+    });
   });
 
   describe('authenticateUserWithMagicAuth', () => {
@@ -1294,6 +1307,19 @@ describe('UserManagement', () => {
           email: 'test01@example.com',
           profilePictureUrl: 'https://example.com/profile_picture.jpg',
         });
+      });
+    });
+
+    it('adds metadata to the request', async () => {
+      fetchOnce(userFixture);
+
+      await workos.userManagement.updateUser({
+        userId,
+        metadata: { key: 'value' },
+      });
+
+      expect(fetchBody()).toMatchObject({
+        metadata: { key: 'value' },
       });
     });
   });


### PR DESCRIPTION
## Description

Supports passing metadata on updating and creation of both as well.

Right now the API doesn't always return metadata, but it will eventually always return empty object if there is none, and so I've made it so that users and organizations will always have a metadata object after deserialization.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
