### PR TITLE
Add argon2 type to PasswordHashType interface

### DIFF
--- a/src/user-management/interfaces/password-hash-type.interface.ts
+++ b/src/user-management/interfaces/password-hash-type.interface.ts
@@ -1,1 +1,6 @@
-export type PasswordHashType = 'bcrypt' | 'firebase-scrypt' | 'ssha' | 'scrypt';
+export type PasswordHashType =
+  | 'bcrypt'
+  | 'firebase-scrypt'
+  | 'ssha'
+  | 'scrypt'
+  | 'argon2';


### PR DESCRIPTION
## Description

Add argon2 type to PasswordHashType interface

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
