### PR TITLE
Change method name to delete to match other methods

### DIFF
--- a/src/organization-domains/organization-domains.spec.ts
+++ b/src/organization-domains/organization-domains.spec.ts
@@ -92,11 +92,11 @@ describe('OrganizationDomains', () => {
     });
   });
 
-  describe('deleteOrganizationDomain', () => {
+  describe('delete', () => {
     it('deletes an Organization Domain', async () => {
       fetchOnce();
 
-      await workos.organizationDomains.deleteOrganizationDomain(
+      await workos.organizationDomains.delete(
         'org_domain_01HCZRAP3TPQ0X0DKJHR32TATG',
       );
 

--- a/src/organization-domains/organization-domains.ts
+++ b/src/organization-domains/organization-domains.ts
@@ -38,7 +38,7 @@ export class OrganizationDomains {
     return deserializeOrganizationDomain(data);
   }
 
-  async deleteOrganizationDomain(id: string): Promise<void> {
+  async delete(id: string): Promise<void> {
     await this.workos.delete(`/organization_domains/${id}`);
   }
 }


### PR DESCRIPTION
## Description

Updates the delete organization domain method (recently merged) to match the other method names in the `organizationDomains` namespace from `deleteOrganizationDomain` to `delete`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/42288
