### PR TITLE
Add api key events

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -43,6 +43,7 @@ import {
   AuthenticationRadarRiskDetectedEventData,
   AuthenticationRadarRiskDetectedEventResponseData,
 } from '../../user-management/interfaces/authentication-radar-risk-detected-event.interface';
+import { ApiKey, SerializedApiKey } from '../../api-keys/interfaces';
 
 export interface EventBase {
   id: string;
@@ -665,6 +666,26 @@ export interface OrganizationDomainDeletedEventResponse
   data: OrganizationDomainResponse;
 }
 
+export interface ApiKeyCreatedEvent extends EventBase {
+  event: 'api_key.created';
+  data: ApiKey;
+}
+
+export interface ApiKeyCreatedEventResponse extends EventResponseBase {
+  event: 'api_key.created';
+  data: SerializedApiKey;
+}
+
+export interface ApiKeyDeletedEvent extends EventBase {
+  event: 'api_key.deleted';
+  data: ApiKey;
+}
+
+export interface ApiKeyDeletedEventResponse extends EventResponseBase {
+  event: 'api_key.deleted';
+  data: SerializedApiKey;
+}
+
 export type Event =
   | AuthenticationEmailVerificationSucceededEvent
   | AuthenticationMfaSucceededEvent
@@ -721,7 +742,9 @@ export type Event =
   | OrganizationDomainVerificationFailedEvent
   | OrganizationDomainCreatedEvent
   | OrganizationDomainUpdatedEvent
-  | OrganizationDomainDeletedEvent;
+  | OrganizationDomainDeletedEvent
+  | ApiKeyCreatedEvent
+  | ApiKeyDeletedEvent;
 
 export type EventResponse =
   | AuthenticationEmailVerificationSucceededEventResponse
@@ -779,6 +802,8 @@ export type EventResponse =
   | OrganizationDomainVerificationFailedEventResponse
   | OrganizationDomainCreatedEventResponse
   | OrganizationDomainUpdatedEventResponse
-  | OrganizationDomainDeletedEventResponse;
+  | OrganizationDomainDeletedEventResponse
+  | ApiKeyCreatedEventResponse
+  | ApiKeyDeletedEventResponse;
 
 export type EventName = Event['event'];

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -22,6 +22,7 @@ import { deserializeRoleEvent } from '../../user-management/serializers/role.ser
 import { deserializeSession } from '../../user-management/serializers/session.serializer';
 import { Event, EventBase, EventResponse } from '../interfaces';
 import { deserializeAuthenticationRadarRiskDetectedEvent } from '../../user-management/serializers/authentication-radar-risk-event-serializer';
+import { deserializeApiKey } from '../../api-keys/serializers/api-key.serializer';
 
 export const deserializeEvent = (event: EventResponse): Event => {
   const eventBase: EventBase = {
@@ -189,6 +190,13 @@ export const deserializeEvent = (event: EventResponse): Event => {
         ...eventBase,
         event: event.event,
         data: deserializeOrganizationDomain(event.data),
+      };
+    case 'api_key.created':
+    case 'api_key.deleted':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeApiKey(event.data),
       };
   }
 };


### PR DESCRIPTION
## Description

Adds support for recently added api key events: `api_key.created` and `api_key.deleted`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
