### PR TITLE
fix(events): handle domain verification failed

### DIFF
--- a/src/common/interfaces/event.interface.ts
+++ b/src/common/interfaces/event.interface.ts
@@ -44,6 +44,8 @@ import {
 import {
   OrganizationDomain,
   OrganizationDomainResponse,
+  OrganizationDomainVerificationFailed,
+  OrganizationDomainVerificationFailedResponse,
 } from '../../organization-domains/interfaces';
 import {
   AuthenticationRadarRiskDetectedEventData,
@@ -656,12 +658,12 @@ export interface OrganizationDomainVerifiedEventResponse extends EventResponseBa
 
 export interface OrganizationDomainVerificationFailedEvent extends EventBase {
   event: 'organization_domain.verification_failed';
-  data: OrganizationDomain;
+  data: OrganizationDomainVerificationFailed;
 }
 
 export interface OrganizationDomainVerificationFailedEventResponse extends EventResponseBase {
   event: 'organization_domain.verification_failed';
-  data: OrganizationDomainResponse;
+  data: OrganizationDomainVerificationFailedResponse;
 }
 
 export interface OrganizationDomainCreatedEvent extends EventBase {

--- a/src/common/serializers/event.serializer.ts
+++ b/src/common/serializers/event.serializer.ts
@@ -38,6 +38,7 @@ import {
   deserializeVaultDekDecryptedEvent,
   deserializeVaultByokKeyVerificationCompletedEvent,
 } from '../../vault/serializers/vault-event.serializer';
+import { deserializeOrganizationDomainVerificationFailed } from '../../organization-domains/serializers/organization-domain-verification-failed.serializer';
 
 export const deserializeEvent = (event: EventResponse): Event => {
   const eventBase: EventBase = {
@@ -210,8 +211,13 @@ export const deserializeEvent = (event: EventResponse): Event => {
         event: event.event,
         data: deserializeOrganization(event.data),
       };
-    case 'organization_domain.verified':
     case 'organization_domain.verification_failed':
+      return {
+        ...eventBase,
+        event: event.event,
+        data: deserializeOrganizationDomainVerificationFailed(event.data),
+      };
+    case 'organization_domain.verified':
     case 'organization_domain.created':
     case 'organization_domain.updated':
     case 'organization_domain.deleted':

--- a/src/events/events.spec.ts
+++ b/src/events/events.spec.ts
@@ -8,6 +8,10 @@ import {
   FlagCreatedEvent,
   FlagCreatedEventResponse,
   ListResponse,
+  OrganizationDomainCreatedEvent,
+  OrganizationDomainCreatedEventResponse,
+  OrganizationDomainVerificationFailedEvent,
+  OrganizationDomainVerificationFailedEventResponse,
   VaultDataCreatedEvent,
   VaultDataCreatedEventResponse,
   VaultDataUpdatedEvent,
@@ -31,6 +35,10 @@ import {
 } from '../common/interfaces';
 import { WorkOS } from '../workos';
 import { ConnectionType } from '../sso/interfaces';
+import {
+  OrganizationDomainState,
+  OrganizationDomainVerificationStrategy,
+} from '../organization-domains/interfaces';
 
 describe('Event', () => {
   beforeEach(() => fetch.resetMocks());
@@ -733,6 +741,121 @@ describe('Event', () => {
             data: [directoryUserUpdated],
             listMetadata: {},
           });
+        });
+      });
+    });
+
+    describe('organization domain events', () => {
+      it('deserializes organization_domain.created events', async () => {
+        const response: OrganizationDomainCreatedEventResponse = {
+          event: 'organization_domain.created',
+          id: 'event_01DOMAINCREATED001',
+          data: {
+            id: 'org_domain_01TESTDOMAIN',
+            state: OrganizationDomainState.Pending,
+            domain: 'example.com',
+            object: 'organization_domain',
+            created_at: '2026-04-06T06:24:06.749Z',
+            updated_at: '2026-04-06T06:24:06.749Z',
+            organization_id: 'org_01TESTORGANIZATION',
+            verification_strategy:
+              OrganizationDomainVerificationStrategy.Manual,
+          },
+          context: {},
+          created_at: '2026-04-06T06:24:06.776Z',
+        };
+
+        const expected: OrganizationDomainCreatedEvent = {
+          event: 'organization_domain.created',
+          id: 'event_01DOMAINCREATED001',
+          data: {
+            id: 'org_domain_01TESTDOMAIN',
+            state: OrganizationDomainState.Pending,
+            domain: 'example.com',
+            object: 'organization_domain',
+            createdAt: '2026-04-06T06:24:06.749Z',
+            updatedAt: '2026-04-06T06:24:06.749Z',
+            organizationId: 'org_01TESTORGANIZATION',
+            verificationStrategy: OrganizationDomainVerificationStrategy.Manual,
+          },
+          context: {},
+          createdAt: '2026-04-06T06:24:06.776Z',
+        };
+
+        fetchOnce({
+          object: 'list',
+          data: [response],
+          list_metadata: {},
+        });
+
+        const list = await workos.events.listEvents({
+          events: ['organization_domain.created'],
+        });
+
+        expect(list).toEqual({
+          object: 'list',
+          data: [expected],
+          listMetadata: {},
+        });
+      });
+
+      it('deserializes organization_domain.verification_failed events', async () => {
+        const response: OrganizationDomainVerificationFailedEventResponse = {
+          event: 'organization_domain.verification_failed',
+          id: 'event_01DOMAIN0002',
+          data: {
+            reason: 'domain_verification_period_expired',
+            organization_domain: {
+              id: 'org_domain_0TESTDOMAIN',
+              state: OrganizationDomainState.Failed,
+              domain: 'example.com',
+              object: 'organization_domain',
+              created_at: '2026-03-07T02:24:56.621Z',
+              updated_at: '2026-04-06T02:25:00.494Z',
+              organization_id: 'org_01TESTORGANIZATION',
+              verification_token: 'FAKETOKEN',
+              verification_strategy: OrganizationDomainVerificationStrategy.Dns,
+            },
+          },
+          context: {},
+          created_at: '2026-04-06T02:26:05.430Z',
+        };
+
+        const expected: OrganizationDomainVerificationFailedEvent = {
+          event: 'organization_domain.verification_failed',
+          id: 'event_01DOMAIN0002',
+          data: {
+            reason: 'domain_verification_period_expired',
+            organizationDomain: {
+              id: 'org_domain_0TESTDOMAIN',
+              state: OrganizationDomainState.Failed,
+              domain: 'example.com',
+              object: 'organization_domain',
+              createdAt: '2026-03-07T02:24:56.621Z',
+              updatedAt: '2026-04-06T02:25:00.494Z',
+              organizationId: 'org_01TESTORGANIZATION',
+              verificationToken: 'FAKETOKEN',
+              verificationStrategy: OrganizationDomainVerificationStrategy.Dns,
+            },
+          },
+          context: {},
+          createdAt: '2026-04-06T02:26:05.430Z',
+        };
+
+        fetchOnce({
+          object: 'list',
+          data: [response],
+          list_metadata: {},
+        });
+
+        const list = await workos.events.listEvents({
+          events: ['organization_domain.verification_failed'],
+        });
+
+        expect(list).toEqual({
+          object: 'list',
+          data: [expected],
+          listMetadata: {},
         });
       });
     });

--- a/src/organization-domains/interfaces/index.ts
+++ b/src/organization-domains/interfaces/index.ts
@@ -1,2 +1,3 @@
 export * from './create-organization-domain-options.interface';
 export * from './organization-domain.interface';
+export * from './organization-domain-verification-failed.interface';

--- a/src/organization-domains/interfaces/organization-domain-verification-failed.interface.ts
+++ b/src/organization-domains/interfaces/organization-domain-verification-failed.interface.ts
@@ -1,0 +1,14 @@
+import {
+  OrganizationDomain,
+  OrganizationDomainResponse,
+} from './organization-domain.interface';
+
+export interface OrganizationDomainVerificationFailed {
+  reason: string;
+  organizationDomain: OrganizationDomain;
+}
+
+export interface OrganizationDomainVerificationFailedResponse {
+  reason: string;
+  organization_domain: OrganizationDomainResponse;
+}

--- a/src/organization-domains/serializers/organization-domain-verification-failed.serializer.ts
+++ b/src/organization-domains/serializers/organization-domain-verification-failed.serializer.ts
@@ -1,0 +1,26 @@
+import {
+  OrganizationDomainVerificationFailed,
+  OrganizationDomainVerificationFailedResponse,
+} from '../interfaces';
+import {
+  deserializeOrganizationDomain,
+  serializeOrganizationDomain,
+} from './organization-domain.serializer';
+
+export const deserializeOrganizationDomainVerificationFailed = (
+  organizationDomainVerificationFailed: OrganizationDomainVerificationFailedResponse,
+): OrganizationDomainVerificationFailed => ({
+  reason: organizationDomainVerificationFailed.reason,
+  organizationDomain: deserializeOrganizationDomain(
+    organizationDomainVerificationFailed.organization_domain,
+  ),
+});
+
+export const serializeOrganizationDomainVerificationFailed = (
+  organizationDomainVerificationFailed: OrganizationDomainVerificationFailed,
+): OrganizationDomainVerificationFailedResponse => ({
+  reason: organizationDomainVerificationFailed.reason,
+  organization_domain: serializeOrganizationDomain(
+    organizationDomainVerificationFailed.organizationDomain,
+  ),
+});


### PR DESCRIPTION
## Description
The domain verfication failed events have a slightly different schema to other organization domain events. This was causing the data to be parsed incorrectly in the list events api resulting in empty `data` properties.

I've added the required interfaces, serializers, and deserializers to capture the difference and parse the events successfully. I've also added some unit tests for the serialization.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
