### PR TITLE
[v8] Add dynamic import wrapper for jose to support Node.js 20.15-20.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-eslint": "^8.46.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.15.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "workos"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=20.15.0"
   },
   "type": "module",
   "main": "./lib/cjs/index.cjs",

--- a/src/user-management/session.ts
+++ b/src/user-management/session.ts
@@ -1,4 +1,3 @@
-import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
 import { OauthException } from '../common/exceptions/oauth.exception';
 import {
   AccessToken,
@@ -12,6 +11,7 @@ import {
 } from './interfaces';
 import { UserManagement } from './user-management';
 import { unsealData } from 'iron-session';
+import { getJose } from '../utils/jose';
 
 type RefreshOptions = {
   cookiePassword?: string;
@@ -19,7 +19,6 @@ type RefreshOptions = {
 };
 
 export class CookieSession {
-  private jwks: ReturnType<typeof createRemoteJWKSet> | undefined;
   private userManagement: UserManagement;
   private cookiePassword: string;
   private sessionData: string;
@@ -36,8 +35,6 @@ export class CookieSession {
     this.userManagement = userManagement;
     this.cookiePassword = cookiePassword;
     this.sessionData = sessionData;
-
-    this.jwks = this.userManagement.jwks;
   }
 
   /**
@@ -86,6 +83,8 @@ export class CookieSession {
       };
     }
 
+    const { decodeJwt } = await getJose();
+
     const {
       sid: sessionId,
       org_id: organizationId,
@@ -120,6 +119,7 @@ export class CookieSession {
    * @returns An object indicating whether the refresh was successful or not. If successful, it will include the new sealed session data.
    */
   async refresh(options: RefreshOptions = {}): Promise<RefreshSessionResponse> {
+    const { decodeJwt } = await getJose();
     const session = await unsealData<SessionCookieData>(this.sessionData, {
       password: this.cookiePassword,
     });
@@ -224,14 +224,16 @@ export class CookieSession {
   }
 
   private async isValidJwt(accessToken: string): Promise<boolean> {
-    if (!this.jwks) {
+    const { jwtVerify } = await getJose();
+    const jwks = await this.userManagement.getJWKS();
+    if (!jwks) {
       throw new Error(
         'Missing client ID. Did you provide it when initializing WorkOS?',
       );
     }
 
     try {
-      await jwtVerify(accessToken, this.jwks);
+      await jwtVerify(accessToken, jwks);
       return true;
     } catch (e) {
       return false;

--- a/src/utils/jose.ts
+++ b/src/utils/jose.ts
@@ -1,0 +1,17 @@
+let _josePromise: Promise<typeof import('jose')> | undefined;
+
+/**
+ * Dynamically imports the jose library using import() to support Node.js 20.0-20.18.
+ *
+ * The jose library is ESM-only and cannot be loaded via require() in Node.js versions
+ * before 20.19.0. This wrapper uses dynamic import() which works in both ESM and CJS
+ * across all Node.js 20+ versions.
+ *
+ * This workaround can be removed when Node.js 20 reaches end-of-life (April 2026),
+ * at which point we can bump to Node.js 22+ and use direct imports.
+ *
+ * @returns Promise that resolves to the jose module
+ */
+export function getJose() {
+  return (_josePromise ??= import('jose'));
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -18,7 +18,7 @@ export default defineConfig([
     target: 'es2022',
     sourcemap: true,
     clean: true,
-    dts: { 
+    dts: {
       resolve: true,
       compilerOptions: {
         lib: ['dom', 'es2022'],
@@ -26,16 +26,13 @@ export default defineConfig([
       },
     },
     bundle: false,
-    external: ['iron-session', 'jose', 'leb', 'pluralize'],
     outExtension() {
       return { js: '.js' };
     },
     esbuildOptions(options) {
       options.keepNames = true;
     },
-    esbuildPlugins: [
-      fixImportsPlugin()
-    ]
+    esbuildPlugins: [fixImportsPlugin()],
   },
   // CJS build
   {
@@ -53,7 +50,7 @@ export default defineConfig([
     target: 'es2022',
     sourcemap: true,
     clean: false, // Don't clean, keep ESM files
-    dts: { 
+    dts: {
       resolve: true,
       compilerOptions: {
         lib: ['dom', 'es2022'],
@@ -61,15 +58,12 @@ export default defineConfig([
       },
     },
     bundle: false,
-    external: ['iron-session', 'jose', 'leb', 'pluralize'],
     outExtension() {
       return { js: '.cjs', dts: '.d.cts' };
     },
     esbuildOptions(options) {
       options.keepNames = true;
     },
-    esbuildPlugins: [
-      fixImportsPlugin()
-    ]
-  }
+    esbuildPlugins: [fixImportsPlugin()],
+  },
 ]);


### PR DESCRIPTION
The jose library is ESM-only and cannot be loaded via require() in Node.js versions before 20.19.0. This adds a dynamic import wrapper that works across all Node.js 20+ versions using import() which is supported in both ESM and CJS.

Breaking changes:
- UserManagement.jwks getter changed to async UserManagement.getJWKS() method
- CookieSession.jwks property removed (uses UserManagement.getJWKS() instead)

The wrapper enables:
- Lazy loading of jose (only when JWT methods are called)
- Support for all Node.js 20.x versions
- Smaller bundle size (no jose bundling needed)
- Clean migration path when Node 20 reaches EOL (April 2026)

Also updates:
- Minimum Node version to 20.15.0 (conservative choice within 20.x)
- tsup config: removes redundant external arrays (not needed with bundle: false)

## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
