### PR TITLE
add invitation accepted, revoked events

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -343,13 +343,32 @@ export interface EmailVerificationCreatedEventResponse
   data: EmailVerificationEventResponse;
 }
 
+export interface InvitationAcceptedEvent extends EventBase {
+  event: 'invitation.accepted';
+  data: InvitationEvent;
+}
 export interface InvitationCreatedEvent extends EventBase {
   event: 'invitation.created';
   data: InvitationEvent;
 }
 
+export interface InvitationRevokedEvent extends EventBase {
+  event: 'invitation.revoked';
+  data: InvitationEvent;
+}
+
+export interface InvitationAcceptedEventResponse extends EventResponseBase {
+  event: 'invitation.accepted';
+  data: InvitationEventResponse;
+}
+
 export interface InvitationCreatedEventResponse extends EventResponseBase {
   event: 'invitation.created';
+  data: InvitationEventResponse;
+}
+
+export interface InvitationRevokedEventResponse extends EventResponseBase {
+  event: 'invitation.revoked';
   data: InvitationEventResponse;
 }
 
@@ -641,7 +660,9 @@ export type Event =
   | DsyncUserUpdatedEvent
   | DsyncUserDeletedEvent
   | EmailVerificationCreatedEvent
+  | InvitationAcceptedEvent
   | InvitationCreatedEvent
+  | InvitationRevokedEvent
   | MagicAuthCreatedEvent
   | PasswordResetCreatedEvent
   | PasswordResetSucceededEvent
@@ -694,7 +715,9 @@ export type EventResponse =
   | DsyncUserUpdatedEventResponse
   | DsyncUserDeletedEventResponse
   | EmailVerificationCreatedEventResponse
+  | InvitationAcceptedEventResponse
   | InvitationCreatedEventResponse
+  | InvitationRevokedEventResponse
   | MagicAuthCreatedEventResponse
   | PasswordResetCreatedEventResponse
   | PasswordResetSucceededEventResponse

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -115,7 +115,9 @@ export const deserializeEvent = (event: EventResponse): Event => {
         event: event.event,
         data: deserializeEmailVerificationEvent(event.data),
       };
+    case 'invitation.accepted':
     case 'invitation.created':
+    case 'invitation.revoked':
       return {
         ...eventBase,
         event: event.event,


### PR DESCRIPTION
## Description

Adds support for `invitation.accepted` and `invitation.revoked` events

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
