### PR TITLE
ci: Add workflow to bump @workos-inc/node on major release

### DIFF
--- a/.github/workflows/workos-node-dep-bump.yml
+++ b/.github/workflows/workos-node-dep-bump.yml
@@ -184,25 +184,35 @@ jobs:
               pnpm install --lockfile-only
             elif [ -f "package-lock.json" ]; then
               npm install --package-lock-only
-            elif [ -f "yarn.lock" ]; then
-              yarn install --mode update-lockfile
             fi
 
-            git add package.json package-lock.json yarn.lock pnpm-lock.yaml 2>/dev/null || true
-            git commit -m "chore: bump @workos-inc/node to ^${NEW_MAJOR}.0.0"
-            git push origin "$BRANCH"
+            git add package.json package-lock.json pnpm-lock.yaml 2>/dev/null || true
+            git commit -m "chore!: bump @workos-inc/node to ^${NEW_MAJOR}.0.0"
 
-            DEFAULT_BRANCH=$(gh repo view "$REPO" \
-              --json defaultBranchRef \
-              --jq '.defaultBranchRef.name')
+            # Push idempotently — force-with-lease if branch exists from a prior run
+            if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+              echo "   Branch $BRANCH already exists — updating"
+              git push --force-with-lease origin "$BRANCH"
+            else
+              git push origin "$BRANCH"
+            fi
 
-            gh pr create \
-              --repo "$REPO" \
-              --base "$DEFAULT_BRANCH" \
-              --head "$BRANCH" \
-              --title "chore: bump @workos-inc/node to ^${NEW_MAJOR}.0.0" \
-              --body "Bumps \`@workos-inc/node\` from \`${CURRENT}\` to \`${NEW_CONSTRAINT}\` following the [v${NEW_MAJOR}.0.0 release](https://github.com/workos/workos-node/releases/tag/${RELEASE_TAG})." \
-              || echo "   PR may already exist — skipping"
+            # Only create PR if one doesn't already exist for this branch
+            EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --json number --jq '.[0].number')
+            if [ -n "$EXISTING_PR" ]; then
+              echo "   PR #$EXISTING_PR already exists — skipping"
+            else
+              DEFAULT_BRANCH=$(gh repo view "$REPO" \
+                --json defaultBranchRef \
+                --jq '.defaultBranchRef.name')
+
+              gh pr create \
+                --repo "$REPO" \
+                --base "$DEFAULT_BRANCH" \
+                --head "$BRANCH" \
+                --title "chore!: bump @workos-inc/node to ^${NEW_MAJOR}.0.0" \
+                --body "Bumps \`@workos-inc/node\` from \`${CURRENT}\` to \`${NEW_CONSTRAINT}\` following the [v${NEW_MAJOR}.0.0 release](https://github.com/workos/workos-node/releases/tag/${RELEASE_TAG})."
+            fi
 
             cd /tmp && rm -rf "$WORK_DIR"
             echo "   Done ✓"

--- a/.github/workflows/workos-node-dep-bump.yml
+++ b/.github/workflows/workos-node-dep-bump.yml
@@ -168,53 +168,56 @@ jobs:
             rm -rf "$WORK_DIR"
             gh repo clone "$REPO" "$WORK_DIR" || { echo "   Clone failed — skipping"; continue; }
 
-            cd "$WORK_DIR" || { echo "   cd failed — skipping"; continue; }
-            git checkout -b "$BRANCH"
+            # Subshell isolates errexit so one repo failure doesn't abort the loop
+            (
+              cd "$WORK_DIR"
+              git checkout -b "$BRANCH"
 
-            # sed preserves exact file formatting; | delimiter avoids conflicts with /
-            sed -i "s|\"@workos-inc/node\": \"${CURRENT}\"|\"@workos-inc/node\": \"${NEW_CONSTRAINT}\"|g" \
-              package.json
+              # sed preserves exact file formatting; | delimiter avoids conflicts with /
+              sed -i "s|\"@workos-inc/node\": \"${CURRENT}\"|\"@workos-inc/node\": \"${NEW_CONSTRAINT}\"|g" \
+                package.json
 
-            git config user.email "workos-sdk-bot[bot]@users.noreply.github.com"
-            git config user.name "workos-sdk-bot[bot]"
+              git config user.email "workos-sdk-bot[bot]@users.noreply.github.com"
+              git config user.name "workos-sdk-bot[bot]"
 
-            # Regenerate lockfile based on detected package manager
-            if [ -f "pnpm-lock.yaml" ]; then
-              corepack enable pnpm
-              pnpm install --lockfile-only
-            elif [ -f "package-lock.json" ]; then
-              npm install --package-lock-only
-            fi
+              # Regenerate lockfile based on detected package manager
+              if [ -f "pnpm-lock.yaml" ]; then
+                corepack enable pnpm
+                pnpm install --lockfile-only
+              elif [ -f "package-lock.json" ]; then
+                npm install --package-lock-only
+              fi
 
-            git add package.json package-lock.json pnpm-lock.yaml 2>/dev/null || true
-            git commit -m "chore!: bump @workos-inc/node to ^${NEW_MAJOR}.0.0"
+              git add package.json package-lock.json pnpm-lock.yaml 2>/dev/null || true
+              git commit -m "chore!: bump @workos-inc/node to ^${NEW_MAJOR}.0.0"
 
-            # Push idempotently — force-with-lease if branch exists from a prior run
-            if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-              echo "   Branch $BRANCH already exists — updating"
-              git push --force-with-lease origin "$BRANCH"
-            else
-              git push origin "$BRANCH"
-            fi
+              # Push idempotently — force-with-lease if branch exists from a prior run
+              if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+                echo "   Branch $BRANCH already exists — updating"
+                git push --force-with-lease origin "$BRANCH"
+              else
+                git push origin "$BRANCH"
+              fi
 
-            # Only create PR if one doesn't already exist for this branch
-            EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --json number --jq '.[0].number')
-            if [ -n "$EXISTING_PR" ]; then
-              echo "   PR #$EXISTING_PR already exists — skipping"
-            else
-              DEFAULT_BRANCH=$(gh repo view "$REPO" \
-                --json defaultBranchRef \
-                --jq '.defaultBranchRef.name')
+              # Only create PR if one doesn't already exist for this branch
+              EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --json number --jq '.[0].number')
+              if [ -n "$EXISTING_PR" ]; then
+                echo "   PR #$EXISTING_PR already exists — skipping"
+              else
+                DEFAULT_BRANCH=$(gh repo view "$REPO" \
+                  --json defaultBranchRef \
+                  --jq '.defaultBranchRef.name')
 
-              gh pr create \
-                --repo "$REPO" \
-                --base "$DEFAULT_BRANCH" \
-                --head "$BRANCH" \
-                --title "chore!: bump @workos-inc/node to ^${NEW_MAJOR}.0.0" \
-                --body "Bumps \`@workos-inc/node\` from \`${CURRENT}\` to \`${NEW_CONSTRAINT}\` following the [v${NEW_MAJOR}.0.0 release](https://github.com/workos/workos-node/releases/tag/${RELEASE_TAG})."
-            fi
+                gh pr create \
+                  --repo "$REPO" \
+                  --base "$DEFAULT_BRANCH" \
+                  --head "$BRANCH" \
+                  --title "chore!: bump @workos-inc/node to ^${NEW_MAJOR}.0.0" \
+                  --body "Bumps \`@workos-inc/node\` from \`${CURRENT}\` to \`${NEW_CONSTRAINT}\` following the [v${NEW_MAJOR}.0.0 release](https://github.com/workos/workos-node/releases/tag/${RELEASE_TAG})."
+              fi
+            ) || echo "   Failed — skipping"
 
-            cd /tmp && rm -rf "$WORK_DIR"
+            rm -rf "$WORK_DIR"
             echo "   Done ✓"
 
           done < /tmp/repos.txt

--- a/.github/workflows/workos-node-dep-bump.yml
+++ b/.github/workflows/workos-node-dep-bump.yml
@@ -1,0 +1,185 @@
+name: Bump workos-node dependency in workos repos
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Target version (e.g. 9, 9.0.0, or v9.0.0) — major is extracted automatically'
+        required: true
+        type: string
+      dry_run:
+        description: 'Log what would happen without opening any PRs'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.version.outputs.skip }}
+      major: ${{ steps.version.outputs.major }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - name: Determine target major version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+            VERSION="${TAG#v}"
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+            echo "Tag: $TAG  →  major=$MAJOR minor=$MINOR patch=$PATCH"
+
+            if [ "$MINOR" != "0" ] || [ "$PATCH" != "0" ]; then
+              echo "Not a major release ($TAG) — skipping."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          else
+            INPUT="${{ inputs.version }}"
+            VERSION="${INPUT#v}"
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            TAG="v${MAJOR}.0.0"
+
+            echo "Input: $INPUT  →  major=$MAJOR"
+          fi
+
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+  bump-workos-node-deps:
+    needs: check-version
+    if: needs.check-version.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # 3.1.1
+        with:
+          app-id: ${{ vars.SDK_BOT_APP_ID }}
+          private-key: ${{ secrets.SDK_BOT_PRIVATE_KEY }}
+          owner: workos
+
+      - name: Discover repos
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          REPO_PATTERNS=("authkit-")
+
+          > /tmp/repos.txt
+          for PATTERN in "${REPO_PATTERNS[@]}"; do
+            gh repo list workos \
+              --limit 200 \
+              --json name \
+              --jq ".[] | select(.name | startswith(\"$PATTERN\")) | .name" \
+              >> /tmp/repos.txt
+          done
+
+          if [ ! -s /tmp/repos.txt ]; then
+            echo "No repos found matching patterns: ${REPO_PATTERNS[*]}"
+          else
+            echo "Found repos:"
+            cat /tmp/repos.txt
+          fi
+
+      - name: Bump dependencies
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          NEW_MAJOR="${{ needs.check-version.outputs.major }}"
+          DRY_RUN="${{ inputs.dry_run || 'false' }}"
+
+          echo "Target major: $NEW_MAJOR | Dry run: $DRY_RUN"
+
+          if [ ! -s /tmp/repos.txt ]; then
+            echo "No repos to process."
+            exit 0
+          fi
+
+          while IFS= read -r REPO_NAME; do
+            [ -z "$REPO_NAME" ] && continue
+            REPO="workos/$REPO_NAME"
+            echo "── $REPO"
+
+            # Fetch package.json via API (avoids a full clone for the read phase)
+            PKG_CONTENT=$(gh api "repos/$REPO/contents/package.json" \
+              --jq '.content' 2>/dev/null) || {
+              echo "   No package.json — skipping"
+              continue
+            }
+            PKG_JSON=$(echo "$PKG_CONTENT" | base64 -d)
+
+            # Extract current @workos-inc/node version (deps or devDeps)
+            CURRENT=$(echo "$PKG_JSON" | jq -r '
+              (.dependencies["@workos-inc/node"] //
+               .devDependencies["@workos-inc/node"] //
+               "")
+            ')
+            if [ -z "$CURRENT" ]; then
+              echo "   @workos-inc/node not present — skipping"
+              continue
+            fi
+
+            # Compare majors
+            CURRENT_CLEAN="${CURRENT#^}"
+            CURRENT_MAJOR=$(echo "$CURRENT_CLEAN" | cut -d. -f1)
+
+            if [ "$CURRENT_MAJOR" -ge "$NEW_MAJOR" ]; then
+              echo "   Already at major $CURRENT_MAJOR (>= $NEW_MAJOR) — skipping"
+              continue
+            fi
+
+            NEW_CONSTRAINT="^${NEW_MAJOR}.0.0"
+            echo "   Update: $CURRENT → $NEW_CONSTRAINT"
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "   [DRY RUN] Would open PR in $REPO"
+              echo "   [DRY RUN]   Branch: deps/bump-workos-node-to-v${NEW_MAJOR}"
+              echo "   [DRY RUN]   Change: @workos-inc/node $CURRENT → $NEW_CONSTRAINT"
+              continue
+            fi
+
+            BRANCH="deps/bump-workos-node-to-v${NEW_MAJOR}"
+            WORK_DIR="/tmp/${REPO_NAME}"
+
+            rm -rf "$WORK_DIR"
+            gh repo clone "$REPO" "$WORK_DIR"
+
+            cd "$WORK_DIR"
+            git checkout -b "$BRANCH"
+
+            # sed preserves exact file formatting; | delimiter avoids conflicts with /
+            sed -i "s|\"@workos-inc/node\": \"${CURRENT}\"|\"@workos-inc/node\": \"${NEW_CONSTRAINT}\"|g" \
+              package.json
+
+            git config user.email "workos-sdk-bot[bot]@users.noreply.github.com"
+            git config user.name "workos-sdk-bot[bot]"
+            git add package.json
+            git commit -m "chore: bump @workos-inc/node to ^${NEW_MAJOR}.0.0"
+            git push origin "$BRANCH"
+
+            DEFAULT_BRANCH=$(gh repo view "$REPO" \
+              --json defaultBranchRef \
+              --jq '.defaultBranchRef.name')
+
+            gh pr create \
+              --repo "$REPO" \
+              --base "$DEFAULT_BRANCH" \
+              --head "$BRANCH" \
+              --title "chore: bump @workos-inc/node to ^${NEW_MAJOR}.0.0" \
+              --body "Bumps \`@workos-inc/node\` from \`${CURRENT}\` to \`${NEW_CONSTRAINT}\` following the [v${NEW_MAJOR}.0.0 release](https://github.com/workos/workos-node/releases/tag/${{ needs.check-version.outputs.tag }})." \
+              || echo "   PR may already exist — skipping"
+
+            cd /tmp && rm -rf "$WORK_DIR"
+            echo "   Done ✓"
+
+          done < /tmp/repos.txt

--- a/.github/workflows/workos-node-dep-bump.yml
+++ b/.github/workflows/workos-node-dep-bump.yml
@@ -28,9 +28,13 @@ jobs:
     steps:
       - name: Determine target major version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            TAG="${{ github.event.release.tag_name }}"
+          if [ "$EVENT_NAME" = "release" ]; then
+            TAG="$RELEASE_TAG"
             VERSION="${TAG#v}"
             MAJOR=$(echo "$VERSION" | cut -d. -f1)
             MINOR=$(echo "$VERSION" | cut -d. -f2)
@@ -44,9 +48,15 @@ jobs:
               exit 0
             fi
           else
-            INPUT="${{ inputs.version }}"
+            INPUT="$INPUT_VERSION"
             VERSION="${INPUT#v}"
             MAJOR=$(echo "$VERSION" | cut -d. -f1)
+
+            if ! [[ "$MAJOR" =~ ^[0-9]+$ ]]; then
+              echo "Invalid version input: $INPUT"
+              exit 1
+            fi
+
             TAG="v${MAJOR}.0.0"
 
             echo "Input: $INPUT  →  major=$MAJOR"
@@ -94,10 +104,10 @@ jobs:
       - name: Bump dependencies
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          NEW_MAJOR: ${{ needs.check-version.outputs.major }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          RELEASE_TAG: ${{ needs.check-version.outputs.tag }}
         run: |
-          NEW_MAJOR="${{ needs.check-version.outputs.major }}"
-          DRY_RUN="${{ inputs.dry_run || 'false' }}"
-
           echo "Target major: $NEW_MAJOR | Dry run: $DRY_RUN"
 
           if [ ! -s /tmp/repos.txt ]; then
@@ -129,9 +139,13 @@ jobs:
               continue
             fi
 
-            # Compare majors
-            CURRENT_CLEAN="${CURRENT#^}"
-            CURRENT_MAJOR=$(echo "$CURRENT_CLEAN" | cut -d. -f1)
+            # Compare majors — strip any non-numeric prefix (^, ~, >=, etc.)
+            CURRENT_MAJOR=$(echo "$CURRENT" | sed 's/^[^0-9]*//' | cut -d. -f1)
+
+            if ! [[ "$CURRENT_MAJOR" =~ ^[0-9]+$ ]]; then
+              echo "   Unable to parse version: $CURRENT — skipping"
+              continue
+            fi
 
             if [ "$CURRENT_MAJOR" -ge "$NEW_MAJOR" ]; then
               echo "   Already at major $CURRENT_MAJOR (>= $NEW_MAJOR) — skipping"
@@ -152,9 +166,9 @@ jobs:
             WORK_DIR="/tmp/${REPO_NAME}"
 
             rm -rf "$WORK_DIR"
-            gh repo clone "$REPO" "$WORK_DIR"
+            gh repo clone "$REPO" "$WORK_DIR" || { echo "   Clone failed — skipping"; continue; }
 
-            cd "$WORK_DIR"
+            cd "$WORK_DIR" || { echo "   cd failed — skipping"; continue; }
             git checkout -b "$BRANCH"
 
             # sed preserves exact file formatting; | delimiter avoids conflicts with /
@@ -163,7 +177,18 @@ jobs:
 
             git config user.email "workos-sdk-bot[bot]@users.noreply.github.com"
             git config user.name "workos-sdk-bot[bot]"
-            git add package.json
+
+            # Regenerate lockfile based on detected package manager
+            if [ -f "pnpm-lock.yaml" ]; then
+              corepack enable pnpm
+              pnpm install --lockfile-only
+            elif [ -f "package-lock.json" ]; then
+              npm install --package-lock-only
+            elif [ -f "yarn.lock" ]; then
+              yarn install --mode update-lockfile
+            fi
+
+            git add package.json package-lock.json yarn.lock pnpm-lock.yaml 2>/dev/null || true
             git commit -m "chore: bump @workos-inc/node to ^${NEW_MAJOR}.0.0"
             git push origin "$BRANCH"
 
@@ -176,7 +201,7 @@ jobs:
               --base "$DEFAULT_BRANCH" \
               --head "$BRANCH" \
               --title "chore: bump @workos-inc/node to ^${NEW_MAJOR}.0.0" \
-              --body "Bumps \`@workos-inc/node\` from \`${CURRENT}\` to \`${NEW_CONSTRAINT}\` following the [v${NEW_MAJOR}.0.0 release](https://github.com/workos/workos-node/releases/tag/${{ needs.check-version.outputs.tag }})." \
+              --body "Bumps \`@workos-inc/node\` from \`${CURRENT}\` to \`${NEW_CONSTRAINT}\` following the [v${NEW_MAJOR}.0.0 release](https://github.com/workos/workos-node/releases/tag/${RELEASE_TAG})." \
               || echo "   PR may already exist — skipping"
 
             cd /tmp && rm -rf "$WORK_DIR"


### PR DESCRIPTION
## Summary

This PR adds a new CI workflow that bump `workos-inc/node` across repos in the WorkOS org. It fires on `release: published` (filtered to MAJOR changes only) and via `workflow_dispatch` with an explicit version input

Without this, bumping `@workos-inc/node` across every `authkit-*` repo after a major release requires manually opening one PR per repo

This workflow discovers all `authkit-*` repos in the workos org dynamically and skips repos that are already at or ahead of the new release version.

`workflow_dispatch` accepts a `version` input (e.g. `9`, `9.0.0`, `v9.0.0`) and a `dry_run` boolean (default `true`) that logs intended changes without opening any PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI workflow to manage major-version bumps of the Node client dependency across related repositories. Runs on release or manual trigger, skips non-major releases, supports dry-run or apply modes, updates dependency constraints and lockfiles, creates update branches and opens pull requests when updates are required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->