### PR TITLE
[v8] fix: bundle ESM-only deps for CJS compatibility

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
   clean: true,
   dts: true,
   unbundle: true,
+  // bundle ESM-only deps for CJS compatibility
+  noExternal: ['iron-webcrypto', 'uint8array-extras'],
   outExtensions({ format }) {
     return {
       js: format === 'cjs' ? '.cjs' : '.js',


### PR DESCRIPTION
Bundle `iron-webcrypto` and `uint8array-extras` into the build output using `noExternal`.

These packages are ESM-only and cause `ERR_REQUIRE_ESM` errors for CJS consumers without special Jest/bundler configuration.