### PR TITLE
Add tests and typing updates for pagination utils

### DIFF
--- a/src/common/utils/pagination.spec.ts
+++ b/src/common/utils/pagination.spec.ts
@@ -1,0 +1,158 @@
+import { List, PaginationOptions } from '../interfaces';
+import { AutoPaginatable } from './pagination';
+
+type TestObject = {
+  id: string;
+};
+
+describe('AutoPaginatable', () => {
+  let mockApiCall: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockApiCall = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('returns initial data when limit is specified', async () => {
+    const initialData: List<TestObject> = {
+      object: 'list',
+      data: [{ id: '1' }, { id: '2' }],
+      listMetadata: { after: 'cursor1' },
+    };
+
+    const paginatable = new AutoPaginatable<TestObject, PaginationOptions>(
+      initialData,
+      mockApiCall,
+      { limit: 2 },
+    );
+
+    const result = await paginatable.autoPagination();
+
+    expect(result).toEqual(initialData.data);
+    expect(mockApiCall).not.toHaveBeenCalled();
+  });
+
+  it('paginates through all pages', async () => {
+    const initialData: List<TestObject> = {
+      object: 'list',
+      data: [{ id: '1' }, { id: '2' }],
+      listMetadata: { after: 'cursor1' },
+    };
+
+    mockApiCall
+      .mockResolvedValueOnce({
+        object: 'list',
+        data: [{ id: '3' }, { id: '4' }],
+        listMetadata: { after: 'cursor2' },
+      })
+      .mockResolvedValueOnce({
+        object: 'list',
+        data: [{ id: '5' }, { id: '6' }],
+        listMetadata: { after: null },
+      });
+
+    const paginatable = new AutoPaginatable<TestObject, PaginationOptions>(
+      initialData,
+      mockApiCall,
+    );
+
+    const resultPromise = paginatable.autoPagination();
+
+    // Fast-forward through setTimeout calls
+    jest.advanceTimersByTimeAsync(250);
+
+    const result = await resultPromise;
+
+    expect(result).toEqual([
+      { id: '3' },
+      { id: '4' },
+      { id: '5' },
+      { id: '6' },
+    ]);
+
+    expect(mockApiCall).toHaveBeenCalledTimes(2);
+    expect(mockApiCall).toHaveBeenNthCalledWith(1, {
+      limit: 100,
+      after: undefined,
+    });
+    expect(mockApiCall).toHaveBeenNthCalledWith(2, {
+      limit: 100,
+      after: 'cursor2',
+    });
+  });
+
+  it('respects rate limiting between requests', async () => {
+    const initialData: List<TestObject> = {
+      object: 'list',
+      data: [{ id: '1' }],
+      listMetadata: { after: 'cursor1' },
+    };
+
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+
+    mockApiCall
+      .mockResolvedValueOnce({
+        object: 'list',
+        data: [{ id: '2' }],
+        listMetadata: { after: 'cursor2' },
+      })
+      .mockResolvedValueOnce({
+        object: 'list',
+        data: [{ id: '3' }],
+        listMetadata: { after: null },
+      });
+
+    const paginatable = new AutoPaginatable<TestObject, PaginationOptions>(
+      initialData,
+      mockApiCall,
+    );
+
+    const resultPromise = paginatable.autoPagination();
+
+    jest.advanceTimersByTimeAsync(250);
+    await resultPromise;
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 250);
+  });
+
+  it('should pass through additional options to api calls', async () => {
+    const initialData: List<TestObject> = {
+      object: 'list',
+      data: [{ id: '1' }],
+      listMetadata: { after: 'cursor1' },
+    };
+
+    mockApiCall
+      .mockResolvedValueOnce({
+        object: 'list',
+        data: [{ id: '2' }],
+        listMetadata: { after: 'cursor2' },
+      })
+      .mockResolvedValueOnce({
+        object: 'list',
+        data: [{ id: '3' }],
+        listMetadata: { after: null },
+      });
+
+    const paginatable = new AutoPaginatable<
+      TestObject,
+      PaginationOptions & { status: 'active' }
+    >(initialData, mockApiCall, { status: 'active' });
+
+    const resultPromise = paginatable.autoPagination();
+    jest.advanceTimersByTimeAsync(1000);
+    await resultPromise;
+
+    expect(mockApiCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'active',
+        limit: 100,
+      }),
+    );
+  });
+});

--- a/src/common/utils/pagination.spec.ts
+++ b/src/common/utils/pagination.spec.ts
@@ -120,7 +120,7 @@ describe('AutoPaginatable', () => {
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 250);
   });
 
-  it('should pass through additional options to api calls', async () => {
+  it('passes through additional options to API calls', async () => {
     const initialData: List<TestObject> = {
       object: 'list',
       data: [{ id: '1' }],
@@ -148,11 +148,15 @@ describe('AutoPaginatable', () => {
     jest.advanceTimersByTimeAsync(1000);
     await resultPromise;
 
-    expect(mockApiCall).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: 'active',
-        limit: 100,
-      }),
-    );
+    expect(mockApiCall).toHaveBeenNthCalledWith(1, {
+      after: undefined,
+      status: 'active',
+      limit: 100,
+    });
+    expect(mockApiCall).toHaveBeenNthCalledWith(2, {
+      after: 'cursor2',
+      status: 'active',
+      limit: 100,
+    });
   });
 });

--- a/src/common/utils/pagination.ts
+++ b/src/common/utils/pagination.ts
@@ -1,20 +1,21 @@
 import { List, PaginationOptions } from '../interfaces';
 
-export class AutoPaginatable<T> {
-  readonly object = 'list' as const;
-  readonly options: PaginationOptions;
+export class AutoPaginatable<
+  ResourceType,
+  ParametersType extends PaginationOptions,
+> {
+  readonly object: 'list' = 'list';
+  readonly options: ParametersType;
 
   constructor(
-    private list: List<T>,
-    private apiCall: (params: PaginationOptions) => Promise<List<T>>,
-    options?: PaginationOptions,
+    private list: List<ResourceType>,
+    private apiCall: (params: ParametersType) => Promise<List<ResourceType>>,
+    options?: ParametersType,
   ) {
-    this.options = {
-      ...options,
-    };
+    this.options = options ?? ({} as ParametersType);
   }
 
-  get data(): T[] {
+  get data(): ResourceType[] {
     return this.list.data;
   }
 
@@ -22,7 +23,9 @@ export class AutoPaginatable<T> {
     return this.list.listMetadata;
   }
 
-  private async *generatePages(params: PaginationOptions): AsyncGenerator<T[]> {
+  private async *generatePages(
+    params: PaginationOptions,
+  ): AsyncGenerator<ResourceType[]> {
     const result = await this.apiCall({
       ...this.options,
       limit: 100,
@@ -34,7 +37,9 @@ export class AutoPaginatable<T> {
     if (result.listMetadata.after) {
       // Delay of 4rps to respect list users rate limits
       await new Promise((resolve) => setTimeout(resolve, 250));
-      yield* this.generatePages({ after: result.listMetadata.after });
+      yield* this.generatePages({
+        after: result.listMetadata.after,
+      });
     }
   }
 
@@ -42,12 +47,12 @@ export class AutoPaginatable<T> {
    * Automatically paginates over the list of results, returning the complete data set.
    * Returns the first result if `options.limit` is passed to the first request.
    */
-  async autoPagination(): Promise<T[]> {
+  async autoPagination(): Promise<ResourceType[]> {
     if (this.options.limit) {
       return this.data;
     }
 
-    const results: T[] = [];
+    const results: ResourceType[] = [];
 
     for await (const page of this.generatePages({
       after: this.options.after,

--- a/src/common/utils/pagination.ts
+++ b/src/common/utils/pagination.ts
@@ -4,7 +4,7 @@ export class AutoPaginatable<
   ResourceType,
   ParametersType extends PaginationOptions,
 > {
-  readonly object: 'list' = 'list';
+  readonly object = 'list' as const;
   readonly options: ParametersType;
 
   constructor(

--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -11,6 +11,7 @@ import {
   ListDirectoriesOptions,
   ListDirectoryGroupsOptions,
   ListDirectoryUsersOptions,
+  SerializedListDirectoriesOptions,
 } from './interfaces';
 import {
   deserializeDirectory,
@@ -25,7 +26,7 @@ export class DirectorySync {
 
   async listDirectories(
     options?: ListDirectoriesOptions,
-  ): Promise<AutoPaginatable<Directory>> {
+  ): Promise<AutoPaginatable<Directory, SerializedListDirectoriesOptions>> {
     return new AutoPaginatable(
       await fetchAndDeserialize<DirectoryResponse, Directory>(
         this.workos,
@@ -58,7 +59,7 @@ export class DirectorySync {
 
   async listGroups(
     options: ListDirectoryGroupsOptions,
-  ): Promise<AutoPaginatable<DirectoryGroup>> {
+  ): Promise<AutoPaginatable<DirectoryGroup, ListDirectoryGroupsOptions>> {
     return new AutoPaginatable(
       await fetchAndDeserialize<DirectoryGroupResponse, DirectoryGroup>(
         this.workos,
@@ -79,7 +80,12 @@ export class DirectorySync {
 
   async listUsers<TCustomAttributes extends object = DefaultCustomAttributes>(
     options: ListDirectoryUsersOptions,
-  ): Promise<AutoPaginatable<DirectoryUserWithGroups<TCustomAttributes>>> {
+  ): Promise<
+    AutoPaginatable<
+      DirectoryUserWithGroups<TCustomAttributes>,
+      ListDirectoryUsersOptions
+    >
+  > {
     return new AutoPaginatable(
       await fetchAndDeserialize<
         DirectoryUserWithGroupsResponse<TCustomAttributes>,

--- a/src/fga/fga.ts
+++ b/src/fga/fga.ts
@@ -26,6 +26,9 @@ import {
   WarrantTokenResponse,
   BatchWriteResourcesOptions,
   BatchWriteResourcesResponse,
+  SerializedQueryOptions,
+  SerializedListWarrantsOptions,
+  SerializedListResourcesOptions,
 } from './interfaces';
 import {
   deserializeBatchWriteResourcesResponse,
@@ -103,7 +106,7 @@ export class FGA {
 
   async listResources(
     options?: ListResourcesOptions,
-  ): Promise<AutoPaginatable<Resource>> {
+  ): Promise<AutoPaginatable<Resource, SerializedListResourcesOptions>> {
     return new AutoPaginatable(
       await fetchAndDeserialize<ResourceResponse, Resource>(
         this.workos,
@@ -184,7 +187,7 @@ export class FGA {
   async listWarrants(
     options?: ListWarrantsOptions,
     requestOptions?: ListWarrantsRequestOptions,
-  ): Promise<AutoPaginatable<Warrant>> {
+  ): Promise<AutoPaginatable<Warrant, SerializedListWarrantsOptions>> {
     return new AutoPaginatable(
       await fetchAndDeserialize<WarrantResponse, Warrant>(
         this.workos,
@@ -208,7 +211,7 @@ export class FGA {
   async query(
     options: QueryOptions,
     requestOptions: QueryRequestOptions = {},
-  ): Promise<AutoPaginatable<QueryResult>> {
+  ): Promise<AutoPaginatable<QueryResult, SerializedQueryOptions>> {
     return new AutoPaginatable(
       await fetchAndDeserialize<QueryResultResponse, QueryResult>(
         this.workos,

--- a/src/organizations/organizations.ts
+++ b/src/organizations/organizations.ts
@@ -24,7 +24,7 @@ export class Organizations {
 
   async listOrganizations(
     options?: ListOrganizationsOptions,
-  ): Promise<AutoPaginatable<Organization>> {
+  ): Promise<AutoPaginatable<Organization, ListOrganizationsOptions>> {
     return new AutoPaginatable(
       await fetchAndDeserialize<OrganizationResponse, Organization>(
         this.workos,

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -11,6 +11,7 @@ import {
   ProfileAndToken,
   ProfileAndTokenResponse,
   ProfileResponse,
+  SerializedListConnectionsOptions,
 } from './interfaces';
 import {
   deserializeConnection,
@@ -40,7 +41,7 @@ export class SSO {
 
   async listConnections(
     options?: ListConnectionsOptions,
-  ): Promise<AutoPaginatable<Connection>> {
+  ): Promise<AutoPaginatable<Connection, SerializedListConnectionsOptions>> {
     return new AutoPaginatable(
       await fetchAndDeserialize<ConnectionResponse, Connection>(
         this.workos,

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -35,6 +35,7 @@ import {
   SerializedCreateMagicAuthOptions,
   SerializedCreatePasswordResetOptions,
   SerializedCreateUserOptions,
+  SerializedListUsersOptions,
   SerializedResetPasswordOptions,
   SerializedVerifyEmailOptions,
   UpdateUserOptions,
@@ -74,8 +75,14 @@ import {
   Invitation,
   InvitationResponse,
 } from './interfaces/invitation.interface';
-import { ListInvitationsOptions } from './interfaces/list-invitations-options.interface';
-import { ListOrganizationMembershipsOptions } from './interfaces/list-organization-memberships-options.interface';
+import {
+  ListInvitationsOptions,
+  SerializedListInvitationsOptions,
+} from './interfaces/list-invitations-options.interface';
+import {
+  ListOrganizationMembershipsOptions,
+  SerializedListOrganizationMembershipsOptions,
+} from './interfaces/list-organization-memberships-options.interface';
 import {
   OrganizationMembership,
   OrganizationMembershipResponse,
@@ -127,6 +134,7 @@ import { serializeSendInvitationOptions } from './serializers/send-invitation-op
 import { serializeUpdateOrganizationMembershipOptions } from './serializers/update-organization-membership-options.serializer';
 import { Session } from './session';
 import { sealData, unsealData } from 'iron-session';
+import { PaginationOptions } from '../common/interfaces/pagination-options.interface';
 
 const toQueryString = (options: Record<string, string | undefined>): string => {
   const searchParams = new URLSearchParams();
@@ -197,7 +205,9 @@ export class UserManagement {
     return deserializeUser(data);
   }
 
-  async listUsers(options?: ListUsersOptions): Promise<AutoPaginatable<User>> {
+  async listUsers(
+    options?: ListUsersOptions,
+  ): Promise<AutoPaginatable<User, SerializedListUsersOptions>> {
     return new AutoPaginatable(
       await fetchAndDeserialize<UserResponse, User>(
         this.workos,
@@ -645,7 +655,7 @@ export class UserManagement {
 
   async listAuthFactors(
     options: ListAuthFactorsOptions,
-  ): Promise<AutoPaginatable<Factor>> {
+  ): Promise<AutoPaginatable<Factor, PaginationOptions>> {
     const { userId, ...restOfOptions } = options;
     return new AutoPaginatable(
       await fetchAndDeserialize<FactorResponse, Factor>(
@@ -693,7 +703,15 @@ export class UserManagement {
 
   async listOrganizationMemberships(
     options: ListOrganizationMembershipsOptions,
-  ): Promise<AutoPaginatable<OrganizationMembership>> {
+  ): Promise<
+    AutoPaginatable<
+      OrganizationMembership,
+      SerializedListOrganizationMembershipsOptions
+    >
+  > {
+    const serializedOptions =
+      serializeListOrganizationMembershipsOptions(options);
+
     return new AutoPaginatable(
       await fetchAndDeserialize<
         OrganizationMembershipResponse,
@@ -702,9 +720,7 @@ export class UserManagement {
         this.workos,
         '/user_management/organization_memberships',
         deserializeOrganizationMembership,
-        options
-          ? serializeListOrganizationMembershipsOptions(options)
-          : undefined,
+        serializedOptions,
       ),
       (params) =>
         fetchAndDeserialize<
@@ -716,9 +732,7 @@ export class UserManagement {
           deserializeOrganizationMembership,
           params,
         ),
-      options
-        ? serializeListOrganizationMembershipsOptions(options)
-        : undefined,
+      serializedOptions,
     );
   }
 
@@ -799,7 +813,7 @@ export class UserManagement {
 
   async listInvitations(
     options: ListInvitationsOptions,
-  ): Promise<AutoPaginatable<Invitation>> {
+  ): Promise<AutoPaginatable<Invitation, SerializedListInvitationsOptions>> {
     return new AutoPaginatable(
       await fetchAndDeserialize<InvitationResponse, Invitation>(
         this.workos,


### PR DESCRIPTION
## Description
Adds tests and updates typing for pagination utils.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
