### PR TITLE
add password_reset.succeeded event type

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -358,6 +358,16 @@ export interface PasswordResetCreatedEventResponse extends EventResponseBase {
   data: PasswordResetEventResponse;
 }
 
+export interface PasswordResetSucceededEvent extends EventBase {
+  event: 'password_reset.succeeded';
+  data: PasswordResetEvent;
+}
+
+export interface PasswordResetSucceededEventResponse extends EventResponseBase {
+  event: 'password_reset.succeeded';
+  data: PasswordResetEventResponse;
+}
+
 export interface UserCreatedEvent extends EventBase {
   event: 'user.created';
   data: User;
@@ -575,6 +585,7 @@ export type Event =
   | InvitationCreatedEvent
   | MagicAuthCreatedEvent
   | PasswordResetCreatedEvent
+  | PasswordResetSucceededEvent
   | UserCreatedEvent
   | UserUpdatedEvent
   | UserDeletedEvent
@@ -622,6 +633,7 @@ export type EventResponse =
   | InvitationCreatedEventResponse
   | MagicAuthCreatedEventResponse
   | PasswordResetCreatedEventResponse
+  | PasswordResetSucceededEventResponse
   | UserCreatedEventResponse
   | UserUpdatedEventResponse
   | UserDeletedEventResponse

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -121,6 +121,7 @@ export const deserializeEvent = (event: EventResponse): Event => {
         data: deserializeMagicAuthEvent(event.data),
       };
     case 'password_reset.created':
+    case 'password_reset.succeeded':
       return {
         ...eventBase,
         event: event.event,


### PR DESCRIPTION
## Description
https://linear.app/workos/issue/AUTH-4438/add-password-resetsucceeded-event-to-node-sdk

adds support for `password_reset.succeeded` event type

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
