### PR TITLE
Add `apiKeys.validateApiKey` method

### DIFF
--- a/src/api-keys/api-keys.spec.ts
+++ b/src/api-keys/api-keys.spec.ts
@@ -1,0 +1,54 @@
+import fetch from 'jest-fetch-mock';
+import { fetchOnce, fetchURL } from '../common/utils/test-utils';
+import { WorkOS } from '../workos';
+import validateApiKeyFixture from './fixtures/validate-api-key.json';
+
+describe('ApiKeys', () => {
+  let workos: WorkOS;
+
+  beforeAll(() => {
+    workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
+      apiHostname: 'api.workos.test',
+      clientId: 'proj_123',
+    });
+  });
+
+  beforeEach(() => fetch.resetMocks());
+
+  describe('validateApiKey', () => {
+    it('sends a validate API key request', async () => {
+      fetchOnce(validateApiKeyFixture);
+      const response = await workos.apiKeys.validateApiKey({
+        value: 'sk_123',
+      });
+
+      expect(fetchURL()).toContain('/api_keys/validations');
+      expect(response).toEqual({
+        apiKey: {
+          object: 'api_key',
+          id: 'api_key_01H5JQDV7R7ATEYZDEG0W5PRYS',
+          owner: {
+            type: 'organization',
+            id: 'org_01H5JQDV7R7ATEYZDEG0W5PRYS',
+          },
+          name: 'Test Api Key',
+          obfuscatedValue: 'sk_…PRYS',
+          lastUsedAt: null,
+          permissions: ['read', 'write'],
+          createdAt: '2023-07-18T02:07:19.911Z',
+          updatedAt: '2023-07-18T02:07:19.911Z',
+        },
+      });
+    });
+
+    it('returns null if key is invalid', async () => {
+      fetchOnce({ api_key: null });
+      const response = await workos.apiKeys.validateApiKey({
+        value: 'invalid',
+      });
+
+      expect(fetchURL()).toContain('/api_keys/validations');
+      expect(response).toEqual({ apiKey: null });
+    });
+  });
+});

--- a/src/api-keys/api-keys.ts
+++ b/src/api-keys/api-keys.ts
@@ -1,0 +1,22 @@
+import { WorkOS } from '../workos';
+import {
+  SerializedValidateApiKeyResponse,
+  ValidateApiKeyOptions,
+  ValidateApiKeyResponse,
+} from './interfaces/validate-api-key.interface';
+import { deserializeValidateApiKeyResponse } from './serializers/validate-api-key.serializer';
+
+export class ApiKeys {
+  constructor(private readonly workos: WorkOS) {}
+
+  async validateApiKey(
+    payload: ValidateApiKeyOptions,
+  ): Promise<ValidateApiKeyResponse> {
+    const { data } = await this.workos.post<SerializedValidateApiKeyResponse>(
+      '/api_keys/validations',
+      payload,
+    );
+
+    return deserializeValidateApiKeyResponse(data);
+  }
+}

--- a/src/api-keys/fixtures/validate-api-key.json
+++ b/src/api-keys/fixtures/validate-api-key.json
@@ -1,0 +1,16 @@
+{
+  "api_key": {
+    "object": "api_key",
+    "id": "api_key_01H5JQDV7R7ATEYZDEG0W5PRYS",
+    "owner": {
+      "type": "organization",
+      "id": "org_01H5JQDV7R7ATEYZDEG0W5PRYS"
+    },
+    "name": "Test Api Key",
+    "obfuscated_value": "sk_…PRYS",
+    "last_used_at": null,
+    "permissions": ["read", "write"],
+    "created_at": "2023-07-18T02:07:19.911Z",
+    "updated_at": "2023-07-18T02:07:19.911Z"
+  }
+}

--- a/src/api-keys/interfaces/api-key.interface.ts
+++ b/src/api-keys/interfaces/api-key.interface.ts
@@ -1,0 +1,29 @@
+export interface ApiKey {
+  object: 'api_key';
+  id: string;
+  owner: {
+    type: 'organization';
+    id: string;
+  };
+  name: string;
+  obfuscatedValue: string;
+  lastUsedAt: string | null;
+  permissions: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SerializedApiKey {
+  object: 'api_key';
+  id: string;
+  owner: {
+    type: 'organization';
+    id: string;
+  };
+  name: string;
+  obfuscated_value: string;
+  last_used_at: string | null;
+  permissions: string[];
+  created_at: string;
+  updated_at: string;
+}

--- a/src/api-keys/interfaces/validate-api-key.interface.ts
+++ b/src/api-keys/interfaces/validate-api-key.interface.ts
@@ -1,0 +1,13 @@
+import { ApiKey, SerializedApiKey } from './api-key.interface';
+
+export interface ValidateApiKeyOptions {
+  value: string;
+}
+
+export interface ValidateApiKeyResponse {
+  apiKey: ApiKey | null;
+}
+
+export interface SerializedValidateApiKeyResponse {
+  api_key: SerializedApiKey | null;
+}

--- a/src/api-keys/serializers/api-key.serializer.ts
+++ b/src/api-keys/serializers/api-key.serializer.ts
@@ -1,0 +1,15 @@
+import { ApiKey, SerializedApiKey } from '../interfaces/api-key.interface';
+
+export function deserializeApiKey(apiKey: SerializedApiKey): ApiKey {
+  return {
+    object: apiKey.object,
+    id: apiKey.id,
+    owner: apiKey.owner,
+    name: apiKey.name,
+    obfuscatedValue: apiKey.obfuscated_value,
+    lastUsedAt: apiKey.last_used_at,
+    permissions: apiKey.permissions,
+    createdAt: apiKey.created_at,
+    updatedAt: apiKey.updated_at,
+  };
+}

--- a/src/api-keys/serializers/validate-api-key.serializer.ts
+++ b/src/api-keys/serializers/validate-api-key.serializer.ts
@@ -1,0 +1,13 @@
+import {
+  SerializedValidateApiKeyResponse,
+  ValidateApiKeyResponse,
+} from '../interfaces/validate-api-key.interface';
+import { deserializeApiKey } from './api-key.serializer';
+
+export function deserializeValidateApiKeyResponse(
+  response: SerializedValidateApiKeyResponse,
+): ValidateApiKeyResponse {
+  return {
+    apiKey: response.api_key ? deserializeApiKey(response.api_key) : null,
+  };
+}

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -15,6 +15,7 @@ import {
   WorkOSOptions,
   WorkOSResponseError,
 } from './common/interfaces';
+import { ApiKeys } from './api-keys/api-keys';
 import { DirectorySync } from './directory-sync/directory-sync';
 import { Events } from './events/events';
 import { Organizations } from './organizations/organizations';
@@ -54,6 +55,7 @@ export class WorkOS {
   readonly clientId?: string;
 
   readonly actions: Actions;
+  readonly apiKeys = new ApiKeys(this);
   readonly auditLogs = new AuditLogs(this);
   readonly directorySync = new DirectorySync(this);
   readonly organizations = new Organizations(this);


### PR DESCRIPTION
## Description

We're introducing API keys to help developers provide secure authentication to their APIs. This PR exposes the validate API key endpoint, which is currently under development and looks like this:

> ### Validate API key
> `POST /api_keys/validations`
> 
> #### Parameters
> 
> * `value`: The value for an API key
> 
> #### Returns
> 
> * `api_key`: `api_key` | `null`

Here's what a call to this new method might look like in a developer's application:

```node
workos.apiKeys.validateApiKey({ value })
// { apiKey: { ... } } or { apiKey: null }
```

## Documentation

This will require a docs change, which will come in a future PR.