### PR TITLE
Fix feature flags endpoint URL

### DIFF
--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -461,7 +461,7 @@ describe('Organizations', () => {
         });
 
       expect(fetchURL()).toContain(
-        '/organizations/org_01EHT88Z8J8795GZNQ4ZP1J81T/feature_flags',
+        '/organizations/org_01EHT88Z8J8795GZNQ4ZP1J81T/feature-flags',
       );
 
       expect(object).toEqual('list');
@@ -514,7 +514,7 @@ describe('Organizations', () => {
         });
 
         expect(fetchURL()).toContain(
-          '/organizations/org_01EHT88Z8J8795GZNQ4ZP1J81T/feature_flags',
+          '/organizations/org_01EHT88Z8J8795GZNQ4ZP1J81T/feature-flags',
         );
 
         expect(data).toHaveLength(3);
@@ -537,7 +537,7 @@ describe('Organizations', () => {
         });
 
         expect(fetchURL()).toContain(
-          '/organizations/org_01EHT88Z8J8795GZNQ4ZP1J81T/feature_flags',
+          '/organizations/org_01EHT88Z8J8795GZNQ4ZP1J81T/feature-flags',
         );
 
         expect(data).toHaveLength(3);
@@ -560,7 +560,7 @@ describe('Organizations', () => {
         });
 
         expect(fetchURL()).toContain(
-          '/organizations/org_01EHT88Z8J8795GZNQ4ZP1J81T/feature_flags',
+          '/organizations/org_01EHT88Z8J8795GZNQ4ZP1J81T/feature-flags',
         );
 
         expect(data).toHaveLength(3);

--- a/src/organizations/organizations.ts
+++ b/src/organizations/organizations.ts
@@ -119,14 +119,14 @@ export class Organizations {
     return new AutoPaginatable(
       await fetchAndDeserialize<FeatureFlagResponse, FeatureFlag>(
         this.workos,
-        `/organizations/${organizationId}/feature_flags`,
+        `/organizations/${organizationId}/feature-flags`,
         deserializeFeatureFlag,
         paginationOptions,
       ),
       (params) =>
         fetchAndDeserialize<FeatureFlagResponse, FeatureFlag>(
           this.workos,
-          `/organizations/${organizationId}/feature_flags`,
+          `/organizations/${organizationId}/feature-flags`,
           deserializeFeatureFlag,
           params,
         ),


### PR DESCRIPTION
## Summary
- Fixed incorrect URL path for organization feature flags endpoint (changed `feature_flags` to `feature-flags`)
- Updated corresponding tests to match the correct endpoint format

## Test plan
- [x] Updated test URLs to use correct `feature-flags` path
- [x] Existing tests pass with corrected endpoint
- [x] Verified API endpoint consistency

Closes #1334