### PR TITLE
Use retryable HTTP requests for Vault API

### DIFF
--- a/src/common/net/fetch-client.spec.ts
+++ b/src/common/net/fetch-client.spec.ts
@@ -82,6 +82,62 @@ describe('Fetch client', () => {
       expect(await response.toJSON()).toEqual({ data: 'response' });
     });
 
+    it('get for Vault path should call fetchRequestWithRetry and return response', async () => {
+      fetchOnce({ data: 'response' });
+      const mockFetchRequestWithRetry = jest.spyOn(
+        FetchHttpClient.prototype as any,
+        'fetchRequestWithRetry',
+      );
+
+      const response = await fetchClient.get('/vault/v1/kv', {});
+
+      expect(mockFetchRequestWithRetry).toHaveBeenCalledTimes(1);
+      expect(fetchURL()).toBe('https://test.workos.com/vault/v1/kv');
+      expect(await response.toJSON()).toEqual({ data: 'response' });
+    });
+
+    it('post for Vault path should call fetchRequestWithRetry and return response', async () => {
+      fetchOnce({ data: 'response' });
+      const mockFetchRequestWithRetry = jest.spyOn(
+        FetchHttpClient.prototype as any,
+        'fetchRequestWithRetry',
+      );
+
+      const response = await fetchClient.post('/vault/v1/kv', {}, {});
+
+      expect(mockFetchRequestWithRetry).toHaveBeenCalledTimes(1);
+      expect(fetchURL()).toBe('https://test.workos.com/vault/v1/kv');
+      expect(await response.toJSON()).toEqual({ data: 'response' });
+    });
+
+    it('put for Vault path should call fetchRequestWithRetry and return response', async () => {
+      fetchOnce({ data: 'response' });
+      const mockFetchRequestWithRetry = jest.spyOn(
+        FetchHttpClient.prototype as any,
+        'fetchRequestWithRetry',
+      );
+
+      const response = await fetchClient.put('/vault/v1/kv/secret', {}, {});
+
+      expect(mockFetchRequestWithRetry).toHaveBeenCalledTimes(1);
+      expect(fetchURL()).toBe('https://test.workos.com/vault/v1/kv/secret');
+      expect(await response.toJSON()).toEqual({ data: 'response' });
+    });
+
+    it('delete for Vault path should call fetchRequestWithRetry and return response', async () => {
+      fetchOnce({ data: 'response' });
+      const mockFetchRequestWithRetry = jest.spyOn(
+        FetchHttpClient.prototype as any,
+        'fetchRequestWithRetry',
+      );
+
+      const response = await fetchClient.delete('/vault/v1/kv/secret', {});
+
+      expect(mockFetchRequestWithRetry).toHaveBeenCalledTimes(1);
+      expect(fetchURL()).toBe('https://test.workos.com/vault/v1/kv/secret');
+      expect(await response.toJSON()).toEqual({ data: 'response' });
+    });
+
     it('should retry request on 500 status code', async () => {
       fetchOnce(
         {},

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -51,7 +51,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (path.startsWith('/fga/')) {
+    if (HttpClient.isPathRetryable(path)) {
       return await this.fetchRequestWithRetry(
         resourceURL,
         'GET',
@@ -74,7 +74,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (path.startsWith('/fga/')) {
+    if (HttpClient.isPathRetryable(path)) {
       return await this.fetchRequestWithRetry(
         resourceURL,
         'POST',
@@ -108,7 +108,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (path.startsWith('/fga/')) {
+    if (HttpClient.isPathRetryable(path)) {
       return await this.fetchRequestWithRetry(
         resourceURL,
         'PUT',
@@ -141,7 +141,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (path.startsWith('/fga/')) {
+    if (HttpClient.isPathRetryable(path)) {
       return await this.fetchRequestWithRetry(
         resourceURL,
         'DELETE',

--- a/src/common/net/http-client.ts
+++ b/src/common/net/http-client.ts
@@ -10,7 +10,7 @@ export abstract class HttpClient implements HttpClientInterface {
   readonly MAX_RETRY_ATTEMPTS = 3;
   readonly BACKOFF_MULTIPLIER = 1.5;
   readonly MINIMUM_SLEEP_TIME_IN_MILLISECONDS = 500;
-  readonly RETRY_STATUS_CODES = [500, 502, 504];
+  readonly RETRY_STATUS_CODES = [408, 500, 502, 504];
 
   constructor(readonly baseURL: string, readonly options?: RequestInit) {}
 
@@ -86,6 +86,10 @@ export abstract class HttpClient implements HttpClientInterface {
     }
 
     return JSON.stringify(entity);
+  }
+
+  static isPathRetryable(path: string): boolean {
+    return path.startsWith('/fga/') || path.startsWith('/vault/');
   }
 
   private getSleepTimeInMilliseconds(retryAttempt: number): number {

--- a/src/common/net/node-client.spec.ts
+++ b/src/common/net/node-client.spec.ts
@@ -78,6 +78,66 @@ describe('Node client', () => {
     expect(await response.toJSON()).toEqual({ data: 'response' });
   });
 
+  it('get for Vault path should call nodeRequestWithRetry and return response', async () => {
+    nock('https://test.workos.com')
+      .get('/vault/v1/kv')
+      .reply(200, { data: 'response' });
+    const mockNodeRequestWithRetry = jest.spyOn(
+      NodeHttpClient.prototype as any,
+      'nodeRequestWithRetry',
+    );
+
+    const response = await nodeClient.get('/vault/v1/kv', {});
+
+    expect(mockNodeRequestWithRetry).toHaveBeenCalledTimes(1);
+    expect(await response.toJSON()).toEqual({ data: 'response' });
+  });
+
+  it('post for Vault path should call nodeRequestWithRetry and return response', async () => {
+    nock('https://test.workos.com')
+      .post('/vault/v1/kv')
+      .reply(200, { data: 'response' });
+    const mockNodeRequestWithRetry = jest.spyOn(
+      NodeHttpClient.prototype as any,
+      'nodeRequestWithRetry',
+    );
+
+    const response = await nodeClient.post('/vault/v1/kv', {}, {});
+
+    expect(mockNodeRequestWithRetry).toHaveBeenCalledTimes(1);
+    expect(await response.toJSON()).toEqual({ data: 'response' });
+  });
+
+  it('put for Vault path should call nodeRequestWithRetry and return response', async () => {
+    nock('https://test.workos.com')
+      .put('/vault/v1/kv/secret')
+      .reply(200, { data: 'response' });
+    const mockNodeRequestWithRetry = jest.spyOn(
+      NodeHttpClient.prototype as any,
+      'nodeRequestWithRetry',
+    );
+
+    const response = await nodeClient.put('/vault/v1/kv/secret', {}, {});
+
+    expect(mockNodeRequestWithRetry).toHaveBeenCalledTimes(1);
+    expect(await response.toJSON()).toEqual({ data: 'response' });
+  });
+
+  it('delete for Vault path should call nodeRequestWithRetry and return response', async () => {
+    nock('https://test.workos.com')
+      .delete('/vault/v1/kv/secret')
+      .reply(200, { data: 'response' });
+    const mockNodeRequestWithRetry = jest.spyOn(
+      NodeHttpClient.prototype as any,
+      'nodeRequestWithRetry',
+    );
+
+    const response = await nodeClient.delete('/vault/v1/kv/secret', {});
+
+    expect(mockNodeRequestWithRetry).toHaveBeenCalledTimes(1);
+    expect(await response.toJSON()).toEqual({ data: 'response' });
+  });
+
   it('should retry request on 500 status code', async () => {
     nock('https://test.workos.com')
       .get('/fga/v1/resources')

--- a/src/common/net/node-client.ts
+++ b/src/common/net/node-client.ts
@@ -62,7 +62,7 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (path.startsWith('/fga/')) {
+    if (HttpClient.isPathRetryable(path)) {
       return await this.nodeRequestWithRetry(
         resourceURL,
         'GET',
@@ -85,7 +85,7 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (path.startsWith('/fga/')) {
+    if (HttpClient.isPathRetryable(path)) {
       return await this.nodeRequestWithRetry(
         resourceURL,
         'POST',
@@ -119,7 +119,7 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (path.startsWith('/fga/')) {
+    if (HttpClient.isPathRetryable(path)) {
       return await this.nodeRequestWithRetry(
         resourceURL,
         'PUT',
@@ -152,7 +152,7 @@ export class NodeHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (path.startsWith('/fga/')) {
+    if (HttpClient.isPathRetryable(path)) {
       return await this.nodeRequestWithRetry(
         resourceURL,
         'DELETE',


### PR DESCRIPTION
## Description

By default API requests will immediately fail. FGA endpoints are the exception that use a wrapper to retry some failures. This adds Vault paths to the same retry logic. It also adds `408` response codes to the list of retryable codes - `408` is set by the SDK when catching/rethrowing a [request timeout](https://github.com/workos/workos-node/blob/main/src/common/net/fetch-client.ts#L251).

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
