### PR TITLE
General dev dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/cookie": "^0.6.0",
         "@types/jest": "^29.5.14",
         "@types/node": "~18",
-        "@types/pluralize": "0.0.30",
+        "@types/pluralize": "0.0.33",
         "@typescript-eslint/parser": "^8.25.0",
         "babel-jest": "^29.7.0",
         "eslint": "^9.21.0",
@@ -3140,9 +3140,9 @@
       }
     },
     "node_modules/@types/pluralize": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.30.tgz",
-      "integrity": "sha512-kVww6xZrW/db5BR9OqiT71J9huRdQ+z/r+LbDuT7/EK50mCmj5FoaIARnVv0rvjUS/YpDox0cDU9lpQT011VBA==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.33.tgz",
+      "integrity": "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/cookie": "^0.6.0",
     "@types/jest": "^29.5.14",
     "@types/node": "~18",
-    "@types/pluralize": "0.0.30",
+    "@types/pluralize": "0.0.33",
     "@typescript-eslint/parser": "^8.25.0",
     "babel-jest": "^29.7.0",
     "eslint": "^9.21.0",


### PR DESCRIPTION
>[!note]
>This change is against the `version-8` branch.

## Description

Update to latest of the following dev dependencies
- TypeScript
- ts-jest
- Jest
- Supertest

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
