### PR TITLE
refactor: Add `widgets:audit-log-streaming:manage` to WidgetScope

### DIFF
--- a/src/widgets/interfaces/get-token.ts
+++ b/src/widgets/interfaces/get-token.ts
@@ -3,7 +3,8 @@ export type WidgetScope =
   | 'widgets:sso:manage'
   | 'widgets:domain-verification:manage'
   | 'widgets:dsync:manage'
-  | 'widgets:api-keys:manage';
+  | 'widgets:api-keys:manage'
+  | 'widgets:audit-log-streaming:manage';
 export interface GetTokenOptions {
   organizationId: string;
   userId?: string;


### PR DESCRIPTION
## Summary
- Adds `widgets:audit-log-streaming:manage` to the `WidgetScope` union type to support the new audit log streaming widget

Fixes DAAP-2219

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes (pre-existing unrelated error in roles serializer)
- [x] Widget tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)