### PR TITLE
Organization role and permission events support

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -34,7 +34,13 @@ import {
 import {
   RoleEvent,
   RoleEventResponse,
+  OrganizationRoleResponse,
 } from '../../roles/interfaces/role.interface';
+import { OrganizationRole } from '../../authorization/interfaces/organization-role.interface';
+import {
+  Permission,
+  PermissionResponse,
+} from '../../authorization/interfaces/permission.interface';
 import {
   OrganizationDomain,
   OrganizationDomainResponse,
@@ -532,6 +538,66 @@ export interface RoleUpdatedEventResponse extends EventResponseBase {
   data: RoleEventResponse;
 }
 
+export interface OrganizationRoleCreatedEvent extends EventBase {
+  event: 'organization_role.created';
+  data: OrganizationRole;
+}
+
+export interface OrganizationRoleCreatedEventResponse extends EventResponseBase {
+  event: 'organization_role.created';
+  data: OrganizationRoleResponse;
+}
+
+export interface OrganizationRoleUpdatedEvent extends EventBase {
+  event: 'organization_role.updated';
+  data: OrganizationRole;
+}
+
+export interface OrganizationRoleUpdatedEventResponse extends EventResponseBase {
+  event: 'organization_role.updated';
+  data: OrganizationRoleResponse;
+}
+
+export interface OrganizationRoleDeletedEvent extends EventBase {
+  event: 'organization_role.deleted';
+  data: OrganizationRole;
+}
+
+export interface OrganizationRoleDeletedEventResponse extends EventResponseBase {
+  event: 'organization_role.deleted';
+  data: OrganizationRoleResponse;
+}
+
+export interface PermissionCreatedEvent extends EventBase {
+  event: 'permission.created';
+  data: Permission;
+}
+
+export interface PermissionCreatedEventResponse extends EventResponseBase {
+  event: 'permission.created';
+  data: PermissionResponse;
+}
+
+export interface PermissionUpdatedEvent extends EventBase {
+  event: 'permission.updated';
+  data: Permission;
+}
+
+export interface PermissionUpdatedEventResponse extends EventResponseBase {
+  event: 'permission.updated';
+  data: PermissionResponse;
+}
+
+export interface PermissionDeletedEvent extends EventBase {
+  event: 'permission.deleted';
+  data: Permission;
+}
+
+export interface PermissionDeletedEventResponse extends EventResponseBase {
+  event: 'permission.deleted';
+  data: PermissionResponse;
+}
+
 export interface SessionCreatedEvent extends EventBase {
   event: 'session.created';
   data: Session;
@@ -666,6 +732,12 @@ export type Event =
   | RoleCreatedEvent
   | RoleDeletedEvent
   | RoleUpdatedEvent
+  | OrganizationRoleCreatedEvent
+  | OrganizationRoleUpdatedEvent
+  | OrganizationRoleDeletedEvent
+  | PermissionCreatedEvent
+  | PermissionUpdatedEvent
+  | PermissionDeletedEvent
   | SessionCreatedEvent
   | SessionRevokedEvent
   | OrganizationCreatedEvent
@@ -723,6 +795,12 @@ export type EventResponse =
   | RoleCreatedEventResponse
   | RoleDeletedEventResponse
   | RoleUpdatedEventResponse
+  | OrganizationRoleCreatedEventResponse
+  | OrganizationRoleUpdatedEventResponse
+  | OrganizationRoleDeletedEventResponse
+  | PermissionCreatedEventResponse
+  | PermissionUpdatedEventResponse
+  | PermissionDeletedEventResponse
   | SessionCreatedEventResponse
   | SessionRevokedEventResponse
   | OrganizationCreatedResponse

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -23,6 +23,8 @@ import { deserializeSession } from '../../user-management/serializers/session.se
 import { Event, EventBase, EventResponse } from '../interfaces';
 import { deserializeAuthenticationRadarRiskDetectedEvent } from '../../user-management/serializers/authentication-radar-risk-event-serializer';
 import { deserializeApiKey } from '../../api-keys/serializers/api-key.serializer';
+import { deserializeOrganizationRole } from '../../authorization/serializers/organization-role.serializer';
+import { deserializePermission } from '../../authorization/serializers/permission.serializer';
 
 export const deserializeEvent = (event: EventResponse): Event => {
   const eventBase: EventBase = {
@@ -163,6 +165,22 @@ export const deserializeEvent = (event: EventResponse): Event => {
         ...eventBase,
         event: event.event,
         data: deserializeRoleEvent(event.data),
+      };
+    case 'organization_role.created':
+    case 'organization_role.updated':
+    case 'organization_role.deleted':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeOrganizationRole(event.data),
+      };
+    case 'permission.created':
+    case 'permission.updated':
+    case 'permission.deleted':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializePermission(event.data),
       };
     case 'session.created':
     case 'session.revoked':


### PR DESCRIPTION
## Description

Events support for:
- `organization_role.created`
- `organization_role.updated`
- `organization_role.deleted`
- `permission.created`
- `permission.updated`
- `permission.deleted`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
