### PR TITLE
Add custom_attributes field to OrganizationMembership

### DIFF
--- a/src/actions/actions.spec.ts
+++ b/src/actions/actions.spec.ts
@@ -155,7 +155,7 @@ describe('Actions', () => {
             slug: 'member',
           },
           status: 'active',
-          idpAttributes: {},
+          customAttributes: {},
           createdAt: '2024-10-22T17:12:50.746Z',
           updatedAt: '2024-10-22T17:12:50.746Z',
         },

--- a/src/actions/fixtures/authentication-action-context.json
+++ b/src/actions/fixtures/authentication-action-context.json
@@ -35,7 +35,7 @@
             "slug": "member"
         },
         "status": "active",
-        "idp_attributes": {},
+        "custom_attributes": {},
         "created_at": "2024-10-22T17:12:50.746Z",
         "updated_at": "2024-10-22T17:12:50.746Z"
     }

--- a/src/user-management/fixtures/deactivate-organization-membership.json
+++ b/src/user-management/fixtures/deactivate-organization-membership.json
@@ -7,7 +7,7 @@
   "role": {
     "slug": "member"
   },
-  "idp_attributes": {},
+  "custom_attributes": {},
   "created_at": "2023-07-18T02:07:19.911Z",
   "updated_at": "2023-07-18T02:07:19.911Z"
 }

--- a/src/user-management/fixtures/list-organization-memberships.json
+++ b/src/user-management/fixtures/list-organization-memberships.json
@@ -11,7 +11,7 @@
       "role": {
         "slug": "member"
       },
-      "idp_attributes": {},
+      "custom_attributes": {},
       "created_at": "2023-07-18T02:07:19.911Z",
       "updated_at": "2023-07-18T02:07:19.911Z"
     }

--- a/src/user-management/fixtures/organization-membership.json
+++ b/src/user-management/fixtures/organization-membership.json
@@ -7,7 +7,7 @@
   "role": {
     "slug": "member"
   },
-  "idp_attributes": {},
+  "custom_attributes": {},
   "created_at": "2023-07-18T02:07:19.911Z",
   "updated_at": "2023-07-18T02:07:19.911Z"
 }

--- a/src/user-management/interfaces/organization-membership.interface.ts
+++ b/src/user-management/interfaces/organization-membership.interface.ts
@@ -13,7 +13,7 @@ export interface OrganizationMembership {
   updatedAt: string;
   role: RoleResponse;
   roles?: RoleResponse[];
-  idpAttributes: Record<string, unknown>;
+  customAttributes: Record<string, unknown>;
 }
 
 export interface OrganizationMembershipResponse {
@@ -27,5 +27,5 @@ export interface OrganizationMembershipResponse {
   updated_at: string;
   role: RoleResponse;
   roles?: RoleResponse[];
-  idp_attributes: Record<string, unknown>;
+  custom_attributes: Record<string, unknown>;
 }

--- a/src/user-management/serializers/organization-membership.serializer.ts
+++ b/src/user-management/serializers/organization-membership.serializer.ts
@@ -16,5 +16,5 @@ export const deserializeOrganizationMembership = (
   updatedAt: organizationMembership.updated_at,
   role: organizationMembership.role,
   ...(organizationMembership.roles && { roles: organizationMembership.roles }),
-  idpAttributes: organizationMembership.idp_attributes,
+  customAttributes: organizationMembership.custom_attributes,
 });


### PR DESCRIPTION
## Summary

Adds `custom_attributes` field to `OrganizationMembership` model to expose custom attributes from identity providers.

## Changes

- Added `custom_attributes` field to OrganizationMembership type/model
- Field type: Record/Map/Dictionary of string keys to any values
- Always present, defaults to empty object `{}`
- Updated fixtures and tests

## API Field Details

The field will be present in:
- REST API responses
- Webhook events
- Events API responses

JSON field name: `custom_attributes` (snake_case)