### PR TITLE
Add randomUUID to CryptoProvider for edge runtime compatibility

### DIFF
--- a/src/audit-logs/audit-logs.ts
+++ b/src/audit-logs/audit-logs.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 import { WorkOS } from '../workos';
 import {
   CreateAuditLogEventOptions,
@@ -34,7 +33,9 @@ export class AuditLogs {
     // Auto-generate idempotency key if not provided
     const optionsWithIdempotency: CreateAuditLogEventRequestOptions = {
       ...options,
-      idempotencyKey: options.idempotencyKey || `workos-node-${randomUUID()}`,
+      idempotencyKey:
+        options.idempotencyKey ||
+        `workos-node-${this.workos.getCryptoProvider().randomUUID()}`,
     };
 
     await this.workos.post(

--- a/src/common/crypto/crypto-provider.spec.ts
+++ b/src/common/crypto/crypto-provider.spec.ts
@@ -65,4 +65,52 @@ describe('CryptoProvider', () => {
       );
     });
   });
+
+  describe('when generating UUIDs', () => {
+    const UUID_V4_REGEX =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+    it('generates valid UUID v4 format for NodeCryptoProvider', () => {
+      const nodeCryptoProvider = new NodeCryptoProvider();
+      const uuid = nodeCryptoProvider.randomUUID();
+
+      expect(uuid).toMatch(UUID_V4_REGEX);
+    });
+
+    it('generates valid UUID v4 format for SubtleCryptoProvider', () => {
+      const subtleCryptoProvider = new SubtleCryptoProvider();
+      const uuid = subtleCryptoProvider.randomUUID();
+
+      expect(uuid).toMatch(UUID_V4_REGEX);
+    });
+
+    it('generates unique UUIDs', () => {
+      const nodeCryptoProvider = new NodeCryptoProvider();
+      const subtleCryptoProvider = new SubtleCryptoProvider();
+
+      const uuids = new Set([
+        nodeCryptoProvider.randomUUID(),
+        nodeCryptoProvider.randomUUID(),
+        subtleCryptoProvider.randomUUID(),
+        subtleCryptoProvider.randomUUID(),
+      ]);
+
+      expect(uuids.size).toBe(4);
+    });
+
+    it('SubtleCryptoProvider falls back when crypto.randomUUID is unavailable', () => {
+      const originalRandomUUID = globalThis.crypto.randomUUID;
+      // @ts-ignore - intentionally removing for test
+      delete globalThis.crypto.randomUUID;
+
+      try {
+        const subtleCryptoProvider = new SubtleCryptoProvider();
+        const uuid = subtleCryptoProvider.randomUUID();
+
+        expect(uuid).toMatch(UUID_V4_REGEX);
+      } finally {
+        globalThis.crypto.randomUUID = originalRandomUUID;
+      }
+    });
+  });
 });

--- a/src/common/crypto/crypto-provider.ts
+++ b/src/common/crypto/crypto-provider.ts
@@ -82,4 +82,11 @@ export abstract class CryptoProvider {
    * @returns A Uint8Array containing the random bytes
    */
   abstract randomBytes(length: number): Uint8Array;
+
+  /**
+   * Generates a random UUID v4 string.
+   *
+   * @returns A UUID v4 string in the format xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+   */
+  abstract randomUUID(): string;
 }

--- a/src/common/crypto/node-crypto-provider.ts
+++ b/src/common/crypto/node-crypto-provider.ts
@@ -96,4 +96,8 @@ export class NodeCryptoProvider extends CryptoProvider {
   randomBytes(length: number): Uint8Array {
     return new Uint8Array(crypto.randomBytes(length));
   }
+
+  randomUUID(): string {
+    return crypto.randomUUID();
+  }
 }

--- a/src/common/crypto/subtle-crypto-provider.ts
+++ b/src/common/crypto/subtle-crypto-provider.ts
@@ -173,6 +173,28 @@ export class SubtleCryptoProvider extends CryptoProvider {
     crypto.getRandomValues(bytes);
     return bytes;
   }
+
+  randomUUID(): string {
+    if (
+      typeof crypto !== 'undefined' &&
+      typeof crypto.randomUUID === 'function'
+    ) {
+      return crypto.randomUUID();
+    }
+
+    // Fallback for environments without crypto.randomUUID
+    const bytes = this.randomBytes(16);
+    // tslint:disable-next-line:no-bitwise
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    // tslint:disable-next-line:no-bitwise
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant
+
+    const hex = Array.from(bytes, (b) => byteHexMapping[b]).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(
+      12,
+      16,
+    )}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
 }
 
 // Cached mapping of byte to hex representation. We do this once to avoid re-


### PR DESCRIPTION
## Summary

Fixes #1403

- Adds `randomUUID()` abstract method to `CryptoProvider` interface
- Implements in `NodeCryptoProvider` using Node's `crypto.randomUUID()`
- Implements in `SubtleCryptoProvider` using `randomBytes(16)` with UUID v4 bit manipulation
- Updates `AuditLogs` to use `getCryptoProvider().randomUUID()` instead of direct Node crypto import

This ensures the audit-logs idempotency key generation works across all supported runtimes including edge environments (Convex, Cloudflare Workers) that cannot import the Node "crypto" package.