### PR TITLE
Add feature flags to parsed access-token results

### DIFF
--- a/src/user-management/interfaces/authenticate-with-session-cookie.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-session-cookie.interface.ts
@@ -13,6 +13,7 @@ export interface AccessToken {
   role?: string;
   permissions?: string[];
   entitlements?: string[];
+  feature_flags?: string[];
 }
 
 export type SessionCookieData = Pick<
@@ -38,6 +39,7 @@ export type AuthenticateWithSessionCookieSuccessResponse = {
   role?: string;
   permissions?: string[];
   entitlements?: string[];
+  featureFlags?: string[];
   user: User;
   impersonator?: Impersonator;
   accessToken: string;

--- a/src/user-management/session.spec.ts
+++ b/src/user-management/session.spec.ts
@@ -106,7 +106,7 @@ describe('Session', () => {
       const cookiePassword = 'alongcookiesecretmadefortestingsessions';
 
       const accessToken =
-        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJpbXBlcnNvbmF0b3IiOnsiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSIsInJlYXNvbiI6InRlc3QifSwic2lkIjoic2Vzc2lvbl8xMjMiLCJvcmdfaWQiOiJvcmdfMTIzIiwicm9sZSI6Im1lbWJlciIsInBlcm1pc3Npb25zIjpbInBvc3RzOmNyZWF0ZSIsInBvc3RzOmRlbGV0ZSJdLCJlbnRpdGxlbWVudHMiOlsiYXVkaXQtbG9ncyJdLCJ1c2VyIjp7Im9iamVjdCI6InVzZXIiLCJpZCI6InVzZXJfMDFINUpRRFY3UjdBVEVZWkRFRzBXNVBSWVMiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20ifX0.A8mDST4wtq_0vId6ALg7k2Ukr7FXrszZtdJ_6dfXeAc';
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJpbXBlcnNvbmF0b3IiOnsiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSIsInJlYXNvbiI6InRlc3QifSwic2lkIjoic2Vzc2lvbl8xMjMiLCJvcmdfaWQiOiJvcmdfMTIzIiwicm9sZSI6Im1lbWJlciIsInBlcm1pc3Npb25zIjpbInBvc3RzOmNyZWF0ZSIsInBvc3RzOmRlbGV0ZSJdLCJlbnRpdGxlbWVudHMiOlsiYXVkaXQtbG9ncyJdLCJmZWF0dXJlX2ZsYWdzIjpbImRhcmstbW9kZSIsImJldGEtZmVhdHVyZXMiXSwidXNlciI6eyJvYmplY3QiOiJ1c2VyIiwiaWQiOiJ1c2VyXzAxSDVKUURWN1I3QVRFWVpERUcwVzVQUllTIiwiZW1haWwiOiJ0ZXN0QGV4YW1wbGUuY29tIn19.YVNjR8S2xGn2jAoLuEcBQNJ1_xY3OzjRE1-BK0zjfQE';
 
       const sessionData = await sealData(
         {
@@ -141,6 +141,7 @@ describe('Session', () => {
         role: 'member',
         permissions: ['posts:create', 'posts:delete'],
         entitlements: ['audit-logs'],
+        featureFlags: ['dark-mode', 'beta-features'],
         user: {
           object: 'user',
           id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -97,6 +97,7 @@ export class Session {
       role,
       permissions,
       entitlements,
+      feature_flags: featureFlags,
     } = decodeJwt<AccessToken>(session.accessToken);
 
     return {
@@ -106,6 +107,7 @@ export class Session {
       role,
       permissions,
       entitlements,
+      featureFlags,
       user: session.user,
       impersonator: session.impersonator,
       accessToken: session.accessToken,
@@ -169,6 +171,7 @@ export class Session {
         role,
         permissions,
         entitlements,
+        feature_flags: featureFlags,
       } = decodeJwt<AccessToken>(authenticationResponse.accessToken);
 
       // TODO: Returning `session` here means there's some duplicated data.
@@ -182,6 +185,7 @@ export class Session {
         role,
         permissions,
         entitlements,
+        featureFlags,
         user: session.user,
         impersonator: session.impersonator,
       };

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -894,7 +894,7 @@ describe('UserManagement', () => {
 
       const cookiePassword = 'alongcookiesecretmadefortestingsessions';
       const accessToken =
-        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJpbXBlcnNvbmF0b3IiOnsiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSIsInJlYXNvbiI6InRlc3QifSwic2lkIjoic2Vzc2lvbl8xMjMiLCJvcmdfaWQiOiJvcmdfMTIzIiwicm9sZSI6Im1lbWJlciIsInBlcm1pc3Npb25zIjpbInBvc3RzOmNyZWF0ZSIsInBvc3RzOmRlbGV0ZSJdLCJlbnRpdGxlbWVudHMiOlsiYXVkaXQtbG9ncyJdLCJ1c2VyIjp7Im9iamVjdCI6InVzZXIiLCJpZCI6InVzZXJfMDFINUpRRFY3UjdBVEVZWkRFRzBXNVBSWVMiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20ifX0.A8mDST4wtq_0vId6ALg7k2Ukr7FXrszZtdJ_6dfXeAc';
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdXRoZW50aWNhdGVkIjp0cnVlLCJpbXBlcnNvbmF0b3IiOnsiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSIsInJlYXNvbiI6InRlc3QifSwic2lkIjoic2Vzc2lvbl8xMjMiLCJvcmdfaWQiOiJvcmdfMTIzIiwicm9sZSI6Im1lbWJlciIsInBlcm1pc3Npb25zIjpbInBvc3RzOmNyZWF0ZSIsInBvc3RzOmRlbGV0ZSJdLCJlbnRpdGxlbWVudHMiOlsiYXVkaXQtbG9ncyJdLCJmZWF0dXJlX2ZsYWdzIjpbImRhcmstbW9kZSIsImJldGEtZmVhdHVyZXMiXSwidXNlciI6eyJvYmplY3QiOiJ1c2VyIiwiaWQiOiJ1c2VyXzAxSDVKUURWN1I3QVRFWVpERUcwVzVQUllTIiwiZW1haWwiOiJ0ZXN0QGV4YW1wbGUuY29tIn19.YVNjR8S2xGn2jAoLuEcBQNJ1_xY3OzjRE1-BK0zjfQE';
 
       const sessionData = await sealData(
         {
@@ -921,6 +921,7 @@ describe('UserManagement', () => {
         role: 'member',
         permissions: ['posts:create', 'posts:delete'],
         entitlements: ['audit-logs'],
+        featureFlags: ['dark-mode', 'beta-features'],
         user: expect.objectContaining({
           email: 'test@example.com',
         }),

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -455,6 +455,7 @@ export class UserManagement {
       role,
       permissions,
       entitlements,
+      feature_flags: featureFlags,
     } = decodeJwt<AccessToken>(session.accessToken);
 
     return {
@@ -465,6 +466,7 @@ export class UserManagement {
       user: session.user,
       permissions,
       entitlements,
+      featureFlags,
       accessToken: session.accessToken,
     };
   }


### PR DESCRIPTION
## Description
This change pulls the `feature_flags` claim from the JWT if it exists. This claim is exposed as `featureFlags` to the developer.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes - https://github.com/workos/workos/pull/40562
```
