### PR TITLE
feat: Add resource_type_slug to createOrganizationRole to create resource-scoped custom roles

### DIFF
--- a/src/authorization/authorization.spec.ts
+++ b/src/authorization/authorization.spec.ts
@@ -291,6 +291,48 @@ describe('Authorization', () => {
         type: 'OrganizationRole',
       });
     });
+
+    it('creates an organization role with resourceTypeSlug', async () => {
+      fetchOnce(organizationRoleFixture, { status: 201 });
+
+      const role = await workos.authorization.createOrganizationRole(
+        testOrgId,
+        {
+          slug: 'org-admin',
+          name: 'Org Admin',
+          resourceTypeSlug: 'organization',
+        },
+      );
+
+      expect(fetchBody()).toEqual({
+        slug: 'org-admin',
+        name: 'Org Admin',
+        resource_type_slug: 'organization',
+      });
+      expect(role.resourceTypeSlug).toEqual('organization');
+    });
+
+    it('creates an organization role without slug', async () => {
+      fetchOnce(organizationRoleFixture, { status: 201 });
+
+      const role = await workos.authorization.createOrganizationRole(
+        testOrgId,
+        {
+          name: 'Org Admin',
+          description: 'Organization administrator',
+        },
+      );
+
+      expect(fetchBody()).toEqual({
+        name: 'Org Admin',
+        description: 'Organization administrator',
+      });
+      expect(role).toMatchObject({
+        object: 'role',
+        name: 'Org Admin',
+        type: 'OrganizationRole',
+      });
+    });
   });
 
   describe('listOrganizationRoles', () => {

--- a/src/authorization/interfaces/create-organization-role-options.interface.ts
+++ b/src/authorization/interfaces/create-organization-role-options.interface.ts
@@ -1,11 +1,13 @@
 export interface CreateOrganizationRoleOptions {
-  slug: string;
+  slug?: string;
   name: string;
   description?: string;
+  resourceTypeSlug?: string;
 }
 
 export interface SerializedCreateOrganizationRoleOptions {
-  slug: string;
+  slug?: string;
   name: string;
   description?: string;
+  resource_type_slug?: string;
 }

--- a/src/authorization/serializers/create-organization-role-options.serializer.ts
+++ b/src/authorization/serializers/create-organization-role-options.serializer.ts
@@ -9,4 +9,5 @@ export const serializeCreateOrganizationRoleOptions = (
   slug: options.slug,
   name: options.name,
   description: options.description,
+  resource_type_slug: options.resourceTypeSlug,
 });


### PR DESCRIPTION
Also makes permission slug optional. If omitted, the service will create auto-generated slugs