### PR TITLE
Update repository.url to match npm expectation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/workos-inc/workos-node.git"
+    "url": "https://github.com/workos-inc/workos-node"
   },
   "bugs": {
     "url": "https://github.com/workos-inc/workos-node/issues"


### PR DESCRIPTION
## Description

This should fix [an error publishing to npm](https://github.com/workos/workos-node/actions/runs/20600211504/job/59164131172)

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
