### PR TITLE
Add organizationId to organization domain

### DIFF
--- a/src/organization-domains/fixtures/get-organization-domain-pending.json
+++ b/src/organization-domains/fixtures/get-organization-domain-pending.json
@@ -1,6 +1,7 @@
 {
   "object": "organization_domain",
   "id": "org_domain_01HD50K7EPWCMNPGMKXKKE14XT",
+  "organization_id": "org_01JR8C1EHCRPV4B4XP4W2B9X1M",
   "domain": "workos.com",
   "state": "pending",
   "verification_token": "F06PGMsZIO0shrveGWuGxgCj7",

--- a/src/organization-domains/fixtures/get-organization-domain-verified.json
+++ b/src/organization-domains/fixtures/get-organization-domain-verified.json
@@ -1,6 +1,7 @@
 {
   "object": "organization_domain",
   "id": "org_domain_01HCZRAP3TPQ0X0DKJHR32TATG",
+  "organization_id": "org_01JR8C1EHCRPV4B4XP4W2B9X1M",
   "domain": "workos.com",
   "state": "verified",
   "verification_token": null,

--- a/src/organization-domains/interfaces/organization-domain.interface.ts
+++ b/src/organization-domains/interfaces/organization-domain.interface.ts
@@ -17,6 +17,7 @@ export interface OrganizationDomain {
   object: 'organization_domain';
   id: string;
   domain: string;
+  organizationId: string;
   state: OrganizationDomainState;
   verificationToken?: string;
   verificationStrategy: OrganizationDomainVerificationStrategy;
@@ -26,6 +27,7 @@ export interface OrganizationDomainResponse {
   object: 'organization_domain';
   id: string;
   domain: string;
+  organization_id: string;
   state: OrganizationDomainState;
   verification_token?: string;
   verification_strategy: OrganizationDomainVerificationStrategy;

--- a/src/organization-domains/organization-domains.spec.ts
+++ b/src/organization-domains/organization-domains.spec.ts
@@ -23,6 +23,7 @@ describe('OrganizationDomains', () => {
       );
       expect(subject.id).toEqual('org_domain_01HCZRAP3TPQ0X0DKJHR32TATG');
       expect(subject.domain).toEqual('workos.com');
+      expect(subject.organizationId).toEqual('org_01JR8C1EHCRPV4B4XP4W2B9X1M');
       expect(subject.state).toEqual(OrganizationDomainState.Verified);
       expect(subject.verificationToken).toBeNull();
       expect(subject.verificationStrategy).toEqual('manual');
@@ -40,6 +41,7 @@ describe('OrganizationDomains', () => {
       );
       expect(subject.id).toEqual('org_domain_01HD50K7EPWCMNPGMKXKKE14XT');
       expect(subject.domain).toEqual('workos.com');
+      expect(subject.organizationId).toEqual('org_01JR8C1EHCRPV4B4XP4W2B9X1M');
       expect(subject.state).toEqual(OrganizationDomainState.Pending);
       expect(subject.verificationToken).toEqual('F06PGMsZIO0shrveGWuGxgCj7');
       expect(subject.verificationStrategy).toEqual('dns');
@@ -59,6 +61,7 @@ describe('OrganizationDomains', () => {
       );
       expect(subject.id).toEqual('org_domain_01HD50K7EPWCMNPGMKXKKE14XT');
       expect(subject.domain).toEqual('workos.com');
+      expect(subject.organizationId).toEqual('org_01JR8C1EHCRPV4B4XP4W2B9X1M');
       expect(subject.state).toEqual(OrganizationDomainState.Pending);
       expect(subject.verificationToken).toEqual('F06PGMsZIO0shrveGWuGxgCj7');
       expect(subject.verificationStrategy).toEqual('dns');
@@ -82,6 +85,7 @@ describe('OrganizationDomains', () => {
 
       expect(subject.id).toEqual('org_domain_01HD50K7EPWCMNPGMKXKKE14XT');
       expect(subject.domain).toEqual('workos.com');
+      expect(subject.organizationId).toEqual('org_01JR8C1EHCRPV4B4XP4W2B9X1M');
       expect(subject.state).toEqual(OrganizationDomainState.Pending);
       expect(subject.verificationToken).toEqual('F06PGMsZIO0shrveGWuGxgCj7');
       expect(subject.verificationStrategy).toEqual('dns');

--- a/src/organization-domains/serializers/organization-domain.serializer.ts
+++ b/src/organization-domains/serializers/organization-domain.serializer.ts
@@ -6,6 +6,7 @@ export const deserializeOrganizationDomain = (
   object: organizationDomain.object,
   id: organizationDomain.id,
   domain: organizationDomain.domain,
+  organizationId: organizationDomain.organization_id,
   state: organizationDomain.state,
   verificationToken: organizationDomain.verification_token,
   verificationStrategy: organizationDomain.verification_strategy,


### PR DESCRIPTION
## Description

Add `organizationId` to the response as indicated in work-os-playground-domain-verification-v4hbbh

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
