### PR TITLE
Support optional authenticated data in local encrypt/decrypt

### DIFF
--- a/src/vault/cryptography/decrypt.ts
+++ b/src/vault/cryptography/decrypt.ts
@@ -8,15 +8,21 @@ export interface Decoded {
   ciphertext: Buffer;
 }
 
-export const decrypt = (payload: string | Decoded, dataKey: string): string => {
+export const decrypt = (
+  payload: string | Decoded,
+  dataKey: string,
+  aad: string,
+): string => {
   if (typeof payload === 'string') {
     payload = decode(payload);
   }
   const { iv, tag, ciphertext } = payload;
   const key = Buffer.from(dataKey, 'base64');
 
-  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
-  decipher.setAuthTag(tag);
+  const decipher = crypto
+    .createDecipheriv('aes-256-gcm', key, iv)
+    .setAAD(Buffer.from(aad))
+    .setAuthTag(tag);
   const decrypted =
     decipher.update(ciphertext, undefined, 'utf-8') + decipher.final('utf-8');
   return decrypted;

--- a/src/vault/cryptography/encrypt.ts
+++ b/src/vault/cryptography/encrypt.ts
@@ -5,13 +5,16 @@ export const encrypt = (
   data: string,
   dataKey: string,
   encryptedKeys: string,
+  aad: string,
 ): string => {
   // encrypt using the returned data key
   const key = Buffer.from(dataKey, 'base64');
   const keyBlob = Buffer.from(encryptedKeys, 'base64');
   const prefixLen = encodeUInt32(keyBlob.length);
   const iv = crypto.randomBytes(32);
-  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const cipher = crypto
+    .createCipheriv('aes-256-gcm', key, iv)
+    .setAAD(Buffer.from(aad));
   const ciphertext = Buffer.concat([
     cipher.update(data, 'utf8'),
     cipher.final(),

--- a/src/vault/vault-live-test.spec.ts
+++ b/src/vault/vault-live-test.spec.ts
@@ -280,5 +280,24 @@ describe.skip('Vault Live Test', () => {
       const decrypted = await workos.vault.decrypt(encrypted);
       expect(decrypted).toBe(superObject);
     });
+
+    it('authenticates additional data', async () => {
+      const data = 'hot water freezes faster than cold water';
+      const keyContext = { everything: 'everywhere' };
+      const aad = 'seq1';
+      const encrypted = await workos.vault.encrypt(data, keyContext, aad);
+      const decrypted = await workos.vault.decrypt(encrypted, aad);
+      expect(decrypted).toBe(data);
+    });
+
+    it('fails with invalid AD', async () => {
+      const data = 'hot water freezes faster than cold water';
+      const keyContext = { everything: 'everywhere' };
+      const aad = 'seq1';
+      const encrypted = await workos.vault.encrypt(data, keyContext, aad);
+      await expect(() => workos.vault.decrypt(encrypted)).rejects.toThrow(
+        'unable to authenticate data',
+      );
+    });
   });
 });

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -116,17 +116,24 @@ export class Vault {
     return deserializeDecryptDataKeyResponse(data);
   }
 
-  async encrypt(data: string, context: KeyContext): Promise<string> {
+  async encrypt(
+    data: string,
+    context: KeyContext,
+    associatedData?: string,
+  ): Promise<string> {
     const { dataKey, encryptedKeys } = await this.createDataKey({
       context,
     });
-    return encrypt(data, dataKey.key, encryptedKeys);
+    return encrypt(data, dataKey.key, encryptedKeys, associatedData || '');
   }
 
-  async decrypt(encryptedData: string): Promise<string> {
+  async decrypt(
+    encryptedData: string,
+    associatedData?: string,
+  ): Promise<string> {
     const decoded = decode(encryptedData);
     const dataKey = await this.decryptDataKey({ keys: decoded.keys });
-    return decrypt(decoded, dataKey.key);
+    return decrypt(decoded, dataKey.key, associatedData || '');
   }
 
   /*


### PR DESCRIPTION
## Description

Add an optional parameter to the Vault local encrypt/decrypt functions for additionally authenticated data.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
https://github.com/workos/workos/pull/38690
