### PR TITLE
Add ability to resend invitation

### DIFF
--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -2128,6 +2128,85 @@ describe('UserManagement', () => {
     });
   });
 
+  describe('resendInvitation', () => {
+    it('send a Resend Invitation request', async () => {
+      const invitationId = 'invitation_01H5JQDV7R7ATEYZDEG0W5PRYS';
+      fetchOnce(invitationFixture);
+
+      const response = await workos.userManagement.resendInvitation(
+        invitationId,
+      );
+
+      expect(fetchURL()).toContain(
+        `/user_management/invitations/${invitationId}/resend`,
+      );
+      expect(response).toMatchObject({
+        object: 'invitation',
+        email: 'dane@workos.com',
+      });
+    });
+
+    it('throws an error when invitation is not found (404)', async () => {
+      const invitationId = 'invitation_01H5JQDV7R7ATEYZDEG0W5PRYS';
+      fetchOnce(
+        {
+          message: 'Invitation not found',
+          code: 'not_found',
+        },
+        { status: 404 },
+      );
+
+      await expect(
+        workos.userManagement.resendInvitation(invitationId),
+      ).rejects.toThrow();
+    });
+
+    it('throws an error when invitation is expired (400)', async () => {
+      const invitationId = 'invitation_01H5JQDV7R7ATEYZDEG0W5PRYS';
+      fetchOnce(
+        {
+          message: 'Invite has expired.',
+          code: 'invite_expired',
+        },
+        { status: 400 },
+      );
+
+      await expect(
+        workos.userManagement.resendInvitation(invitationId),
+      ).rejects.toThrow();
+    });
+
+    it('throws an error when invitation is revoked (400)', async () => {
+      const invitationId = 'invitation_01H5JQDV7R7ATEYZDEG0W5PRYS';
+      fetchOnce(
+        {
+          message: 'Invite has been revoked.',
+          code: 'invite_revoked',
+        },
+        { status: 400 },
+      );
+
+      await expect(
+        workos.userManagement.resendInvitation(invitationId),
+      ).rejects.toThrow();
+    });
+
+    it('throws an error when invitation is accepted (400)', async () => {
+      const invitationId = 'invitation_01H5JQDV7R7ATEYZDEG0W5PRYS';
+      fetchOnce(
+        {
+          message: 'Invite has already been accepted.',
+          code: 'invite_accepted',
+        },
+        { status: 400 },
+      );
+
+      await expect(
+        workos.userManagement.resendInvitation(invitationId),
+      ).rejects.toThrow();
+    });
+  });
+
   describe('revokeSession', () => {
     it('sends a Revoke Session request', async () => {
       const sessionId = 'session_12345';

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -1057,6 +1057,15 @@ export class UserManagement {
     return deserializeInvitation(data);
   }
 
+  async resendInvitation(invitationId: string): Promise<Invitation> {
+    const { data } = await this.workos.post<InvitationResponse, any>(
+      `/user_management/invitations/${invitationId}/resend`,
+      null,
+    );
+
+    return deserializeInvitation(data);
+  }
+
   async revokeSession(payload: RevokeSessionOptions): Promise<void> {
     await this.workos.post<void, SerializedRevokeSessionOptions>(
       '/user_management/sessions/revoke',


### PR DESCRIPTION
Toward AUTH-5512.

## Description

This adds support for the new resend invitation endpoint.

It can be used like this:

```js
await workos.userManagement.resendInvitation(
  'invitation_01E4ZCR3C56J083X43JQXF3JK5',
);
```

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/47145