### PR TITLE
Expose interfaces for feature flags

### DIFF
--- a/src/feature-flags/interfaces/index.ts
+++ b/src/feature-flags/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from './feature-flag.interface';

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export * from './portal/interfaces';
 export * from './sso/interfaces';
 export * from './user-management/interfaces';
 export * from './roles/interfaces';
+export * from './feature-flags/interfaces';
 
 class WorkOSNode extends WorkOS {
   /** @override */


### PR DESCRIPTION
## Description

The types that the functions that deal with feature flags return (`FeatureFlag` and `FeatureFlagResponse`) https://github.com/workos/workos-node/blob/0a8b3db79502781382cd5ff255de928e04a8c809/src/organizations/organizations.ts#L114-L116 aren't visible from the package entrypoint which means they can't be imported by third-party code.

This differs from other functionality (e.g. organizations) which 
1. Have an `index.ts` file which re-exports all their interfaces https://github.com/workos/workos-node/blob/d0067d58d2ab93362b08c1c26d4b5ccea3b81a09/src/organizations/interfaces/index.ts#L1-L6
2. Re-export these index files from the main entrypoint https://github.com/workos/workos-node/blob/0a8b3db79502781382cd5ff255de928e04a8c809/src/index.ts#L25

## Changes

1. Adds a `feature-flags/interfaces/index.ts` file to mirror the other namespaces
2. Adds a `export * from` the above in `src/index.ts`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
