### PR TITLE
Add workos.pipes.getAccessToken

### DIFF
--- a/src/pipes/fixtures/get-access-token-needs-reauth.json
+++ b/src/pipes/fixtures/get-access-token-needs-reauth.json
@@ -1,0 +1,4 @@
+{
+  "active": false,
+  "error": "needs_reauthorization"
+}

--- a/src/pipes/fixtures/get-access-token-no-expiry.json
+++ b/src/pipes/fixtures/get-access-token-no-expiry.json
@@ -1,0 +1,10 @@
+{
+  "active": true,
+  "access_token": {
+    "object": "access_token",
+    "access_token": "test_access_token_456",
+    "expires_at": null,
+    "scopes": ["read:data"],
+    "missing_scopes": ["write:data"]
+  }
+}

--- a/src/pipes/fixtures/get-access-token-not-installed.json
+++ b/src/pipes/fixtures/get-access-token-not-installed.json
@@ -1,0 +1,4 @@
+{
+  "active": false,
+  "error": "not_installed"
+}

--- a/src/pipes/fixtures/get-access-token-success.json
+++ b/src/pipes/fixtures/get-access-token-success.json
@@ -1,0 +1,10 @@
+{
+  "active": true,
+  "access_token": {
+    "object": "access_token",
+    "access_token": "test_access_token_123",
+    "expires_at": "2025-10-18T12:00:00.000Z",
+    "scopes": ["read:users", "write:users"],
+    "missing_scopes": []
+  }
+}

--- a/src/pipes/interfaces/access-token.interface.ts
+++ b/src/pipes/interfaces/access-token.interface.ts
@@ -1,0 +1,15 @@
+export interface AccessToken {
+  object: 'access_token';
+  accessToken: string;
+  expiresAt: Date | null;
+  scopes: string[];
+  missingScopes: string[];
+}
+
+export interface SerializedAccessToken {
+  object: 'access_token';
+  access_token: string;
+  expires_at: string | null;
+  scopes: string[];
+  missing_scopes: string[];
+}

--- a/src/pipes/interfaces/get-access-token.interface.ts
+++ b/src/pipes/interfaces/get-access-token.interface.ts
@@ -1,0 +1,39 @@
+import { AccessToken, SerializedAccessToken } from './access-token.interface';
+
+export interface GetAccessTokenOptions {
+  userId: string;
+  organizationId?: string | null;
+}
+
+export interface SerializedGetAccessTokenOptions {
+  user_id: string;
+  organization_id?: string | null;
+}
+
+export interface GetAccessTokenSuccessResponse {
+  active: true;
+  accessToken: AccessToken;
+}
+
+export interface GetAccessTokenFailureResponse {
+  active: false;
+  error: 'not_installed' | 'needs_reauthorization';
+}
+
+export type GetAccessTokenResponse =
+  | GetAccessTokenSuccessResponse
+  | GetAccessTokenFailureResponse;
+
+export interface SerializedGetAccessTokenSuccessResponse {
+  active: true;
+  access_token: SerializedAccessToken;
+}
+
+export interface SerializedGetAccessTokenFailureResponse {
+  active: false;
+  error: 'not_installed' | 'needs_reauthorization';
+}
+
+export type SerializedGetAccessTokenResponse =
+  | SerializedGetAccessTokenSuccessResponse
+  | SerializedGetAccessTokenFailureResponse;

--- a/src/pipes/pipes.spec.ts
+++ b/src/pipes/pipes.spec.ts
@@ -1,0 +1,110 @@
+import fetch from 'jest-fetch-mock';
+import { fetchOnce, fetchURL, fetchBody } from '../common/utils/test-utils';
+import { WorkOS } from '../workos';
+import getAccessTokenSuccessFixture from './fixtures/get-access-token-success.json';
+import getAccessTokenNoExpiryFixture from './fixtures/get-access-token-no-expiry.json';
+import getAccessTokenNotInstalledFixture from './fixtures/get-access-token-not-installed.json';
+import getAccessTokenNeedsReauthFixture from './fixtures/get-access-token-needs-reauth.json';
+
+describe('Pipes', () => {
+  let workos: WorkOS;
+
+  beforeAll(() => {
+    workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
+      apiHostname: 'api.workos.test',
+      clientId: 'proj_123',
+    });
+  });
+
+  beforeEach(() => fetch.resetMocks());
+
+  describe('getAccessToken', () => {
+    it('returns access token with expiry date', async () => {
+      fetchOnce(getAccessTokenSuccessFixture);
+      const response = await workos.pipes.getAccessToken({
+        provider: 'test-provider',
+        userId: 'user_123',
+        organizationId: 'org_456',
+      });
+
+      expect(fetchURL()).toContain('/data-integrations/test-provider/token');
+      expect(fetchBody()).toEqual({
+        user_id: 'user_123',
+        organization_id: 'org_456',
+      });
+      expect(response).toEqual({
+        active: true,
+        accessToken: {
+          object: 'access_token',
+          accessToken: 'test_access_token_123',
+          expiresAt: new Date('2025-10-18T12:00:00.000Z'),
+          scopes: ['read:users', 'write:users'],
+          missingScopes: [],
+        },
+      });
+    });
+
+    it('returns access token without expiry date', async () => {
+      fetchOnce(getAccessTokenNoExpiryFixture);
+      const response = await workos.pipes.getAccessToken({
+        provider: 'test-provider',
+        userId: 'user_789',
+      });
+
+      expect(fetchURL()).toContain('/data-integrations/test-provider/token');
+      expect(fetchBody()).toEqual({
+        user_id: 'user_789',
+        organization_id: undefined,
+      });
+      expect(response).toEqual({
+        active: true,
+        accessToken: {
+          object: 'access_token',
+          accessToken: 'test_access_token_456',
+          expiresAt: null,
+          scopes: ['read:data'],
+          missingScopes: ['write:data'],
+        },
+      });
+    });
+
+    it('returns not_installed failure when integration is not installed', async () => {
+      fetchOnce(getAccessTokenNotInstalledFixture);
+      const response = await workos.pipes.getAccessToken({
+        provider: 'test-provider',
+        userId: 'user_123',
+      });
+
+      expect(fetchURL()).toContain('/data-integrations/test-provider/token');
+      expect(response).toEqual({
+        active: false,
+        error: 'not_installed',
+      });
+    });
+
+    it('returns needs_reauthorization failure when token needs refresh', async () => {
+      fetchOnce(getAccessTokenNeedsReauthFixture);
+      const response = await workos.pipes.getAccessToken({
+        provider: 'test-provider',
+        userId: 'user_123',
+      });
+
+      expect(fetchURL()).toContain('/data-integrations/test-provider/token');
+      expect(response).toEqual({
+        active: false,
+        error: 'needs_reauthorization',
+      });
+    });
+
+    it('throws error for server errors', async () => {
+      fetchOnce({ message: 'Internal Server Error' }, { status: 500 });
+
+      await expect(
+        workos.pipes.getAccessToken({
+          provider: 'test-provider',
+          userId: 'user_123',
+        }),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/src/pipes/pipes.ts
+++ b/src/pipes/pipes.ts
@@ -1,0 +1,28 @@
+import type { WorkOS } from '../workos';
+import {
+  GetAccessTokenOptions,
+  GetAccessTokenResponse,
+  SerializedGetAccessTokenResponse,
+} from './interfaces/get-access-token.interface';
+import {
+  serializeGetAccessTokenOptions,
+  deserializeGetAccessTokenResponse,
+} from './serializers/get-access-token.serializer';
+
+export class Pipes {
+  constructor(private readonly workos: WorkOS) {}
+
+  async getAccessToken({
+    provider,
+    ...options
+  }: GetAccessTokenOptions & {
+    provider: string;
+  }): Promise<GetAccessTokenResponse> {
+    const { data } = await this.workos.post<SerializedGetAccessTokenResponse>(
+      `data-integrations/${provider}/token`,
+      serializeGetAccessTokenOptions(options),
+    );
+
+    return deserializeGetAccessTokenResponse(data);
+  }
+}

--- a/src/pipes/serializers/access-token.serializer.ts
+++ b/src/pipes/serializers/access-token.serializer.ts
@@ -1,0 +1,18 @@
+import {
+  AccessToken,
+  SerializedAccessToken,
+} from '../interfaces/access-token.interface';
+
+export function deserializeAccessToken(
+  serialized: SerializedAccessToken,
+): AccessToken {
+  return {
+    object: 'access_token',
+    accessToken: serialized.access_token,
+    expiresAt: serialized.expires_at
+      ? new Date(Date.parse(serialized.expires_at))
+      : null,
+    scopes: serialized.scopes,
+    missingScopes: serialized.missing_scopes,
+  };
+}

--- a/src/pipes/serializers/get-access-token.serializer.ts
+++ b/src/pipes/serializers/get-access-token.serializer.ts
@@ -1,0 +1,32 @@
+import {
+  GetAccessTokenOptions,
+  GetAccessTokenResponse,
+  SerializedGetAccessTokenOptions,
+  SerializedGetAccessTokenResponse,
+} from '../interfaces/get-access-token.interface';
+import { deserializeAccessToken } from './access-token.serializer';
+
+export function serializeGetAccessTokenOptions(
+  options: GetAccessTokenOptions,
+): SerializedGetAccessTokenOptions {
+  return {
+    user_id: options.userId,
+    organization_id: options.organizationId,
+  };
+}
+
+export function deserializeGetAccessTokenResponse(
+  response: SerializedGetAccessTokenResponse,
+): GetAccessTokenResponse {
+  if (response.active) {
+    return {
+      active: true,
+      accessToken: deserializeAccessToken(response.access_token),
+    };
+  }
+
+  return {
+    active: false,
+    error: response.error,
+  };
+}

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -21,6 +21,7 @@ import { Events } from './events/events';
 import { Organizations } from './organizations/organizations';
 import { OrganizationDomains } from './organization-domains/organization-domains';
 import { Passwordless } from './passwordless/passwordless';
+import { Pipes } from './pipes/pipes';
 import { Portal } from './portal/portal';
 import { SSO } from './sso/sso';
 import { Webhooks } from './webhooks/webhooks';
@@ -61,6 +62,7 @@ export class WorkOS {
   readonly organizations = new Organizations(this);
   readonly organizationDomains = new OrganizationDomains(this);
   readonly passwordless = new Passwordless(this);
+  readonly pipes = new Pipes(this);
   readonly portal = new Portal(this);
   readonly sso = new SSO(this);
   readonly webhooks: Webhooks;


### PR DESCRIPTION
## Description

This adds support for the Pipes get-access-token endpoint.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
