### PR TITLE
Bump to version 7.69.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/node",
-  "version": "7.69.0",
+  "version": "7.69.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/node",
-      "version": "7.69.0",
+      "version": "7.69.1",
       "license": "MIT",
       "dependencies": {
         "iron-session": "~6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.69.0",
+  "version": "7.69.1",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -23,7 +23,7 @@ exports[`SSO SSO getProfileAndToken with all information provided sends a reques
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/7.69.0/fetch",
+  "User-Agent": "workos-node/7.69.1/fetch",
 }
 `;
 
@@ -67,7 +67,7 @@ exports[`SSO SSO getProfileAndToken without a groups attribute sends a request t
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/7.69.0/fetch",
+  "User-Agent": "workos-node/7.69.1/fetch",
 }
 `;
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -40,7 +40,7 @@ import { ConflictException } from './common/exceptions/conflict.exception';
 import { CryptoProvider } from './common/crypto/crypto-provider';
 import { ParseError } from './common/exceptions/parse-error';
 
-const VERSION = '7.69.0';
+const VERSION = '7.69.1';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
 


### PR DESCRIPTION
## Summary
Version bump to 7.69.1

## Changes
- Bump version to 7.69.1 in package.json, package-lock.json, and src/workos.ts
- Update snapshot tests with new version

## Recent additions in this version
- Add `provider_query_params` to SSO `getAuthorizationUrl` method (#1347)