### PR TITLE
fix: Normalize GithubOAuth to GitHubOAuth in identity deserialization

### DIFF
--- a/docs/V9_MIGRATION_GUIDE.md
+++ b/docs/V9_MIGRATION_GUIDE.md
@@ -363,3 +363,31 @@ This is intended to make strict TypeScript error handling easier, especially if 
 The v9 update also tightens webhook/event deserialization behavior for unknown event types.
 
 If your integration assumed unknown event types would be ignored or treated loosely, re-test webhook handling on the latest v9 release.
+
+### User Management
+
+#### `getUserIdentities` now normalizes `GithubOAuth` to `GitHubOAuth`
+
+The WorkOS API returns `GithubOAuth` (lowercase 'h') as the provider in identity responses, but `getAuthorizationUrl` expects `GitHubOAuth` (uppercase 'H'). The SDK now normalizes the casing during deserialization so that identity provider values can be passed directly to `getAuthorizationUrl`.
+
+If your code was comparing against the raw API value `'GithubOAuth'`, update it to `'GitHubOAuth'`:
+
+**Before (v8):**
+
+```typescript
+const identities = await workos.userManagement.getUserIdentities(userId);
+const github = identities.find((i) => i.provider === 'GithubOAuth');
+```
+
+**After (v9):**
+
+```typescript
+const identities = await workos.userManagement.getUserIdentities(userId);
+const github = identities.find((i) => i.provider === 'GitHubOAuth');
+
+// The provider value can now be passed directly to getAuthorizationUrl
+const url = workos.userManagement.getAuthorizationUrl({
+  provider: github.provider,
+  redirectUri: 'https://example.com/callback',
+});
+```

--- a/src/user-management/interfaces/identity-response.interface.ts
+++ b/src/user-management/interfaces/identity-response.interface.ts
@@ -1,0 +1,13 @@
+interface RawIdentityResponse {
+  idp_id: string;
+  type: 'OAuth';
+  provider:
+    | 'AppleOAuth'
+    | 'GithubOAuth'
+    | 'GitHubOAuth'
+    | 'GoogleOAuth'
+    | 'MicrosoftOAuth'
+    | 'SalesforceOAuth';
+}
+
+export type { RawIdentityResponse };

--- a/src/user-management/interfaces/identity.interface.ts
+++ b/src/user-management/interfaces/identity.interface.ts
@@ -14,8 +14,9 @@ export interface IdentityResponse {
   type: 'OAuth';
   provider:
     | 'AppleOAuth'
-    | 'GoogleOAuth'
+    | 'GithubOAuth'
     | 'GitHubOAuth'
+    | 'GoogleOAuth'
     | 'MicrosoftOAuth'
     | 'SalesforceOAuth';
 }

--- a/src/user-management/interfaces/identity.interface.ts
+++ b/src/user-management/interfaces/identity.interface.ts
@@ -8,15 +8,3 @@ export interface Identity {
     | 'MicrosoftOAuth'
     | 'SalesforceOAuth';
 }
-
-export interface IdentityResponse {
-  idp_id: string;
-  type: 'OAuth';
-  provider:
-    | 'AppleOAuth'
-    | 'GithubOAuth'
-    | 'GitHubOAuth'
-    | 'GoogleOAuth'
-    | 'MicrosoftOAuth'
-    | 'SalesforceOAuth';
-}

--- a/src/user-management/serializers/identity.serializer.spec.ts
+++ b/src/user-management/serializers/identity.serializer.spec.ts
@@ -1,0 +1,25 @@
+import { deserializeIdentities } from './identity.serializer';
+
+describe('deserializeIdentities', () => {
+  it('normalizes GithubOAuth to GitHubOAuth', () => {
+    const result = deserializeIdentities([
+      { idp_id: '123', type: 'OAuth', provider: 'GithubOAuth' },
+    ]);
+
+    expect(result).toEqual([
+      { idpId: '123', type: 'OAuth', provider: 'GitHubOAuth' },
+    ]);
+  });
+
+  it('leaves other providers unchanged', () => {
+    const result = deserializeIdentities([
+      { idp_id: '456', type: 'OAuth', provider: 'GoogleOAuth' },
+      { idp_id: '789', type: 'OAuth', provider: 'AppleOAuth' },
+    ]);
+
+    expect(result).toEqual([
+      { idpId: '456', type: 'OAuth', provider: 'GoogleOAuth' },
+      { idpId: '789', type: 'OAuth', provider: 'AppleOAuth' },
+    ]);
+  });
+});

--- a/src/user-management/serializers/identity.serializer.ts
+++ b/src/user-management/serializers/identity.serializer.ts
@@ -1,10 +1,11 @@
-import { Identity, IdentityResponse } from '../interfaces/identity.interface';
+import { Identity } from '../interfaces/identity.interface';
+import { RawIdentityResponse } from '../interfaces/identity-response.interface';
 
 // The API returns 'GithubOAuth' but getAuthorizationUrl expects 'GitHubOAuth'.
 // Normalize here so callers can pass identity.provider directly.
 // See: https://github.com/workos/workos-node/issues/1227
 const normalizeProvider = (
-  provider: IdentityResponse['provider'],
+  provider: RawIdentityResponse['provider'],
 ): Identity['provider'] => {
   if (provider === 'GithubOAuth') {
     return 'GitHubOAuth';
@@ -13,7 +14,7 @@ const normalizeProvider = (
 };
 
 export const deserializeIdentities = (
-  identities: IdentityResponse[],
+  identities: RawIdentityResponse[],
 ): Identity[] => {
   return identities.map((identity) => {
     return {

--- a/src/user-management/serializers/identity.serializer.ts
+++ b/src/user-management/serializers/identity.serializer.ts
@@ -1,5 +1,17 @@
 import { Identity, IdentityResponse } from '../interfaces/identity.interface';
 
+// The API returns 'GithubOAuth' but getAuthorizationUrl expects 'GitHubOAuth'.
+// Normalize here so callers can pass identity.provider directly.
+// See: https://github.com/workos/workos-node/issues/1227
+const normalizeProvider = (
+  provider: IdentityResponse['provider'],
+): Identity['provider'] => {
+  if (provider === 'GithubOAuth') {
+    return 'GitHubOAuth';
+  }
+  return provider;
+};
+
 export const deserializeIdentities = (
   identities: IdentityResponse[],
 ): Identity[] => {
@@ -7,7 +19,7 @@ export const deserializeIdentities = (
     return {
       idpId: identity.idp_id,
       type: identity.type,
-      provider: identity.provider,
+      provider: normalizeProvider(identity.provider),
     };
   });
 };

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -1745,8 +1745,7 @@ describe('UserManagement', () => {
     it('normalizes GithubOAuth to GitHubOAuth so it can be passed to getAuthorizationUrl', async () => {
       fetchOnce(identityFixture);
 
-      const identities =
-        await workos.userManagement.getUserIdentities(userId);
+      const identities = await workos.userManagement.getUserIdentities(userId);
 
       const githubIdentity = identities.find(
         (i) => i.provider === 'GitHubOAuth',

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -1732,7 +1732,7 @@ describe('UserManagement', () => {
         {
           idpId: '108872335',
           type: 'OAuth',
-          provider: 'GithubOAuth',
+          provider: 'GitHubOAuth',
         },
         {
           idpId: '111966195055680542408',
@@ -1740,6 +1740,25 @@ describe('UserManagement', () => {
           provider: 'GoogleOAuth',
         },
       ]);
+    });
+
+    it('normalizes GithubOAuth to GitHubOAuth so it can be passed to getAuthorizationUrl', async () => {
+      fetchOnce(identityFixture);
+
+      const identities =
+        await workos.userManagement.getUserIdentities(userId);
+
+      const githubIdentity = identities.find(
+        (i) => i.provider === 'GitHubOAuth',
+      );
+      expect(githubIdentity).toBeDefined();
+
+      const url = workos.userManagement.getAuthorizationUrl({
+        provider: githubIdentity!.provider,
+        redirectUri: 'https://example.com/callback',
+      });
+
+      expect(url).toContain('provider=GitHubOAuth');
     });
   });
 

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -73,7 +73,8 @@ import {
   CreateOrganizationMembershipOptions,
   SerializedCreateOrganizationMembershipOptions,
 } from './interfaces/create-organization-membership-options.interface';
-import { Identity, IdentityResponse } from './interfaces/identity.interface';
+import { Identity } from './interfaces/identity.interface';
+import { RawIdentityResponse } from './interfaces/identity-response.interface';
 import {
   Invitation,
   InvitationResponse,
@@ -812,7 +813,7 @@ export class UserManagement {
       throw new TypeError(`Incomplete arguments. Need to specify 'userId'.`);
     }
 
-    const { data } = await this.workos.get<IdentityResponse[]>(
+    const { data } = await this.workos.get<RawIdentityResponse[]>(
       `/user_management/users/${userId}/identities`,
     );
 


### PR DESCRIPTION
## Summary
- The API returns `GithubOAuth` from `getUserIdentities` but `getAuthorizationUrl` expects `GitHubOAuth` — normalizes the casing during deserialization so the value can be passed directly between the two
- Adds `IdentityResponse` type coverage for the raw API value (`GithubOAuth`)
- Adds serializer unit test and integration-style test verifying the full workflow (get identity → pass provider to `getAuthorizationUrl`)
- Documents the behavior change in the V9 migration guide

Closes #1227

## Test plan
- [x] Serializer unit test: `GithubOAuth` → `GitHubOAuth`, other providers unchanged
- [x] Integration test: identity provider value flows through to `getAuthorizationUrl` URL
- [x] Existing `getUserIdentities` test updated to expect normalized value

🤖 Generated with [Claude Code](https://claude.com/claude-code)