### PR TITLE
Fix `GetTokenOptions[scopes]` type

### DIFF
--- a/src/widgets/interfaces/get-token.ts
+++ b/src/widgets/interfaces/get-token.ts
@@ -6,13 +6,13 @@ export type WidgetScope =
 export interface GetTokenOptions {
   organizationId: string;
   userId?: string;
-  scopes?: [WidgetScope];
+  scopes?: WidgetScope[];
 }
 
 export interface SerializedGetTokenOptions {
   organization_id: string;
   user_id?: string;
-  scopes?: [WidgetScope];
+  scopes?: WidgetScope[];
 }
 
 export const serializeGetTokenOptions = (


### PR DESCRIPTION
## Description

This was accidentally typed as a single-item tuple, so passing multiple scopes currently results in a type error.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
