### PR TITLE
Revert "Bump version to 8.2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.2.0",
+  "version": "8.1.0",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -45,7 +45,7 @@ import { ParseError } from './common/exceptions/parse-error';
 import { getEnv } from './common/utils/env';
 import { getRuntimeInfo } from './common/utils/runtime-info';
 
-const VERSION = '8.2.0';
+const VERSION = '8.1.0';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
 


### PR DESCRIPTION
Reverts workos/workos-node#1463

My intended changes were already released in v8.1 and this did not create a tag. It's safe to revert