### PR TITLE
add organization_domain created/updated/deleted events

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -581,6 +581,39 @@ export interface OrganizationDomainVerificationFailedEventResponse
   data: OrganizationDomainResponse;
 }
 
+export interface OrganizationDomainCreatedEvent extends EventBase {
+  event: 'organization_domain.created';
+  data: OrganizationDomain;
+}
+
+export interface OrganizationDomainCreatedEventResponse
+  extends EventResponseBase {
+  event: 'organization_domain.created';
+  data: OrganizationDomainResponse;
+}
+
+export interface OrganizationDomainUpdatedEvent extends EventBase {
+  event: 'organization_domain.updated';
+  data: OrganizationDomain;
+}
+
+export interface OrganizationDomainUpdatedEventResponse
+  extends EventResponseBase {
+  event: 'organization_domain.updated';
+  data: OrganizationDomainResponse;
+}
+
+export interface OrganizationDomainDeletedEvent extends EventBase {
+  event: 'organization_domain.deleted';
+  data: OrganizationDomain;
+}
+
+export interface OrganizationDomainDeletedEventResponse
+  extends EventResponseBase {
+  event: 'organization_domain.deleted';
+  data: OrganizationDomainResponse;
+}
+
 export type Event =
   | AuthenticationEmailVerificationSucceededEvent
   | AuthenticationMfaSucceededEvent
@@ -629,7 +662,10 @@ export type Event =
   | OrganizationUpdatedEvent
   | OrganizationDeletedEvent
   | OrganizationDomainVerifiedEvent
-  | OrganizationDomainVerificationFailedEvent;
+  | OrganizationDomainVerificationFailedEvent
+  | OrganizationDomainCreatedEvent
+  | OrganizationDomainUpdatedEvent
+  | OrganizationDomainDeletedEvent;
 
 export type EventResponse =
   | AuthenticationEmailVerificationSucceededEventResponse
@@ -679,6 +715,9 @@ export type EventResponse =
   | OrganizationUpdatedResponse
   | OrganizationDeletedResponse
   | OrganizationDomainVerifiedEventResponse
-  | OrganizationDomainVerificationFailedEventResponse;
+  | OrganizationDomainVerificationFailedEventResponse
+  | OrganizationDomainCreatedEventResponse
+  | OrganizationDomainUpdatedEventResponse
+  | OrganizationDomainDeletedEventResponse;
 
 export type EventName = Event['event'];

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -177,6 +177,9 @@ export const deserializeEvent = (event: EventResponse): Event => {
       };
     case 'organization_domain.verified':
     case 'organization_domain.verification_failed':
+    case 'organization_domain.created':
+    case 'organization_domain.updated':
+    case 'organization_domain.deleted':
       return {
         ...eventBase,
         event: event.event,

--- a/src/organization-domains/interfaces/organization-domain.interface.ts
+++ b/src/organization-domains/interfaces/organization-domain.interface.ts
@@ -21,6 +21,8 @@ export interface OrganizationDomain {
   state: OrganizationDomainState;
   verificationToken?: string;
   verificationStrategy: OrganizationDomainVerificationStrategy;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface OrganizationDomainResponse {
@@ -31,4 +33,6 @@ export interface OrganizationDomainResponse {
   state: OrganizationDomainState;
   verification_token?: string;
   verification_strategy: OrganizationDomainVerificationStrategy;
+  created_at: string;
+  updated_at: string;
 }

--- a/src/organization-domains/serializers/organization-domain.serializer.ts
+++ b/src/organization-domains/serializers/organization-domain.serializer.ts
@@ -10,4 +10,6 @@ export const deserializeOrganizationDomain = (
   state: organizationDomain.state,
   verificationToken: organizationDomain.verification_token,
   verificationStrategy: organizationDomain.verification_strategy,
+  createdAt: organizationDomain.created_at,
+  updatedAt: organizationDomain.updated_at,
 });


### PR DESCRIPTION
## Description

Independent organization_domain events for created, updated, and deleted are available in the dashboard. 

This PR updates the node sdk to support those events

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

Docs PR: 

https://github.com/workos/workos/pull/39990
