### PR TITLE
Update convex import paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,8 @@
         "require": "./lib/cjs/index.cjs"
       },
       "convex": {
-        "import": "./lib/index.worker.js",
-        "default": "./lib/index.worker.js"
+        "import": "./lib/esm/index.worker.js",
+        "default": "./lib/cjs/index.worker.cjs"
       },
       "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.cjs",


### PR DESCRIPTION
## Description

pretty self explanatory. the current path doesn't exist and gives an error when trying to deploy 
<img width="1620" height="682" alt="CleanShot 2025-11-15 at 19 38 29@2x" src="https://github.com/user-attachments/assets/dadf41ee-5e53-49a6-a895-860840f2c404" />


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

- [ ] Yes

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
