### PR TITLE
Make userId or organizationId required when calling listOrganizationMemberships

### DIFF
--- a/src/user-management/interfaces/list-organization-memberships-options.interface.ts
+++ b/src/user-management/interfaces/list-organization-memberships-options.interface.ts
@@ -1,11 +1,12 @@
 import { PaginationOptions } from '../../common/interfaces';
 import { OrganizationMembershipStatus } from './organization-membership.interface';
 
-export interface ListOrganizationMembershipsOptions extends PaginationOptions {
-  organizationId?: string;
-  userId?: string;
+export type ListOrganizationMembershipsOptions = PaginationOptions & {
   statuses?: OrganizationMembershipStatus[];
-}
+} & (
+    | { organizationId: string; userId?: string }
+    | { organizationId?: string; userId: string }
+  );
 
 export interface SerializedListOrganizationMembershipsOptions
   extends PaginationOptions {


### PR DESCRIPTION
## Description
Make `userId` or `organizationId` required when calling list org. memberships, which is how the API is designed. This came up recently in a triage thread, but is a semi-breaking change, so adding to v8 branch.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
