### PR TITLE
Fix URLs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",
-  "homepage": "https://github.com/workos-inc/workos-node",
+  "homepage": "https://github.com/workos/workos-node",
   "license": "MIT",
   "keywords": [
     "workos"
@@ -17,10 +17,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/workos-inc/workos-node.git"
+    "url": "git+https://github.com/workos/workos-node.git"
   },
   "bugs": {
-    "url": "https://github.com/workos-inc/workos-node/issues"
+    "url": "https://github.com/workos/workos-node/issues"
   },
   "scripts": {
     "clean": "rm -rf lib",


### PR DESCRIPTION
## Description

I believe these outdated URLs are the cause of our NPM publishing failures. Trusted Publisher expects this URL to match the URL of the repo.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
