### PR TITLE
[V8] remove direct process.env access, replacing with getEnv helper

### DIFF
--- a/src/workos.ts
+++ b/src/workos.ts
@@ -36,6 +36,7 @@ import { Actions } from './actions/actions';
 import { Vault } from './vault/vault';
 import { ConflictException } from './common/exceptions/conflict.exception';
 import { CryptoProvider } from './common/crypto/crypto-provider';
+import { getEnv } from './common/utils/env';
 
 const VERSION = '8.0.0-beta.2';
 
@@ -72,10 +73,7 @@ export class WorkOS {
   ) {
     if (!key) {
       // process might be undefined in some environments
-      this.key =
-        typeof process !== 'undefined'
-          ? process?.env.WORKOS_API_KEY
-          : undefined;
+      this.key = getEnv('WORKOS_API_KEY');
 
       if (!this.key) {
         throw new NoApiKeyProvidedException();
@@ -87,8 +85,8 @@ export class WorkOS {
     }
 
     this.clientId = this.options.clientId;
-    if (!this.clientId && typeof process !== 'undefined') {
-      this.clientId = process?.env.WORKOS_CLIENT_ID;
+    if (!this.clientId) {
+      this.clientId = getEnv('WORKOS_CLIENT_ID');
     }
 
     const protocol: string = this.options.https ? 'https' : 'http';


### PR DESCRIPTION
## Description

This pull request refactors how environment variables are accessed in the `WorkOS` class to improve code clarity and maintainability. The changes replace direct access to `process.env` with a utility function `getEnv`.

### Refactoring environment variable access:

* [`src/workos.ts`](diffhunk://#diff-43fae42284da1898f98b43b56a7bc6f5fb979e271bca59f4670751ba2c0020efR39): Introduced the `getEnv` utility function from `./common/utils/env` to centralize and simplify access to environment variables.
* [`src/workos.ts`](diffhunk://#diff-43fae42284da1898f98b43b56a7bc6f5fb979e271bca59f4670751ba2c0020efL75-R76): Replaced direct usage of `process.env.WORKOS_API_KEY` with `getEnv('WORKOS_API_KEY')` for retrieving the API key. This ensures consistent handling of environment variables across environments.
* [`src/workos.ts`](diffhunk://#diff-43fae42284da1898f98b43b56a7bc6f5fb979e271bca59f4670751ba2c0020efL90-R89): Replaced direct usage of `process.env.WORKOS_CLIENT_ID` with `getEnv('WORKOS_CLIENT_ID')` for retrieving the client ID. This further standardizes the approach to accessing environment variables.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
