### PR TITLE
Deprecate `context` option on `getAuthorizationUrl`

### DIFF
--- a/src/user-management/interfaces/authorization-url-options.interface.ts
+++ b/src/user-management/interfaces/authorization-url-options.interface.ts
@@ -3,6 +3,10 @@ export interface AuthorizationURLOptions {
   codeChallenge?: string;
   codeChallengeMethod?: 'S256';
   connectionId?: string;
+  /**
+   *  @deprecated We previously required initiate login endpoints to return the `context`
+   *  query parameter when getting the authorization URL. This is no longer necessary.
+   */
   context?: string;
   organizationId?: string;
   domainHint?: string;

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -1007,6 +1007,13 @@ export class UserManagement {
       );
     }
 
+    if (context) {
+      this.workos.emitWarning(
+        `\`context\` is deprecated. We previously required initiate login endpoints to return the
+\`context\` query parameter when getting the authorization URL. This is no longer necessary.`,
+      );
+    }
+
     const query = toQueryString({
       connection_id: connectionId,
       code_challenge: codeChallenge,


### PR DESCRIPTION
We no longer need applications' initiate login endpoints to return the `context` query parameter when getting the authorization URL. This PR deprecates that option from the `getAuthorizationUrl` and `signIn` functions and prints a message to the console when it's used. In a future release, we can remove this option entirely.
