### PR TITLE
fix: split ESM/CJS builds to fix Electron bundling issue

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,26 +1,38 @@
 import { defineConfig } from 'tsdown';
 
-export default defineConfig({
-  entry: [
-    'src/**/*.ts',
-    '!src/**/*.spec.ts',
-    '!src/**/*.test.ts',
-    '!src/**/fixtures/**',
-    '!src/**/*.d.ts',
-    '!src/**/test-utils.ts',
-  ],
-  format: ['esm', 'cjs'],
-  outDir: 'lib',
-  target: 'es2022',
-  sourcemap: true,
-  clean: true,
-  dts: true,
-  unbundle: true,
-  // bundle ESM-only deps for CJS compatibility
-  noExternal: ['iron-webcrypto', 'uint8array-extras'],
-  outExtensions({ format }) {
-    return {
-      js: format === 'cjs' ? '.cjs' : '.js',
-    };
+const sharedEntry = [
+  'src/**/*.ts',
+  '!src/**/*.spec.ts',
+  '!src/**/*.test.ts',
+  '!src/**/fixtures/**',
+  '!src/**/*.d.ts',
+  '!src/**/test-utils.ts',
+];
+
+export default defineConfig([
+  // ESM - unbundled, external deps (ESM consumers can import ESM deps directly)
+  {
+    entry: sharedEntry,
+    format: ['esm'],
+    outDir: 'lib',
+    target: 'es2022',
+    sourcemap: true,
+    clean: true,
+    dts: true,
+    unbundle: true,
+    outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
   },
-});
+  // CJS - bundled, inline ESM-only deps for compatibility
+  {
+    entry: sharedEntry,
+    format: ['cjs'],
+    outDir: 'lib',
+    target: 'es2022',
+    sourcemap: true,
+    // no clean - ESM build already cleaned
+    dts: true, // Generate .d.cts for CJS consumers
+    // no unbundle - allows proper inlining of ESM-only deps
+    noExternal: ['iron-webcrypto', 'uint8array-extras'],
+    outExtensions: () => ({ js: '.cjs', dts: '.d.cts' }),
+  },
+]);


### PR DESCRIPTION
## Summary
- Splits tsdown build config into separate ESM and CJS configurations
- ESM: unbundled with external deps (ESM consumers import ESM deps directly)
- CJS: bundled with `iron-webcrypto` and `uint8array-extras` inlined

## Problem
Previous single config with `noExternal` created `lib/node_modules/` structure that broke Electron asar packaging and pnpm symlink resolution.

## Why CJS inlining is required
`iron-webcrypto` and `uint8array-extras` are ESM-only packages—they don't ship CJS builds. CJS code can't `require()` ESM modules, so these deps must be inlined/bundled into the CJS output for compatibility.