### PR TITLE
Allow null value metadata

### DIFF
--- a/src/user-management/interfaces/update-user-options.interface.ts
+++ b/src/user-management/interfaces/update-user-options.interface.ts
@@ -9,7 +9,7 @@ export interface UpdateUserOptions {
   passwordHash?: string;
   passwordHashType?: PasswordHashType;
   externalId?: string;
-  metadata?: Record<string, string>;
+  metadata?: Record<string, string | null>;
 }
 
 export interface SerializedUpdateUserOptions {

--- a/src/user-management/interfaces/update-user-options.interface.ts
+++ b/src/user-management/interfaces/update-user-options.interface.ts
@@ -20,5 +20,5 @@ export interface SerializedUpdateUserOptions {
   password_hash?: string;
   password_hash_type?: PasswordHashType;
   external_id?: string;
-  metadata?: Record<string, string>;
+  metadata?: Record<string, string | null>;
 }

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -1322,6 +1322,19 @@ describe('UserManagement', () => {
         metadata: { key: 'value' },
       });
     });
+
+    it('adds metadata to the request', async () => {
+      fetchOnce(userFixture);
+
+      await workos.userManagement.updateUser({
+        userId,
+        metadata: { key: null },
+      });
+
+      expect(fetchBody()).toMatchObject({
+        metadata: {},
+      });
+    });
   });
 
   describe('enrollAuthFactor', () => {

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -1323,7 +1323,7 @@ describe('UserManagement', () => {
       });
     });
 
-    it('adds metadata to the request', async () => {
+    it('removes metadata from the request', async () => {
       fetchOnce(userFixture);
 
       await workos.userManagement.updateUser({


### PR DESCRIPTION
## Description
We say in our [docs](https://workos.com/docs/user-management/metadata/add-and-update-metadata) that to remove a metadata field, you should set the value to null:

> To delete a metadata attribute, set the key to null in the metadata object of the request body.

This works via Postman. However, in our workos-node SDK, we have the TS interface set to only accept string values for the metadata object ([here](https://github.com/workos/workos-node/blob/16a31c8605bc91c66616e7e54dd15c0ec2b7da66/src/user-management/interfaces/update-user-options.interface.ts#L12)).

This PR adds `null` to the`UpdateUserOptions` and `SerializedUpdateUserOptions` interfaces and adds one test. 

## Documentation
No docs changes needed

## Review
I would love eyes on my test - I am pretty sure it is correctly testing that the key is removed from the metadata since the [user fixture](https://github.com/workos/workos-node/blob/16a31c8605bc91c66616e7e54dd15c0ec2b7da66/src/user-management/fixtures/user.json) starts with a value there, but I'd love confirmation! 