### PR TITLE
Add Invitation Resent Event Interfaces

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -379,6 +379,11 @@ export interface InvitationRevokedEvent extends EventBase {
   data: InvitationEvent;
 }
 
+export interface InvitationResentEvent extends EventBase {
+  event: 'invitation.resent';
+  data: InvitationEvent;
+}
+
 export interface InvitationAcceptedEventResponse extends EventResponseBase {
   event: 'invitation.accepted';
   data: InvitationEventResponse;
@@ -391,6 +396,11 @@ export interface InvitationCreatedEventResponse extends EventResponseBase {
 
 export interface InvitationRevokedEventResponse extends EventResponseBase {
   event: 'invitation.revoked';
+  data: InvitationEventResponse;
+}
+
+export interface InvitationResentEventResponse extends EventResponseBase {
+  event: 'invitation.resent';
   data: InvitationEventResponse;
 }
 
@@ -687,6 +697,7 @@ export type Event =
   | InvitationAcceptedEvent
   | InvitationCreatedEvent
   | InvitationRevokedEvent
+  | InvitationResentEvent
   | MagicAuthCreatedEvent
   | PasswordResetCreatedEvent
   | PasswordResetSucceededEvent
@@ -744,6 +755,7 @@ export type EventResponse =
   | InvitationAcceptedEventResponse
   | InvitationCreatedEventResponse
   | InvitationRevokedEventResponse
+  | InvitationResentEventResponse
   | MagicAuthCreatedEventResponse
   | PasswordResetCreatedEventResponse
   | PasswordResetSucceededEventResponse

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -120,6 +120,7 @@ export const deserializeEvent = (event: EventResponse): Event => {
     case 'invitation.accepted':
     case 'invitation.created':
     case 'invitation.revoked':
+    case 'invitation.resent':
       return {
         ...eventBase,
         event: event.event,


### PR DESCRIPTION
## Description
- Introduced `InvitationResentEvent` and `InvitationResentEventResponse` interfaces to handle the 'invitation.resent' event.
- Updated the `Event` and `EventResponse` types to include the new event interfaces.
- Modified the `deserializeEvent` function to support the new event type.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
