### PR TITLE
Add deserialization of organization membership roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yarn-error.log
 lib/
 .DS_Store
 yarn.lock
+.idea/

--- a/src/user-management/interfaces/create-organization-membership-options.interface.ts
+++ b/src/user-management/interfaces/create-organization-membership-options.interface.ts
@@ -2,12 +2,12 @@ export interface CreateOrganizationMembershipOptions {
   organizationId: string;
   userId: string;
   roleSlug?: string;
-  roleSlugs?: string;
+  roleSlugs?: string[];
 }
 
 export interface SerializedCreateOrganizationMembershipOptions {
   organization_id: string;
   user_id: string;
   role_slug?: string;
-  role_slugs?: string;
+  role_slugs?: string[];
 }

--- a/src/user-management/interfaces/create-organization-membership-options.interface.ts
+++ b/src/user-management/interfaces/create-organization-membership-options.interface.ts
@@ -2,10 +2,12 @@ export interface CreateOrganizationMembershipOptions {
   organizationId: string;
   userId: string;
   roleSlug?: string;
+  roleSlugs?: string;
 }
 
 export interface SerializedCreateOrganizationMembershipOptions {
   organization_id: string;
   user_id: string;
   role_slug?: string;
+  role_slugs?: string;
 }

--- a/src/user-management/interfaces/organization-membership.interface.ts
+++ b/src/user-management/interfaces/organization-membership.interface.ts
@@ -12,6 +12,7 @@ export interface OrganizationMembership {
   createdAt: string;
   updatedAt: string;
   role: RoleResponse;
+  roles?: RoleResponse[];
 }
 
 export interface OrganizationMembershipResponse {
@@ -24,4 +25,5 @@ export interface OrganizationMembershipResponse {
   created_at: string;
   updated_at: string;
   role: RoleResponse;
+  roles?: RoleResponse[];
 }

--- a/src/user-management/interfaces/update-organization-membership-options.interface.ts
+++ b/src/user-management/interfaces/update-organization-membership-options.interface.ts
@@ -1,7 +1,9 @@
 export interface UpdateOrganizationMembershipOptions {
   roleSlug?: string;
+  roleSlugs?: string[];
 }
 
 export interface SerializedUpdateOrganizationMembershipOptions {
   role_slug?: string;
+  role_slugs?: string[];
 }

--- a/src/user-management/serializers/create-organization-membership-options.serializer.ts
+++ b/src/user-management/serializers/create-organization-membership-options.serializer.ts
@@ -9,4 +9,5 @@ export const serializeCreateOrganizationMembershipOptions = (
   organization_id: options.organizationId,
   user_id: options.userId,
   role_slug: options.roleSlug,
+  role_slugs: options.roleSlugs,
 });

--- a/src/user-management/serializers/organization-membership.serializer.ts
+++ b/src/user-management/serializers/organization-membership.serializer.ts
@@ -15,4 +15,5 @@ export const deserializeOrganizationMembership = (
   createdAt: organizationMembership.created_at,
   updatedAt: organizationMembership.updated_at,
   role: organizationMembership.role,
+  ...(organizationMembership.roles && { roles: organizationMembership.roles }),
 });

--- a/src/user-management/serializers/update-organization-membership-options.serializer.ts
+++ b/src/user-management/serializers/update-organization-membership-options.serializer.ts
@@ -7,4 +7,5 @@ export const serializeUpdateOrganizationMembershipOptions = (
   options: UpdateOrganizationMembershipOptions,
 ): SerializedUpdateOrganizationMembershipOptions => ({
   role_slug: options.roleSlug,
+  role_slugs: options.roleSlugs,
 });


### PR DESCRIPTION
## Description

Deserialize `roles` of organization membership responses
This is deserialization is conditional since OM resource endpoints always return `roles`, but OM events don't always return `roles`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
