### PR TITLE
fix: update renovate rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,9 @@
     "config:base"
   ],
   "schedule": [
-    "every 2 weeks on Tuesday"
+    "on the third tuesday of the month before 12pm"
   ],
+  "timezone": "UTC",
   "rebaseWhen": "conflicted",
   "packageRules": [
     {


### PR DESCRIPTION
## Description

There's been some feedback that the renovate notifications are super noisy and can clog up GitHub. This PR is an attempt to trim down the noise by setting a few options:

- `schedule: ["every 3rd Tuesday"]`: Renovate will only create/update branches once a month, on the 3rd Tuesday
- `rebaseWhen: "conflicted"`: only rebases when there are actual conflicts (not just when behind the base branch)
- Major vs minor/patch vs digest separation — three packageRules entries:
  - Minor/patch are grouped into a single PR  and automerged
  - Major and digest updates each get their own individual PRs with automerge disabled

The major v major/minor thing is so that Renovate doesn't open a PR per change—which, given the new cron scheduling, is likely to have some drift between packages—but rather, groups the PRs together into one. 

`digest` is currently unused in this PR, but soon I'll open a PR to pin the GitHub Actions to a specific SHA, to tighten any potential security vulns that come up. These, too, are grouped into their own PRs, because we can't tell if the SHA updates will introduce breaking or non-breaking changes.

I removed `pin` because it does not seem to me that we would ever want a dependency frozen at a specific version, never to be updated.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
