### PR TITLE
[v8] drop node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/fix-latest.yml
+++ b/.github/workflows/fix-latest.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies

--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 22
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v1.x

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See the [API Reference](https://workos.com/docs/reference/client-libraries) for 
 
 ## Requirements
 
-Node 18 or higher.
+Node 20 or higher.
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/cookie": "^0.6.0",
         "@types/glob": "^8.1.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "~18",
+        "@types/node": "~20",
         "@types/pluralize": "0.0.33",
         "@types/qs": "^6.14.0",
         "@typescript-eslint/parser": "^8.25.0",
@@ -47,7 +47,7 @@
         "typescript-eslint": "^8.25.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3857,13 +3857,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.123",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
-      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "version": "20.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.19.tgz",
+      "integrity": "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/pluralize": {
@@ -9549,9 +9549,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "workos"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "type": "module",
   "main": "./lib/cjs/index.cjs",
@@ -54,7 +54,7 @@
     "@types/cookie": "^0.6.0",
     "@types/glob": "^8.1.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "~18",
+    "@types/node": "~20",
     "@types/pluralize": "0.0.33",
     "@types/qs": "^6.14.0",
     "@typescript-eslint/parser": "^8.25.0",


### PR DESCRIPTION
## Description

This pull request updates the project's Node.js version requirements and related configuration files to use Node.js 20 or newer, and removes support for Node.js 18. These changes help ensure compatibility with the latest Node.js features and security updates.

**Node.js version updates:**

* Updated the required Node.js engine in `package.json` from `>=18` to `>=20`.
* Changed the `@types/node` development dependency in `package.json` from version `~18` to `~20`.

**CI/CD workflow updates:**

* Modified the matrix in `.github/workflows/ci.yml` to run tests only on Node.js versions 20, 22, and 24, removing Node.js 18.
* Updated the Node.js version used in `.github/workflows/fix-latest.yml`, `.github/workflows/release.yml`, and `.github/workflows/runtime-tests.yml` from 18 to 22. [[1]](diffhunk://#diff-942585ab102b61d7fc2b3ebd901f78b627f006e4fe9ed539189fce8bfc503740L23-R23) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L22-R22) [[3]](diffhunk://#diff-8240caaafb609c069828d284a282ebeb4f57b1ce1668ab60c97ad12412dfeb6dL12-R12)

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
