### PR TITLE
Add passkey authentication events

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -121,6 +121,28 @@ export interface AuthenticationOAuthSucceededEventResponse
   data: AuthenticationEventResponse;
 }
 
+export interface AuthenticationPasskeyFailedEvent extends EventBase {
+  event: 'authentication.passkey_failed';
+  data: AuthenticationEvent;
+}
+
+export interface AuthenticationPasskeyFailedEventResponse
+  extends EventResponseBase {
+  event: 'authentication.passkey_failed';
+  data: AuthenticationEventResponse;
+}
+
+export interface AuthenticationPasskeySucceededEvent extends EventBase {
+  event: 'authentication.passkey_succeeded';
+  data: AuthenticationEvent;
+}
+
+export interface AuthenticationPasskeySucceededEventResponse
+  extends EventResponseBase {
+  event: 'authentication.passkey_succeeded';
+  data: AuthenticationEventResponse;
+}
+
 export interface AuthenticationPasswordFailedEvent extends EventBase {
   event: 'authentication.password_failed';
   data: AuthenticationEvent;
@@ -640,6 +662,8 @@ export type Event =
   | AuthenticationOAuthSucceededEvent
   | AuthenticationSSOFailedEvent
   | AuthenticationSSOSucceededEvent
+  | AuthenticationPasskeyFailedEvent
+  | AuthenticationPasskeySucceededEvent
   | AuthenticationPasswordFailedEvent
   | AuthenticationPasswordSucceededEvent
   | AuthenticationMagicAuthFailedEvent
@@ -695,6 +719,8 @@ export type EventResponse =
   | AuthenticationMfaSucceededEventResponse
   | AuthenticationOAuthFailedEventResponse
   | AuthenticationOAuthSucceededEventResponse
+  | AuthenticationPasskeyFailedEventResponse
+  | AuthenticationPasskeySucceededEventResponse
   | AuthenticationPasswordFailedEventResponse
   | AuthenticationPasswordSucceededEventResponse
   | AuthenticationSSOFailedEventResponse

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -36,6 +36,8 @@ export const deserializeEvent = (event: EventResponse): Event => {
     case 'authentication.mfa_succeeded':
     case 'authentication.oauth_failed':
     case 'authentication.oauth_succeeded':
+    case 'authentication.passkey_failed':
+    case 'authentication.passkey_succeeded':
     case 'authentication.password_failed':
     case 'authentication.password_succeeded':
     case 'authentication.sso_failed':


### PR DESCRIPTION


## Description

A bug in our API prevented these from being returned but also we are missing them from the types in this library. The API bug has been fixed and this fixes the SDK.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
