### PR TITLE
fix: Fix incorrect url for listEffectivePermissionsByExternalId

### DIFF
--- a/src/authorization/authorization.spec.ts
+++ b/src/authorization/authorization.spec.ts
@@ -2418,13 +2418,12 @@ describe('Authorization', () => {
       const result =
         await workos.authorization.listEffectivePermissionsByExternalId({
           organizationMembershipId: testOrgMembershipId,
-          organizationId: testOrgId,
           resourceTypeSlug: 'document',
           externalId: 'doc-456',
         });
 
       expect(fetchURL()).toContain(
-        `/authorization/organizations/${testOrgId}/resources/document/doc-456/organization_memberships/${testOrgMembershipId}/permissions`,
+        `/authorization/organization_memberships/${testOrgMembershipId}/resources/document/doc-456/permissions`,
       );
       expect(result.object).toEqual('list');
       expect(result.data).toHaveLength(2);
@@ -2453,7 +2452,6 @@ describe('Authorization', () => {
 
       await workos.authorization.listEffectivePermissionsByExternalId({
         organizationMembershipId: testOrgMembershipId,
-        organizationId: testOrgId,
         resourceTypeSlug: 'document',
         externalId: 'doc-456',
         limit: 10,
@@ -2473,7 +2471,6 @@ describe('Authorization', () => {
 
       await workos.authorization.listEffectivePermissionsByExternalId({
         organizationMembershipId: testOrgMembershipId,
-        organizationId: testOrgId,
         resourceTypeSlug: 'document',
         externalId: 'doc-456',
         before: 'perm_cursor789',
@@ -2491,7 +2488,6 @@ describe('Authorization', () => {
 
       await workos.authorization.listEffectivePermissionsByExternalId({
         organizationMembershipId: testOrgMembershipId,
-        organizationId: testOrgId,
         resourceTypeSlug: 'document',
         externalId: 'doc-456',
       });

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -1134,13 +1134,8 @@ export class Authorization {
   async listEffectivePermissionsByExternalId(
     options: ListEffectivePermissionsByExternalIdOptions,
   ): Promise<AutoPaginatable<Permission>> {
-    const {
-      organizationMembershipId,
-      organizationId,
-      resourceTypeSlug,
-      externalId,
-    } = options;
-    const endpoint = `/authorization/organizations/${organizationId}/resources/${resourceTypeSlug}/${externalId}/organization_memberships/${organizationMembershipId}/permissions`;
+    const { organizationMembershipId, resourceTypeSlug, externalId } = options;
+    const endpoint = `/authorization/organization_memberships/${organizationMembershipId}/resources/${resourceTypeSlug}/${externalId}/permissions`;
     const serializedOptions = serializeListEffectivePermissionsOptions(options);
     return new AutoPaginatable(
       await fetchAndDeserialize<PermissionResponse, Permission>(

--- a/src/authorization/interfaces/list-effective-permissions-by-external-id-options.interface.ts
+++ b/src/authorization/interfaces/list-effective-permissions-by-external-id-options.interface.ts
@@ -2,7 +2,6 @@ import { PaginationOptions } from '../../common/interfaces/pagination-options.in
 
 export interface ListEffectivePermissionsByExternalIdOptions extends PaginationOptions {
   organizationMembershipId: string;
-  organizationId: string;
   resourceTypeSlug: string;
   externalId: string;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated effective permissions API: removed `organizationId` requirement from the query parameters. The endpoint now queries permissions directly using organization membership scope instead of organization scope, simplifying the request structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->