### PR TITLE
fix: Export `ConflictException` and add `code`

### DIFF
--- a/src/common/exceptions/conflict.exception.ts
+++ b/src/common/exceptions/conflict.exception.ts
@@ -4,15 +4,18 @@ export class ConflictException extends Error implements RequestException {
   readonly status = 409;
   readonly name = 'ConflictException';
   readonly requestID: string;
+  readonly code?: string;
 
   constructor({
     error,
     message,
     requestID,
+    code,
   }: {
     error?: string;
     message?: string;
     requestID: string;
+    code?: string;
   }) {
     super();
 
@@ -25,5 +28,7 @@ export class ConflictException extends Error implements RequestException {
     } else {
       this.message = `An conflict has occurred on the server.`;
     }
+
+    this.code = code;
   }
 }

--- a/src/common/exceptions/conflict.exception.ts
+++ b/src/common/exceptions/conflict.exception.ts
@@ -26,7 +26,7 @@ export class ConflictException extends Error implements RequestException {
     } else if (error) {
       this.message = `Error: ${error}`;
     } else {
-      this.message = `An conflict has occurred on the server.`;
+      this.message = `A conflict has occurred on the server.`;
     }
 
     this.code = code;

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -2,6 +2,7 @@ export * from './api-key-required.exception';
 export * from './authentication.exception';
 export * from './generic-server.exception';
 export * from './bad-request.exception';
+export * from './conflict.exception';
 export * from './no-api-key-provided.exception';
 export * from './not-found.exception';
 export * from './oauth.exception';

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -454,7 +454,7 @@ export class WorkOS {
           throw new UnauthorizedException(requestID);
         }
         case 409: {
-          throw new ConflictException({ requestID, message, error });
+          throw new ConflictException({ requestID, message, error, code });
         }
         case 422: {
           throw new UnprocessableEntityException({


### PR DESCRIPTION
## Description

Some operations like `workos.authorization.deleteOrganizationRole` will `throw` a `ConflictException` that needs to be handled appropriately (e.g. to customize the error message before showing it to users).

However, `ConflictException` isn't current exported so it can't be used to perform type-safe error handling (e.g. `error instanceof ConflictException`). It also doesn't pass along the `code` property which is needed to differentiate error types (e.g. https://workos.com/docs/reference/roles/custom-role#delete-a-custom-role).

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default wording for conflict errors to fix a typo in the message.
  * Conflict errors may now include an optional error code in error payloads.

* **Chores**
  * Made the conflict error type available via the public exception exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->