### PR TITLE
Raise ParseError if non-200 response returns invalid JSON

### DIFF
--- a/src/common/exceptions/parse-error.ts
+++ b/src/common/exceptions/parse-error.ts
@@ -4,11 +4,23 @@ export class ParseError extends Error implements RequestException {
   readonly name = 'ParseError';
   readonly status = 500;
   readonly rawBody: string;
+  readonly rawStatus: number;
   readonly requestID: string;
 
-  constructor(message: string, rawBody: string, requestID: string) {
+  constructor({
+    message,
+    rawBody,
+    rawStatus,
+    requestID,
+  }: {
+    message: string;
+    rawBody: string;
+    requestID: string;
+    rawStatus: number;
+  }) {
     super(message);
     this.rawBody = rawBody;
+    this.rawStatus = rawStatus;
     this.requestID = requestID;
   }
 }

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -185,7 +185,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       const requestID = res.headers.get('X-Request-ID') ?? '';
       const rawBody = await res.text();
 
-      let responseJson: any = undefined;
+      let responseJson: any;
 
       try {
         responseJson = JSON.parse(rawBody);

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -278,8 +278,14 @@ export class WorkOS {
     if (error instanceof SyntaxError) {
       const rawResponse = res.getRawResponse() as Response;
       const requestID = rawResponse.headers.get('X-Request-ID') ?? '';
+      const rawStatus = rawResponse.status;
       const rawBody = await rawResponse.text();
-      throw new ParseError(error.message, rawBody, requestID);
+      throw new ParseError({
+        message: error.message,
+        rawBody,
+        rawStatus,
+        requestID,
+      });
     }
   }
 


### PR DESCRIPTION
## Description
Missed a codepath in #1313 where non-200 responses would attempt to parse the body
