### PR TITLE
Type constructEvent payload parameter as Record<string, unknown>

### DIFF
--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -30,7 +30,7 @@ export class Webhooks {
     secret,
     tolerance = 180000,
   }: {
-    payload: unknown;
+    payload: Record<string, unknown>;
     sigHeader: string;
     secret: string;
     tolerance?: number;
@@ -38,7 +38,7 @@ export class Webhooks {
     const options = { payload, sigHeader, secret, tolerance };
     await this.verifyHeader(options);
 
-    const webhookPayload = payload as EventResponse;
+    const webhookPayload = payload as unknown as EventResponse;
 
     return deserializeEvent(webhookPayload);
   }


### PR DESCRIPTION
## Description
Type constructEvent payload parameter as Record<string, unknown>.

Example usage:
```
app.post("/webhooks", async (request, response) => {
  const payload = request.body;
  const sigHeader = request.headers["workos-signature"] as string;

  const webhook = await workosClient.webhooks.constructEvent({
    payload,
    sigHeader,
    secret: WEBHOOK_SECRET,
  });

  const data = webhook.data;

  // Verify the signature and process the event
  response.status(200).end();
});
```

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
