### PR TITLE
Add ParseError to include rawBody and requestID for debugging purposes

### DIFF
--- a/src/common/exceptions/parse-error.ts
+++ b/src/common/exceptions/parse-error.ts
@@ -1,0 +1,14 @@
+import { RequestException } from '../interfaces/request-exception.interface';
+
+export class ParseError extends Error implements RequestException {
+  readonly name = 'ParseError';
+  readonly status = 500;
+  readonly rawBody: string;
+  readonly requestID: string;
+
+  constructor(message: string, rawBody: string, requestID: string) {
+    super(message);
+    this.rawBody = rawBody;
+    this.requestID = requestID;
+  }
+}

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -279,7 +279,10 @@ export class WorkOS {
       const rawResponse = res.getRawResponse() as Response;
       const requestID = rawResponse.headers.get('X-Request-ID') ?? '';
       const rawBody = await (res.getRawResponse() as Response).text();
-      throw new ParseError(error.message, rawBody, requestID);
+      const rawResponse = res.getRawResponse() as Response;
+const requestID = rawResponse.headers.get('X-Request-ID') ?? '';
+const rawBody = await rawResponse.text();
+throw new ParseError(error.message, rawBody, requestID);
     }
   }
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -9,6 +9,7 @@ import {
 } from './common/exceptions';
 import {
   GetOptions,
+  HttpClientResponseInterface,
   PostOptions,
   PutOptions,
   WorkOSOptions,
@@ -37,6 +38,7 @@ import { Actions } from './actions/actions';
 import { Vault } from './vault/vault';
 import { ConflictException } from './common/exceptions/conflict.exception';
 import { CryptoProvider } from './common/crypto/crypto-provider';
+import { ParseError } from './common/exceptions/parse-error';
 
 const VERSION = '7.60.0';
 
@@ -166,16 +168,22 @@ export class WorkOS {
       requestHeaders[HEADER_WARRANT_TOKEN] = options.warrantToken;
     }
 
+    let res: HttpClientResponseInterface;
+
     try {
-      const res = await this.client.post<Entity>(path, entity, {
+      res = await this.client.post<Entity>(path, entity, {
         params: options.query,
         headers: requestHeaders,
       });
-
-      return { data: await res.toJSON() };
     } catch (error) {
       this.handleHttpError({ path, error });
+      throw error;
+    }
 
+    try {
+      return { data: await res.toJSON() };
+    } catch (error) {
+      await this.handleParseError(error, res);
       throw error;
     }
   }
@@ -194,15 +202,22 @@ export class WorkOS {
       requestHeaders[HEADER_WARRANT_TOKEN] = options.warrantToken;
     }
 
+    let res: HttpClientResponseInterface;
     try {
-      const res = await this.client.get(path, {
+      res = await this.client.get(path, {
         params: options.query,
         headers: requestHeaders,
       });
-      return { data: await res.toJSON() };
     } catch (error) {
       this.handleHttpError({ path, error });
 
+      throw error;
+    }
+
+    try {
+      return { data: await res.toJSON() };
+    } catch (error) {
+      await this.handleParseError(error, res);
       throw error;
     }
   }
@@ -218,15 +233,23 @@ export class WorkOS {
       requestHeaders[HEADER_IDEMPOTENCY_KEY] = options.idempotencyKey;
     }
 
+    let res: HttpClientResponseInterface;
+
     try {
-      const res = await this.client.put<Entity>(path, entity, {
+      res = await this.client.put<Entity>(path, entity, {
         params: options.query,
         headers: requestHeaders,
       });
-      return { data: await res.toJSON() };
     } catch (error) {
       this.handleHttpError({ path, error });
 
+      throw error;
+    }
+
+    try {
+      return { data: await res.toJSON() };
+    } catch (error) {
+      await this.handleParseError(error, res);
       throw error;
     }
   }
@@ -246,6 +269,18 @@ export class WorkOS {
   emitWarning(warning: string) {
     // tslint:disable-next-line:no-console
     console.warn(`WorkOS: ${warning}`);
+  }
+
+  private async handleParseError(
+    error: unknown,
+    res: HttpClientResponseInterface,
+  ) {
+    if (error instanceof SyntaxError) {
+      const rawResponse = res.getRawResponse() as Response;
+      const requestID = rawResponse.headers.get('X-Request-ID') ?? '';
+      const rawBody = await (res.getRawResponse() as Response).text();
+      throw new ParseError(error.message, rawBody, requestID);
+    }
   }
 
   private handleHttpError({ path, error }: { path: string; error: unknown }) {

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -278,9 +278,6 @@ export class WorkOS {
     if (error instanceof SyntaxError) {
       const rawResponse = res.getRawResponse() as Response;
       const requestID = rawResponse.headers.get('X-Request-ID') ?? '';
-      const rawBody = await (res.getRawResponse() as Response).text();
-      const rawResponse = res.getRawResponse() as Response;
-      const requestID = rawResponse.headers.get('X-Request-ID') ?? '';
       const rawBody = await rawResponse.text();
       throw new ParseError(error.message, rawBody, requestID);
     }

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -280,9 +280,9 @@ export class WorkOS {
       const requestID = rawResponse.headers.get('X-Request-ID') ?? '';
       const rawBody = await (res.getRawResponse() as Response).text();
       const rawResponse = res.getRawResponse() as Response;
-const requestID = rawResponse.headers.get('X-Request-ID') ?? '';
-const rawBody = await rawResponse.text();
-throw new ParseError(error.message, rawBody, requestID);
+      const requestID = rawResponse.headers.get('X-Request-ID') ?? '';
+      const rawBody = await rawResponse.text();
+      throw new ParseError(error.message, rawBody, requestID);
     }
   }
 


### PR DESCRIPTION
## Description
Some customers have reported receiving non-json responses from the workos API. These raise a syntax error when the Node.js ADK attempts to parse the json. This PR adds rawBody and requestID to a new ParseError exception for debugging purposes. 
