### PR TITLE
Default PaginationOptions on AutoPaginatable

### DIFF
--- a/src/common/utils/pagination.ts
+++ b/src/common/utils/pagination.ts
@@ -2,7 +2,7 @@ import { List, PaginationOptions } from '../interfaces';
 
 export class AutoPaginatable<
   ResourceType,
-  ParametersType extends PaginationOptions,
+  ParametersType extends PaginationOptions = PaginationOptions,
 > {
   readonly object = 'list' as const;
   readonly options: ParametersType;


### PR DESCRIPTION
## Description

This pull request introduces a minor improvement to the `AutoPaginatable` class in `src/common/utils/pagination.ts`. The change sets a default type for the `ParametersType` generic parameter, making the class easier to use when the default `PaginationOptions` are sufficient.

* TypeScript Improvement:
  * Set a default value for the `ParametersType` generic parameter to `PaginationOptions` in the `AutoPaginatable` class, simplifying instantiation when custom options are not needed.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
