### PR TITLE
fix: export CookieSession from package root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export * from './portal/interfaces';
 export * from './roles/interfaces';
 export * from './sso/interfaces';
 export * from './user-management/interfaces';
+export { CookieSession } from './user-management/session';
 export * from './vault/interfaces';
 export * from './pkce/pkce';
 export {


### PR DESCRIPTION
CookieSession is the return type of loadSealedSession() and is correctly declared in lib/user-management/session.d.ts, but was never re-exported from the root barrel (src/index.ts). This meant TypeScript users couldn't import the type by name from @workos-inc/node.


## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
