### PR TITLE
fix: restore typed data on `AuthenticationErrorData`

### DIFF
--- a/src/admin-portal/serializers.spec.ts
+++ b/src/admin-portal/serializers.spec.ts
@@ -20,14 +20,14 @@ import type { SSOIntentOptionsResponse } from './interfaces/sso-intent-options.i
 import type { IntentOptionsResponse } from './interfaces/intent-options.interface';
 import type { GenerateLinkResponse } from './interfaces/generate-link.interface';
 import type { PortalLinkResponseWire } from './interfaces/portal-link-response.interface';
-import SSOIntentOptionsFixture from './fixtures/sso-intent-options.json';
+import ssoIntentOptionsFixture from './fixtures/sso-intent-options.json';
 import intentOptionsFixture from './fixtures/intent-options.json';
 import generateLinkFixture from './fixtures/generate-link.json';
 import portalLinkResponseFixture from './fixtures/portal-link-response.json';
 
 describe('SSOIntentOptionsSerializer', () => {
   it('round-trips through serialize/deserialize', () => {
-    const fixture = SSOIntentOptionsFixture as SSOIntentOptionsResponse;
+    const fixture = ssoIntentOptionsFixture as SSOIntentOptionsResponse;
     const deserialized = deserializeSSOIntentOptions(fixture);
     const reserialized = serializeSSOIntentOptions(deserialized);
     expect(reserialized).toEqual(expect.objectContaining(fixture));

--- a/src/common/exceptions/authentication.exception.ts
+++ b/src/common/exceptions/authentication.exception.ts
@@ -2,6 +2,7 @@ import {
   GenericServerException,
   WorkOSErrorData,
 } from './generic-server.exception';
+import type { UserResponse } from '../../user-management/interfaces/user.interface';
 
 export type AuthenticationErrorCode =
   | 'email_verification_required'
@@ -14,8 +15,9 @@ export type AuthenticationErrorCode =
 export interface AuthenticationErrorData extends WorkOSErrorData {
   code: AuthenticationErrorCode;
   pending_authentication_token?: string;
-  user?: Record<string, unknown>;
+  user?: UserResponse;
   organizations?: Array<{ id: string; name: string }>;
+  connection_ids?: string[];
 }
 
 const AUTHENTICATION_ERROR_CODES: ReadonlySet<string> = new Set<string>([


### PR DESCRIPTION
## Summary
- Replace the loosely-typed `user?: Record<string, unknown>` with the concrete `UserResponse` type on `AuthenticationErrorData`, restoring type safety for authentication error payloads
- Add missing `connection_ids?: string[]` field to `AuthenticationErrorData`
- Fix casing typo on `SSOIntentOptionsFixture` import (PascalCase → camelCase to match other fixture imports)

## Test plan
- [ ] Verify `AuthenticationErrorData.user` resolves to `UserResponse` in IDE type-checking
- [ ] Verify `connection_ids` field is accessible on `AuthenticationErrorData`
- [ ] Run `npm test` — existing tests pass, including the renamed fixture import in `serializers.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test fixture variable naming in authentication serialization tests for improved maintainability.

* **Refactor**
  * Strengthened type definitions for authentication error handling with more precise user data typing and connection identifier tracking support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->