### PR TITLE
fix: exclude organizationId from autoPagination params in listOrganizationFeatureFlags

### DIFF
--- a/src/organizations/organizations.ts
+++ b/src/organizations/organizations.ts
@@ -127,9 +127,7 @@ export class Organizations {
 
   async listOrganizationFeatureFlags(
     options: ListOrganizationFeatureFlagsOptions,
-  ): Promise<
-    AutoPaginatable<FeatureFlag, ListOrganizationFeatureFlagsOptions>
-  > {
+  ): Promise<AutoPaginatable<FeatureFlag>> {
     const { organizationId, ...paginationOptions } = options;
 
     return new AutoPaginatable(
@@ -146,7 +144,7 @@ export class Organizations {
           deserializeFeatureFlag,
           params,
         ),
-      options,
+      paginationOptions,
     );
   }
 


### PR DESCRIPTION
## Description

The organizationId was being passed to AutoPaginatable constructor which caused it to be included as a query parameter in subsequent pagination requests. The API rejects this because organizationId is already part of the URL path.

Fixes #1459
  
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
