### PR TITLE
Add Salesforce OAuth as an authentication provider

### DIFF
--- a/src/sso/interfaces/connection-type.enum.ts
+++ b/src/sso/interfaces/connection-type.enum.ts
@@ -28,6 +28,7 @@ export enum ConnectionType {
   PingFederateSAML = 'PingFederateSAML',
   PingOneSAML = 'PingOneSAML',
   RipplingSAML = 'RipplingSAML',
+  SalesforceOAuth = 'SalesforceOAuth',
   SalesforceSAML = 'SalesforceSAML',
   ShibbolethGenericSAML = 'ShibbolethGenericSAML',
   ShibbolethSAML = 'ShibbolethSAML',

--- a/src/user-management/interfaces/authentication-response.interface.ts
+++ b/src/user-management/interfaces/authentication-response.interface.ts
@@ -10,6 +10,7 @@ type AuthenticationMethod =
   | 'GitHubOAuth'
   | 'GoogleOAuth'
   | 'MicrosoftOAuth'
+  | 'SalesforceOAuth'
   | 'MagicAuth'
   | 'Impersonation';
 

--- a/src/user-management/interfaces/identity.interface.ts
+++ b/src/user-management/interfaces/identity.interface.ts
@@ -1,11 +1,11 @@
 export interface Identity {
   idpId: string;
   type: 'OAuth';
-  provider: 'AppleOAuth' | 'GoogleOAuth' | 'GitHubOAuth' | 'MicrosoftOAuth';
+  provider: 'AppleOAuth' | 'GoogleOAuth' | 'GitHubOAuth' | 'MicrosoftOAuth' | 'SalesforceOAuth';
 }
 
 export interface IdentityResponse {
   idp_id: string;
   type: 'OAuth';
-  provider: 'AppleOAuth' | 'GoogleOAuth' | 'GitHubOAuth' | 'MicrosoftOAuth';
+  provider: 'AppleOAuth' | 'GoogleOAuth' | 'GitHubOAuth' | 'MicrosoftOAuth' | 'SalesforceOAuth';
 }


### PR DESCRIPTION
## Description

We are rolling out support for Salesforce OAuth. This adds it to the list of providers.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
