### PR TITLE
fix: preserve verification_prefix in organization domain deserialization

### DIFF
--- a/src/organization-domains/interfaces/organization-domain.interface.ts
+++ b/src/organization-domains/interfaces/organization-domain.interface.ts
@@ -17,6 +17,7 @@ export interface OrganizationDomain {
   state: OrganizationDomainState;
   verificationToken?: string;
   verificationStrategy: OrganizationDomainVerificationStrategy;
+  verificationPrefix?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -29,6 +30,7 @@ export interface OrganizationDomainResponse {
   state: OrganizationDomainState;
   verification_token?: string;
   verification_strategy: OrganizationDomainVerificationStrategy;
+  verification_prefix?: string;
   created_at: string;
   updated_at: string;
 }

--- a/src/organization-domains/serializers/organization-domain.serializer.ts
+++ b/src/organization-domains/serializers/organization-domain.serializer.ts
@@ -12,6 +12,9 @@ export const deserializeOrganizationDomain = (
     verificationToken: organizationDomain.verification_token,
   }),
   verificationStrategy: organizationDomain.verification_strategy,
+  ...(organizationDomain.verification_prefix !== undefined && {
+    verificationPrefix: organizationDomain.verification_prefix,
+  }),
   createdAt: organizationDomain.created_at,
   updatedAt: organizationDomain.updated_at,
 });


### PR DESCRIPTION
## Summary

- Adds `verification_prefix` as an optional field to `OrganizationDomain` and `OrganizationDomainResponse` interfaces
- Maps `verification_prefix` → `verificationPrefix` in `deserializeOrganizationDomain`

The [Events API documentation for `organization_domain.*` events](https://workos.com/docs/events/organization-domain) includes a `verification_prefix` field in the event data, but the deserialiser was silently dropping it.

## Test plan

- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All existing tests pass (`npm test`)
- [x] Linter and formatter pass