### PR TITLE
[v8] Use globalThis.crypto.randomUUID for runtime-agnostic UUIDs

### DIFF
--- a/src/audit-logs/audit-logs.ts
+++ b/src/audit-logs/audit-logs.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 import { WorkOS } from '../workos';
 import {
   CreateAuditLogEventOptions,
@@ -34,7 +33,9 @@ export class AuditLogs {
     // Auto-generate idempotency key if not provided
     const optionsWithIdempotency: CreateAuditLogEventRequestOptions = {
       ...options,
-      idempotencyKey: options.idempotencyKey || `workos-node-${randomUUID()}`,
+      idempotencyKey:
+        options.idempotencyKey ||
+        `workos-node-${globalThis.crypto.randomUUID()}`,
     };
 
     await this.workos.post(


### PR DESCRIPTION
Replaces Node.js-specific crypto import with globalThis.crypto to ensure compatibility across Node.js 20 and other runtimes.

## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
