### PR TITLE
Add api-keys widget scope

### DIFF
--- a/src/widgets/interfaces/get-token.ts
+++ b/src/widgets/interfaces/get-token.ts
@@ -1,8 +1,8 @@
 export type WidgetScope =
   | 'widgets:users-table:manage'
   | 'widgets:sso:manage'
-  | 'widgets:domain-verification:manage';
-
+  | 'widgets:domain-verification:manage'
+  | 'widgets:api-keys:manage';
 export interface GetTokenOptions {
   organizationId: string;
   userId?: string;


### PR DESCRIPTION
## Description

Adds `widgets:api-keys:manage` scope

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
