### PR TITLE
[v8] Add other runtime checks for environment variables

### DIFF
--- a/src/common/utils/env.ts
+++ b/src/common/utils/env.ts
@@ -1,0 +1,58 @@
+/**
+ * Cross-runtime environment variable helper
+ */
+
+// Declare global types for runtime environments
+declare global {
+  // Deno namespace declaration
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Deno {
+    export const env: {
+      get(key: string): string | undefined;
+    };
+  }
+
+  // Extend globalThis for Cloudflare Workers
+  interface GlobalThis {
+    env?: Record<string, string>;
+    [key: string]: any;
+  }
+}
+
+function getEnvironmentVariable(key: string): string | undefined {
+  // Node.js
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env[key];
+  }
+
+  // Deno
+  if (typeof (globalThis as any).Deno !== 'undefined') {
+    return (globalThis as any).Deno.env.get(key);
+  }
+
+  // Cloudflare Workers (via global env object)
+  if (typeof globalThis !== 'undefined' && (globalThis as any).env) {
+    return (globalThis as any).env[key];
+  }
+
+  // Cloudflare Workers (direct global access)
+  if (typeof globalThis !== 'undefined' && key in globalThis) {
+    return (globalThis as any)[key];
+  }
+
+  return undefined;
+}
+
+/**
+ * Get an environment variable value, trying to access it in different runtimes.
+ * @param key - The name of the environment variable.
+ * @param defaultValue - The default value to return if the variable is not found.
+ * @return The value of the environment variable or the default value.
+ */
+export function getEnv<T = string>(
+  key: string,
+  defaultValue?: T,
+): string | T | undefined {
+  return getEnvironmentVariable(key) ?? defaultValue;
+}
+

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -1,6 +1,7 @@
 import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
 import { fetchAndDeserialize } from '../common/utils/fetch-and-deserialize';
 import { AutoPaginatable } from '../common/utils/pagination';
+import { getEnv } from '../common/utils/env';
 import { Challenge, ChallengeResponse } from '../mfa/interfaces';
 import { deserializeChallenge } from '../mfa/serializers';
 import { WorkOS } from '../workos';
@@ -391,7 +392,7 @@ export class UserManagement {
 
   async authenticateWithSessionCookie({
     sessionData,
-    cookiePassword = process.env.WORKOS_COOKIE_PASSWORD,
+    cookiePassword = getEnv('WORKOS_COOKIE_PASSWORD'),
   }: AuthenticateWithSessionCookieOptions): Promise<
     | AuthenticateWithSessionCookieSuccessResponse
     | AuthenticateWithSessionCookieFailedResponse
@@ -514,7 +515,7 @@ export class UserManagement {
 
   async getSessionFromCookie({
     sessionData,
-    cookiePassword = process.env.WORKOS_COOKIE_PASSWORD,
+    cookiePassword = getEnv('WORKOS_COOKIE_PASSWORD'),
   }: SessionHandlerOptions): Promise<SessionCookieData | undefined> {
     if (!cookiePassword) {
       throw new Error('Cookie password is required');


### PR DESCRIPTION
## Description

This pull request introduces a cross-runtime utility for accessing environment variables and updates the `UserManagement` class to use this utility for improved runtime compatibility and code consistency.

### Cross-runtime environment variable utility:

* Added a new helper function, `getEnv`, in `src/common/utils/env.ts`. This function retrieves environment variables across different runtimes, including Node.js, Deno, and Cloudflare Workers, with support for a default value.

### Updates to `UserManagement`:

* Replaced direct usage of `process.env` with the new `getEnv` utility for the `cookiePassword` parameter in the `authenticateWithSessionCookie` and `getSessionFromCookie` methods. This ensures compatibility with multiple runtimes. [[1]](diffhunk://#diff-5df813524b03843b7a76359f2c080a36e82f2c065c578794071eb6ffcc0efa7cL394-R395) [[2]](diffhunk://#diff-5df813524b03843b7a76359f2c080a36e82f2c065c578794071eb6ffcc0efa7cL517-R518)
* Imported the `getEnv` function in `src/user-management/user-management.ts`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
