### PR TITLE
Add timeout to http client requests

### DIFF
--- a/src/common/interfaces/workos-options.interface.ts
+++ b/src/common/interfaces/workos-options.interface.ts
@@ -8,4 +8,5 @@ export interface WorkOSOptions {
   appInfo?: AppInfo;
   fetchFn?: typeof fetch;
   clientId?: string;
+  timeout?: number; // Timeout in milliseconds
 }

--- a/src/common/net/fetch-client.spec.ts
+++ b/src/common/net/fetch-client.spec.ts
@@ -312,7 +312,11 @@ describe('FetchHttpClient with timeout', () => {
 
   beforeEach(() => {
     mockFetch = jest.fn();
-    client = new FetchHttpClient('https://api.example.com', { timeout: 100 }, mockFetch);
+    client = new FetchHttpClient(
+      'https://api.example.com',
+      { timeout: 100 },
+      mockFetch,
+    );
   });
 
   it('should timeout requests that take too long', async () => {
@@ -330,9 +334,9 @@ describe('FetchHttpClient with timeout', () => {
       });
     });
 
-    await expect(
-      client.post('/test', { data: 'test' }, {})
-    ).rejects.toThrow(HttpClientError);
+    await expect(client.post('/test', { data: 'test' }, {})).rejects.toThrow(
+      HttpClientError,
+    );
 
     // Reset the mock for the second test
     mockFetch.mockClear();
@@ -350,13 +354,13 @@ describe('FetchHttpClient with timeout', () => {
     });
 
     await expect(
-      client.post('/test', { data: 'test' }, {})
+      client.post('/test', { data: 'test' }, {}),
     ).rejects.toMatchObject({
       message: 'Request timeout after 100ms',
       response: {
         status: 408,
-        data: { error: 'Request timeout' }
-      }
+        data: { error: 'Request timeout' },
+      },
     });
   });
 
@@ -376,8 +380,12 @@ describe('FetchHttpClient with timeout', () => {
   });
 
   it('should work without timeout configured', async () => {
-    const clientWithoutTimeout = new FetchHttpClient('https://api.example.com', {}, mockFetch);
-    
+    const clientWithoutTimeout = new FetchHttpClient(
+      'https://api.example.com',
+      {},
+      mockFetch,
+    );
+
     const mockResponse = {
       ok: true,
       status: 200,
@@ -388,7 +396,11 @@ describe('FetchHttpClient with timeout', () => {
 
     mockFetch.mockResolvedValue(mockResponse);
 
-    const result = await clientWithoutTimeout.post('/test', { data: 'test' }, {});
+    const result = await clientWithoutTimeout.post(
+      '/test',
+      { data: 'test' },
+      {},
+    );
     expect(result).toBeDefined();
   });
-}); 
+});

--- a/src/common/net/fetch-client.spec.ts
+++ b/src/common/net/fetch-client.spec.ts
@@ -1,6 +1,7 @@
 import fetch from 'jest-fetch-mock';
 import { fetchOnce, fetchURL } from '../../common/utils/test-utils';
 import { FetchHttpClient } from './fetch-client';
+import { HttpClientError } from './http-client';
 import { ParseError } from '../exceptions/parse-error';
 
 const fetchClient = new FetchHttpClient('https://test.workos.com', {
@@ -304,3 +305,90 @@ describe('Fetch client', () => {
     });
   });
 });
+
+describe('FetchHttpClient with timeout', () => {
+  let client: FetchHttpClient;
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    mockFetch = jest.fn();
+    client = new FetchHttpClient('https://api.example.com', { timeout: 100 }, mockFetch);
+  });
+
+  it('should timeout requests that take too long', async () => {
+    // Mock a fetch that respects AbortController
+    mockFetch.mockImplementation((_, options) => {
+      return new Promise((_, reject) => {
+        if (options.signal) {
+          options.signal.addEventListener('abort', () => {
+            const error = new Error('AbortError');
+            error.name = 'AbortError';
+            reject(error);
+          });
+        }
+        // Never resolve - let the timeout trigger
+      });
+    });
+
+    await expect(
+      client.post('/test', { data: 'test' }, {})
+    ).rejects.toThrow(HttpClientError);
+
+    // Reset the mock for the second test
+    mockFetch.mockClear();
+    mockFetch.mockImplementation((_, options) => {
+      return new Promise((_, reject) => {
+        if (options.signal) {
+          options.signal.addEventListener('abort', () => {
+            const error = new Error('AbortError');
+            error.name = 'AbortError';
+            reject(error);
+          });
+        }
+        // Never resolve - let the timeout trigger
+      });
+    });
+
+    await expect(
+      client.post('/test', { data: 'test' }, {})
+    ).rejects.toMatchObject({
+      message: 'Request timeout after 100ms',
+      response: {
+        status: 408,
+        data: { error: 'Request timeout' }
+      }
+    });
+  });
+
+  it('should not timeout requests that complete quickly', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      headers: new Map(),
+      json: () => Promise.resolve({ success: true }),
+      text: () => Promise.resolve('{"success": true}'),
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const result = await client.post('/test', { data: 'test' }, {});
+    expect(result).toBeDefined();
+  });
+
+  it('should work without timeout configured', async () => {
+    const clientWithoutTimeout = new FetchHttpClient('https://api.example.com', {}, mockFetch);
+    
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      headers: new Map(),
+      json: () => Promise.resolve({ success: true }),
+      text: () => Promise.resolve('{"success": true}'),
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const result = await clientWithoutTimeout.post('/test', { data: 'test' }, {});
+    expect(result).toBeDefined();
+  });
+}); 

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -8,12 +8,16 @@ import {
 import { HttpClient, HttpClientError, HttpClientResponse } from './http-client';
 import { ParseError } from '../exceptions/parse-error';
 
+interface FetchHttpClientOptions extends RequestInit {
+  timeout?: number;
+}
+
 export class FetchHttpClient extends HttpClient implements HttpClientInterface {
   private readonly _fetchFn;
 
   constructor(
     readonly baseURL: string,
-    readonly options?: RequestInit,
+    readonly options?: FetchHttpClientOptions,
     fetchFn?: typeof fetch,
   ) {
     super(baseURL, options);
@@ -167,50 +171,90 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
 
     const requestBody = body || (methodHasPayload ? '' : undefined);
 
-    const { 'User-Agent': userAgent } = this.options?.headers as RequestHeaders;
+    const { 'User-Agent': userAgent } = (this.options?.headers || {}) as RequestHeaders;
 
-    const res = await this._fetchFn(url, {
-      method,
-      headers: {
-        Accept: 'application/json, text/plain, */*',
-        'Content-Type': 'application/json',
-        ...this.options?.headers,
-        ...headers,
-        'User-Agent': this.addClientToUserAgent(userAgent.toString()),
-      },
-      body: requestBody,
-    });
+    // Create AbortController for timeout if configured
+    let abortController: AbortController | undefined;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
-    if (!res.ok) {
-      const requestID = res.headers.get('X-Request-ID') ?? '';
-      const rawBody = await res.text();
+    // Access timeout from the options
+    const timeout = this.options?.timeout;
+    if (timeout) {
+      abortController = new AbortController();
+      timeoutId = setTimeout(() => {
+        abortController?.abort();
+      }, timeout);
+    }
 
-      let responseJson: any;
+    try {
+      const res = await this._fetchFn(url, {
+        method,
+        headers: {
+          Accept: 'application/json, text/plain, */*',
+          'Content-Type': 'application/json',
+          ...this.options?.headers,
+          ...headers,
+          'User-Agent': this.addClientToUserAgent((userAgent || 'workos-node').toString()),
+        },
+        body: requestBody,
+        signal: abortController?.signal,
+      });
 
-      try {
-        responseJson = JSON.parse(rawBody);
-      } catch (error) {
-        if (error instanceof SyntaxError) {
-          throw new ParseError({
-            message: error.message,
-            rawBody,
-            requestID,
-            rawStatus: res.status,
-          });
-        }
-        throw error;
+      // Clear timeout if request completed successfully
+      if (timeoutId) {
+        clearTimeout(timeoutId);
       }
 
-      throw new HttpClientError({
-        message: res.statusText,
-        response: {
-          status: res.status,
-          headers: res.headers,
-          data: responseJson,
-        },
-      });
+      if (!res.ok) {
+        const requestID = res.headers.get('X-Request-ID') ?? '';
+        const rawBody = await res.text();
+
+        let responseJson: any;
+
+        try {
+          responseJson = JSON.parse(rawBody);
+        } catch (error) {
+          if (error instanceof SyntaxError) {
+            throw new ParseError({
+              message: error.message,
+              rawBody,
+              requestID,
+              rawStatus: res.status,
+            });
+          }
+          throw error;
+        }
+
+        throw new HttpClientError({
+          message: res.statusText,
+          response: {
+            status: res.status,
+            headers: res.headers,
+            data: responseJson,
+          },
+        });
+      }
+      return new FetchHttpClientResponse(res);
+    } catch (error) {
+      // Clear timeout if request failed
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+
+      // Handle timeout errors
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new HttpClientError({
+          message: `Request timeout after ${timeout}ms`,
+          response: {
+            status: 408,
+            headers: {},
+            data: { error: 'Request timeout' },
+          },
+        });
+      }
+
+      throw error;
     }
-    return new FetchHttpClientResponse(res);
   }
 
   private async fetchRequestWithRetry(

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -12,6 +12,7 @@ interface FetchHttpClientOptions extends RequestInit {
   timeout?: number;
 }
 
+const DEFAULT_FETCH_TIMEOUT = 60_000; // 60 seconds
 export class FetchHttpClient extends HttpClient implements HttpClientInterface {
   private readonly _fetchFn;
 
@@ -178,14 +179,12 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
     let abortController: AbortController | undefined;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
-    // Access timeout from the options
-    const timeout = this.options?.timeout;
-    if (timeout) {
-      abortController = new AbortController();
-      timeoutId = setTimeout(() => {
-        abortController?.abort();
-      }, timeout);
-    }
+    // Access timeout from the options with default of 60 seconds
+    const timeout = this.options?.timeout ?? DEFAULT_FETCH_TIMEOUT; // Default 60 seconds
+    abortController = new AbortController();
+    timeoutId = setTimeout(() => {
+      abortController?.abort();
+    }, timeout);
 
     try {
       const res = await this._fetchFn(url, {

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -171,7 +171,8 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
 
     const requestBody = body || (methodHasPayload ? '' : undefined);
 
-    const { 'User-Agent': userAgent } = (this.options?.headers || {}) as RequestHeaders;
+    const { 'User-Agent': userAgent } = (this.options?.headers ||
+      {}) as RequestHeaders;
 
     // Create AbortController for timeout if configured
     let abortController: AbortController | undefined;
@@ -194,7 +195,9 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
           'Content-Type': 'application/json',
           ...this.options?.headers,
           ...headers,
-          'User-Agent': this.addClientToUserAgent((userAgent || 'workos-node').toString()),
+          'User-Agent': this.addClientToUserAgent(
+            (userAgent || 'workos-node').toString(),
+          ),
         },
         body: requestBody,
         signal: abortController?.signal,

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ class WorkOSNode extends WorkOS {
   createHttpClient(options: WorkOSOptions, userAgent: string): HttpClient {
     const opts = {
       ...options.config,
+      timeout: options.timeout, // Pass through the timeout option
       headers: {
         ...options.config?.headers,
         Authorization: `Bearer ${this.key}`,

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -135,6 +135,7 @@ export class WorkOS {
   createHttpClient(options: WorkOSOptions, userAgent: string) {
     return new FetchHttpClient(this.baseURL, {
       ...options.config,
+      timeout: options.timeout,
       headers: {
         ...options.config?.headers,
         Authorization: `Bearer ${this.key}`,


### PR DESCRIPTION
## Description
`fetch` does not have a default timeout, so there is a non-zero chance of our HTTP requests to WorkOS servers hanging indefinitely. This PR introduces `timeout` as an optional parameter while initializing WorkOS client to terminate the request if its taking longer than `timeout` milliseconds. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
