### PR TITLE
Rename api_key.deleted event type to api_key.revoked

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -678,13 +678,13 @@ export interface ApiKeyCreatedEventResponse extends EventResponseBase {
   data: SerializedApiKey;
 }
 
-export interface ApiKeyDeletedEvent extends EventBase {
-  event: 'api_key.deleted';
+export interface ApiKeyRevokedEvent extends EventBase {
+  event: 'api_key.revoked';
   data: ApiKey;
 }
 
-export interface ApiKeyDeletedEventResponse extends EventResponseBase {
-  event: 'api_key.deleted';
+export interface ApiKeyRevokedEventResponse extends EventResponseBase {
+  event: 'api_key.revoked';
   data: SerializedApiKey;
 }
 
@@ -749,7 +749,7 @@ export type Event =
   | OrganizationDomainUpdatedEvent
   | OrganizationDomainDeletedEvent
   | ApiKeyCreatedEvent
-  | ApiKeyDeletedEvent;
+  | ApiKeyRevokedEvent;
 
 export type EventResponse =
   | AuthenticationEmailVerificationSucceededEventResponse
@@ -812,6 +812,6 @@ export type EventResponse =
   | OrganizationDomainUpdatedEventResponse
   | OrganizationDomainDeletedEventResponse
   | ApiKeyCreatedEventResponse
-  | ApiKeyDeletedEventResponse;
+  | ApiKeyRevokedEventResponse;
 
 export type EventName = Event['event'];

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -208,7 +208,7 @@ export const deserializeEvent = (event: EventResponse): Event => {
         data: deserializeOrganizationDomain(event.data),
       };
     case 'api_key.created':
-    case 'api_key.deleted':
+    case 'api_key.revoked':
       return {
         ...eventBase,
         event: event.event,


### PR DESCRIPTION
## Description

The SDK currently defines the API key event type as `api_key.deleted`, but the actual WorkOS API expects `api_key.revoked`. This mismatch causes a 400 error when passing `api_key.deleted` to `listEvents()`:

```
GenericServerException: Invalid name parameter, received: 'api_key.deleted'. You must pass in valid event names
```

The [WorkOS Events documentation](https://workos.com/docs/events) lists this event as **"API key revoked event"** with the type `api_key.revoked`.

### Changes

**`src/common/interfaces/event.interface.ts`**
- `ApiKeyDeletedEvent` → `ApiKeyRevokedEvent`
- `ApiKeyDeletedEventResponse` → `ApiKeyRevokedEventResponse`
- Event literal `'api_key.deleted'` → `'api_key.revoked'`
- Updated `Event` and `EventResponse` union types

**`src/common/serializers/event.serializer.ts`**
- Deserialisation case `'api_key.deleted'` → `'api_key.revoked'`

This is consistent with other revocable resources in the SDK that already use `revoked` (e.g. `invitation.revoked`, `session.revoked`).

Closes #1475

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

- [ ] Yes

The [Events documentation](https://workos.com/docs/events) already lists the correct event name `api_key.revoked`. No documentation changes are required.