### PR TITLE
Add GET /organizations/:orgId/feature-flags support

### DIFF
--- a/src/organizations/fixtures/list-organization-feature-flags.json
+++ b/src/organizations/fixtures/list-organization-feature-flags.json
@@ -1,0 +1,33 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "feature_flag",
+      "id": "flag_01EHQMYV6MBK39QC5PZXHY59C5",
+      "name": "Advanced Dashboard",
+      "slug": "advanced-dashboard",
+      "description": "Enable advanced dashboard features",
+      "created_at": "2024-01-01T00:00:00.000Z",
+      "updated_at": "2024-01-01T00:00:00.000Z"
+    },
+    {
+      "object": "feature_flag",
+      "id": "flag_01EHQMYV6MBK39QC5PZXHY59C6",
+      "name": "Beta Features",
+      "slug": "beta-features",
+      "description": null,
+      "created_at": "2024-01-01T00:00:00.000Z",
+      "updated_at": "2024-01-01T00:00:00.000Z"
+    },
+    {
+      "object": "feature_flag",
+      "id": "flag_01EHQMYV6MBK39QC5PZXHY59C7",
+      "name": "Premium Support",
+      "slug": "premium-support",
+      "description": "Access to premium support features",
+      "created_at": "2024-01-01T00:00:00.000Z",
+      "updated_at": "2024-01-01T00:00:00.000Z"
+    }
+  ],
+  "list_metadata": {}
+}

--- a/src/organizations/interfaces/feature-flag.interface.ts
+++ b/src/organizations/interfaces/feature-flag.interface.ts
@@ -1,0 +1,19 @@
+export interface FeatureFlag {
+  object: 'feature_flag';
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FeatureFlagResponse {
+  object: 'feature_flag';
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/organizations/interfaces/index.ts
+++ b/src/organizations/interfaces/index.ts
@@ -1,5 +1,7 @@
 export * from './create-organization-options.interface';
 export * from './domain-data.interface';
+export * from './feature-flag.interface';
+export * from './list-organization-feature-flags-options.interface';
 export * from './list-organizations-options.interface';
 export * from './organization.interface';
 export * from './update-organization-options.interface';

--- a/src/organizations/interfaces/list-organization-feature-flags-options.interface.ts
+++ b/src/organizations/interfaces/list-organization-feature-flags-options.interface.ts
@@ -1,0 +1,3 @@
+export interface ListOrganizationFeatureFlagsOptions {
+  organizationId: string;
+}

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -13,6 +13,7 @@ import createOrganization from './fixtures/create-organization.json';
 import getOrganization from './fixtures/get-organization.json';
 import listOrganizationsFixture from './fixtures/list-organizations.json';
 import listOrganizationRolesFixture from './fixtures/list-organization-roles.json';
+import listOrganizationFeatureFlagsFixture from './fixtures/list-organization-feature-flags.json';
 import updateOrganization from './fixtures/update-organization.json';
 import setStripeCustomerId from './fixtures/set-stripe-customer-id.json';
 import setStripeCustomerIdDisabled from './fixtures/set-stripe-customer-id-disabled.json';
@@ -443,6 +444,55 @@ describe('Organizations', () => {
           description: null,
           permissions: ['posts:read'],
           type: 'OrganizationRole',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ]);
+    });
+  });
+
+  describe('listOrganizationFeatureFlags', () => {
+    it('returns feature flags for the organization', async () => {
+      fetchOnce(listOrganizationFeatureFlagsFixture);
+
+      const { data, object, listMetadata } = await workos.organizations.listOrganizationFeatureFlags(
+        {
+          organizationId: 'org_01EHT88Z8J8795GZNQ4ZP1J81T',
+        },
+      );
+
+      expect(fetchURL()).toContain(
+        '/organizations/org_01EHT88Z8J8795GZNQ4ZP1J81T/feature_flags',
+      );
+
+      expect(object).toEqual('list');
+      expect(listMetadata).toEqual({});
+      expect(data).toHaveLength(3);
+      expect(data).toEqual([
+        {
+          object: 'feature_flag',
+          id: 'flag_01EHQMYV6MBK39QC5PZXHY59C5',
+          name: 'Advanced Dashboard',
+          slug: 'advanced-dashboard',
+          description: 'Enable advanced dashboard features',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+        {
+          object: 'feature_flag',
+          id: 'flag_01EHQMYV6MBK39QC5PZXHY59C6',
+          name: 'Beta Features',
+          slug: 'beta-features',
+          description: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+        {
+          object: 'feature_flag',
+          id: 'flag_01EHQMYV6MBK39QC5PZXHY59C7',
+          name: 'Premium Support',
+          slug: 'premium-support',
+          description: 'Access to premium support features',
           createdAt: '2024-01-01T00:00:00.000Z',
           updatedAt: '2024-01-01T00:00:00.000Z',
         },

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -455,11 +455,10 @@ describe('Organizations', () => {
     it('returns feature flags for the organization', async () => {
       fetchOnce(listOrganizationFeatureFlagsFixture);
 
-      const { data, object, listMetadata } = await workos.organizations.listOrganizationFeatureFlags(
-        {
+      const { data, object, listMetadata } =
+        await workos.organizations.listOrganizationFeatureFlags({
           organizationId: 'org_01EHT88Z8J8795GZNQ4ZP1J81T',
-        },
-      );
+        });
 
       expect(fetchURL()).toContain(
         '/organizations/org_01EHT88Z8J8795GZNQ4ZP1J81T/feature_flags',

--- a/src/organizations/organizations.ts
+++ b/src/organizations/organizations.ts
@@ -8,6 +8,7 @@ import {
   OrganizationResponse,
   UpdateOrganizationOptions,
 } from './interfaces';
+import { FeatureFlag, FeatureFlagResponse } from './interfaces/feature-flag.interface';
 import {
   deserializeOrganization,
   serializeCreateOrganizationOptions,
@@ -15,9 +16,13 @@ import {
 } from './serializers';
 
 import { fetchAndDeserialize } from '../common/utils/fetch-and-deserialize';
+import { List, ListResponse } from '../common/interfaces';
+import { deserializeList } from '../common/serializers';
 import { ListOrganizationRolesResponse, RoleList } from '../roles/interfaces';
 import { deserializeRole } from '../roles/serializers/role.serializer';
 import { ListOrganizationRolesOptions } from './interfaces/list-organization-roles-options.interface';
+import { ListOrganizationFeatureFlagsOptions } from './interfaces/list-organization-feature-flags-options.interface';
+import { deserializeFeatureFlag } from './serializers/feature-flag.serializer';
 
 export class Organizations {
   constructor(private readonly workos: WorkOS) {}
@@ -103,5 +108,17 @@ export class Organizations {
       object: 'list',
       data: response.data.map((role) => deserializeRole(role)),
     };
+  }
+
+  async listOrganizationFeatureFlags(
+    options: ListOrganizationFeatureFlagsOptions,
+  ): Promise<List<FeatureFlag>> {
+    const { organizationId } = options;
+
+    const { data } = await this.workos.get<ListResponse<FeatureFlagResponse>>(
+      `/organizations/${organizationId}/feature_flags`,
+    );
+
+    return deserializeList(data, deserializeFeatureFlag);
   }
 }

--- a/src/organizations/organizations.ts
+++ b/src/organizations/organizations.ts
@@ -8,7 +8,10 @@ import {
   OrganizationResponse,
   UpdateOrganizationOptions,
 } from './interfaces';
-import { FeatureFlag, FeatureFlagResponse } from './interfaces/feature-flag.interface';
+import {
+  FeatureFlag,
+  FeatureFlagResponse,
+} from './interfaces/feature-flag.interface';
 import {
   deserializeOrganization,
   serializeCreateOrganizationOptions,

--- a/src/organizations/serializers/feature-flag.serializer.ts
+++ b/src/organizations/serializers/feature-flag.serializer.ts
@@ -1,0 +1,16 @@
+import {
+  FeatureFlag,
+  FeatureFlagResponse,
+} from '../interfaces/feature-flag.interface';
+
+export const deserializeFeatureFlag = (
+  featureFlag: FeatureFlagResponse,
+): FeatureFlag => ({
+  object: featureFlag.object,
+  id: featureFlag.id,
+  name: featureFlag.name,
+  slug: featureFlag.slug,
+  description: featureFlag.description,
+  createdAt: featureFlag.created_at,
+  updatedAt: featureFlag.updated_at,
+});


### PR DESCRIPTION
## Description

Add GET /organizations/:orgId/feature-flags support

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
