### PR TITLE
fix: Correctly handle all `isAuthenticationErrorData` cases

### DIFF
--- a/src/common/exceptions/authentication.exception.ts
+++ b/src/common/exceptions/authentication.exception.ts
@@ -32,9 +32,18 @@ const AUTHENTICATION_ERROR_CODES: ReadonlySet<string> = new Set<string>([
 export function isAuthenticationErrorData(
   data: WorkOSErrorData,
 ): data is AuthenticationErrorData {
-  return (
-    typeof data.code === 'string' && AUTHENTICATION_ERROR_CODES.has(data.code)
-  );
+  let discriminant: string | undefined;
+
+  if (typeof data.code === 'string') {
+    discriminant = data.code;
+  } else if (typeof data.error === 'string') {
+    // Some errors like `sso_required` use an `error` field instead of `code`
+    discriminant = data.error;
+  }
+
+  if (!discriminant) return false;
+
+  return AUTHENTICATION_ERROR_CODES.has(discriminant);
 }
 
 export class AuthenticationException extends GenericServerException {

--- a/src/common/exceptions/authentication.exception.ts
+++ b/src/common/exceptions/authentication.exception.ts
@@ -12,13 +12,23 @@ export type AuthenticationErrorCode =
   | 'mfa_verification'
   | 'sso_required';
 
-export interface AuthenticationErrorData extends WorkOSErrorData {
-  code: AuthenticationErrorCode;
+interface BaseAuthenticationErrorData extends WorkOSErrorData {
+  error?: string;
+  error_description?: string;
   pending_authentication_token?: string;
   user?: UserResponse;
   organizations?: Array<{ id: string; name: string }>;
   connection_ids?: string[];
 }
+
+export type AuthenticationErrorData =
+  | (BaseAuthenticationErrorData & {
+      code: AuthenticationErrorCode;
+    })
+  | (BaseAuthenticationErrorData & {
+      code?: AuthenticationErrorCode;
+      error: AuthenticationErrorCode;
+    });
 
 const AUTHENTICATION_ERROR_CODES: ReadonlySet<string> = new Set<string>([
   'email_verification_required',
@@ -29,25 +39,44 @@ const AUTHENTICATION_ERROR_CODES: ReadonlySet<string> = new Set<string>([
   'sso_required',
 ]);
 
+function parseAuthenticationErrorCode(
+  value: unknown,
+): AuthenticationErrorCode | undefined {
+  if (typeof value !== 'string') {
+    return;
+  }
+
+  if (!AUTHENTICATION_ERROR_CODES.has(value)) {
+    return;
+  }
+
+  return value as AuthenticationErrorCode;
+}
+
+function getAuthenticationErrorCode(
+  data: AuthenticationErrorData,
+): AuthenticationErrorCode;
+function getAuthenticationErrorCode(
+  data: WorkOSErrorData,
+): AuthenticationErrorCode | undefined;
+function getAuthenticationErrorCode(
+  data: WorkOSErrorData,
+): AuthenticationErrorCode | undefined {
+  return (
+    parseAuthenticationErrorCode(data.code) ??
+    parseAuthenticationErrorCode(data.error)
+  );
+}
+
 export function isAuthenticationErrorData(
   data: WorkOSErrorData,
 ): data is AuthenticationErrorData {
-  let discriminant: string | undefined;
-
-  if (typeof data.code === 'string') {
-    discriminant = data.code;
-  } else if (typeof data.error === 'string') {
-    // Some errors like `sso_required` use an `error` field instead of `code`
-    discriminant = data.error;
-  }
-
-  if (!discriminant) return false;
-
-  return AUTHENTICATION_ERROR_CODES.has(discriminant);
+  return getAuthenticationErrorCode(data) !== undefined;
 }
 
 export class AuthenticationException extends GenericServerException {
   readonly name = 'AuthenticationException';
+  override readonly code: AuthenticationErrorCode;
   readonly pendingAuthenticationToken: string | undefined;
 
   constructor(
@@ -55,7 +84,15 @@ export class AuthenticationException extends GenericServerException {
     readonly rawData: AuthenticationErrorData,
     requestID: string,
   ) {
-    super(status, rawData.message, rawData, requestID);
+    const code = getAuthenticationErrorCode(rawData);
+
+    super(
+      status,
+      rawData.message ?? rawData.error_description,
+      rawData,
+      requestID,
+    );
+    this.code = code;
     this.pendingAuthenticationToken = rawData.pending_authentication_token;
   }
 }

--- a/src/common/exceptions/authentication.exception.ts
+++ b/src/common/exceptions/authentication.exception.ts
@@ -13,8 +13,6 @@ export type AuthenticationErrorCode =
   | 'sso_required';
 
 interface BaseAuthenticationErrorData extends WorkOSErrorData {
-  error?: string;
-  error_description?: string;
   pending_authentication_token?: string;
   user?: UserResponse;
   organizations?: Array<{ id: string; name: string }>;
@@ -23,11 +21,11 @@ interface BaseAuthenticationErrorData extends WorkOSErrorData {
 
 export type AuthenticationErrorData =
   | (BaseAuthenticationErrorData & {
-      code: AuthenticationErrorCode;
+      code: Exclude<AuthenticationErrorCode, 'sso_required'>;
     })
   | (BaseAuthenticationErrorData & {
-      code?: AuthenticationErrorCode;
-      error: AuthenticationErrorCode;
+      error: 'sso_required';
+      error_description: string;
     });
 
 const AUTHENTICATION_ERROR_CODES: ReadonlySet<string> = new Set<string>([
@@ -88,7 +86,7 @@ export class AuthenticationException extends GenericServerException {
 
     super(
       status,
-      rawData.message ?? rawData.error_description,
+      rawData.message ?? (rawData.error_description as string | undefined),
       rawData,
       requestID,
     );

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -2,6 +2,7 @@ import fetch from 'jest-fetch-mock';
 import { fetchOnce, fetchHeaders, fetchBody } from './common/utils/test-utils';
 import {
   ApiKeyRequiredException,
+  AuthenticationException,
   GenericServerException,
   NotFoundException,
   OauthException,
@@ -354,6 +355,34 @@ describe('WorkOS', () => {
             { error: 'error', error_description: 'error description' },
           ),
         );
+      });
+
+      it('throws an AuthenticationException for known authentication errors', async () => {
+        const rawData = {
+          error: 'sso_required',
+          error_description:
+            'User must authenticate using one of the matching connections.',
+          email: 'user@example.com',
+          connection_ids: ['conn_123'],
+        };
+
+        fetchOnce(rawData, {
+          status: 400,
+          headers: { 'X-Request-ID': 'a-request-id' },
+        });
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+        const request = workos.post('/path', {});
+
+        await expect(request).rejects.toBeInstanceOf(AuthenticationException);
+        await expect(request).rejects.toMatchObject({
+          code: 'sso_required',
+          message:
+            'User must authenticate using one of the matching connections.',
+          name: 'AuthenticationException',
+          rawData,
+          status: 400,
+        });
       });
     });
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -483,7 +483,9 @@ export class WorkOS {
           );
         }
         default: {
-          if (error || errorDescription) {
+          if (isAuthenticationErrorData(data)) {
+            throw new AuthenticationException(status, data, requestID);
+          } else if (error || errorDescription) {
             throw new OauthException(
               status,
               requestID,
@@ -500,8 +502,6 @@ export class WorkOS {
               message,
               requestID,
             });
-          } else if (isAuthenticationErrorData(data)) {
-            throw new AuthenticationException(status, data, requestID);
           } else {
             throw new GenericServerException(
               status,


### PR DESCRIPTION
## Description

https://github.com/workos/workos-node/pull/1561 added a new `AuthenticationException` type to handle the following cases: https://github.com/workos/workos-node/blob/96cf545f973e3e130abdbc9ea09a39b4cced7af3/src/common/exceptions/authentication.exception.ts#L7-L13

However, because the error handling logic first checks whether the payload has an `error` or `error_description` field https://github.com/workos/workos-node/blob/96cf545f973e3e130abdbc9ea09a39b4cced7af3/src/workos.ts#L486-L487
`sso_required` is being treated as an `OauthException` instead of a `AuthenticationException` (see https://workos.com/docs/reference/authkit/authentication-errors#sso-required-error).

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP error classification to prioritize and reliably detect authentication failures (avoiding misclassification as OAuth or generic errors).
  * Authentication errors now surface consistent error codes and clearer messages sourced from multiple response fields.
* **Tests**
  * Added tests to verify authentication error detection and that the thrown exception preserves status, raw response details, code, and message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->