### PR TITLE
feat: add missing auth methods

### DIFF
--- a/src/user-management/interfaces/authentication-response.interface.ts
+++ b/src/user-management/interfaces/authentication-response.interface.ts
@@ -8,15 +8,22 @@ type AuthenticationMethod =
   | 'Passkey'
   | 'AppleOAuth'
   | 'BitbucketOAuth'
+  | 'DiscordOAuth'
   | 'GitHubOAuth'
   | 'GitLabOAuth'
   | 'GoogleOAuth'
+  | 'IntuitOAuth'
   | 'LinkedInOAuth'
   | 'MicrosoftOAuth'
   | 'SalesforceOAuth'
+  | 'SlackOAuth'
+  | 'VercelMarketplaceOAuth'
   | 'VercelOAuth'
+  | 'XeroOAuth'
   | 'MagicAuth'
   | 'CrossAppAuth'
+  | 'ExternalAuth'
+  | 'MigratedSession'
   | 'Impersonation';
 
 export interface AuthenticationResponse {

--- a/src/user-management/interfaces/session.interface.ts
+++ b/src/user-management/interfaces/session.interface.ts
@@ -1,6 +1,7 @@
 import { Impersonator } from './impersonator.interface';
 
 export type AuthMethod =
+  | 'cross_app_auth'
   | 'external_auth'
   | 'impersonation'
   | 'magic_code'


### PR DESCRIPTION
## Description

Some of the authentication methods that the API supports were not included in the types here; adding them

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
