### PR TITLE
fix: set canonical User-Agent header format

### DIFF
--- a/src/common/interfaces/http-client.interface.ts
+++ b/src/common/interfaces/http-client.interface.ts
@@ -7,7 +7,6 @@ export type ResponseHeaderValue = string | string[];
 export type ResponseHeaders = Record<string, ResponseHeaderValue>;
 
 export interface HttpClientInterface {
-  getClientName: () => string;
   get(path: string, options: RequestOptions): any;
   post<Entity = any>(
     path: string,

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -37,11 +37,6 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
     this._fetchFn = fetchFn.bind(globalThis);
   }
 
-  /** @override */
-  getClientName(): string {
-    return 'fetch';
-  }
-
   async get(
     path: string,
     options: RequestOptions,
@@ -259,9 +254,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
           'Content-Type': 'application/json',
           ...this.options?.headers,
           ...headers,
-          'User-Agent': this.addClientToUserAgent(
-            (userAgent || 'workos-node').toString(),
-          ),
+          'User-Agent': (userAgent || 'workos-node').toString(),
         },
         body: requestBody,
         signal: abortController?.signal,

--- a/src/common/net/http-client.ts
+++ b/src/common/net/http-client.ts
@@ -18,11 +18,6 @@ export abstract class HttpClient implements HttpClientInterface {
     readonly options?: RequestInit,
   ) {}
 
-  /** The HTTP client name used for diagnostics */
-  getClientName(): string {
-    throw new Error('getClientName not implemented');
-  }
-
   abstract get(
     path: string,
     options: RequestOptions,
@@ -56,10 +51,6 @@ export abstract class HttpClient implements HttpClientInterface {
     entity: Entity,
     options: RequestOptions,
   ): Promise<HttpClientResponseInterface>;
-
-  addClientToUserAgent(userAgent: string): string {
-    return userAgent;
-  }
 
   static getResourceURL(
     baseURL: string,

--- a/src/common/net/http-client.ts
+++ b/src/common/net/http-client.ts
@@ -58,11 +58,7 @@ export abstract class HttpClient implements HttpClientInterface {
   ): Promise<HttpClientResponseInterface>;
 
   addClientToUserAgent(userAgent: string): string {
-    if (userAgent.indexOf(' ') > -1) {
-      return userAgent.replace(/\b\s/, `/${this.getClientName()} `);
-    } else {
-      return `${userAgent}/${this.getClientName()}`;
-    }
+    return userAgent;
   }
 
   static getResourceURL(

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -379,7 +379,7 @@ describe('SSO', () => {
             'application/x-www-form-urlencoded;charset=utf-8',
           );
           expect(headers['User-Agent']).toMatch(
-            /^workos-node\/\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?\/fetch \(node\/v\d+\.\d+\.\d+\)$/,
+            /^workos-node\/\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/,
           );
 
           expect(accessToken).toBe('01DMEK0J53CVMC32CK5SE0KZ8Q');
@@ -432,7 +432,7 @@ describe('SSO', () => {
             'application/x-www-form-urlencoded;charset=utf-8',
           );
           expect(headers['User-Agent']).toMatch(
-            /^workos-node\/\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?\/fetch \(node\/v\d+\.\d+\.\d+\)$/,
+            /^workos-node\/\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/,
           );
 
           expect(accessToken).toBe('01DMEK0J53CVMC32CK5SE0KZ8Q');

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -165,7 +165,7 @@ describe('WorkOS', () => {
 
         const headers = fetchHeaders() as Record<string, string>;
         expect(headers['User-Agent']).toMatch(
-          /^workos-node\/\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?\/fetch \(node\/v\d+\.\d+\.\d+\) fooApp: 1\.0\.0$/,
+          /^workos-node\/\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/,
         );
       });
     });
@@ -180,7 +180,7 @@ describe('WorkOS', () => {
 
         const headers = fetchHeaders() as Record<string, string>;
         expect(headers['User-Agent']).toMatch(
-          /^workos-node\/\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?\/fetch \(node\/v\d+\.\d+\.\d+\)$/,
+          /^workos-node\/\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/,
         );
       });
     });

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -171,7 +171,7 @@ describe('WorkOS', () => {
     });
 
     describe('when no `appInfo` option is provided', () => {
-      it('adds the HTTP client name to the user-agent', async () => {
+      it('sets the canonical user-agent', async () => {
         fetchOnce('{}');
 
         const workos = new WorkOS('sk_test');

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -151,7 +151,7 @@ describe('WorkOS', () => {
     });
 
     describe('when the `appInfo` option is provided', () => {
-      it('applies the configuration to the fetch client user-agent', async () => {
+      it('sets the canonical user-agent', async () => {
         fetchOnce('{}');
 
         const workos = new WorkOS('sk_test', {

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -48,7 +48,6 @@ import { ConflictException } from './common/exceptions/conflict.exception';
 import { CryptoProvider } from './common/crypto/crypto-provider';
 import { ParseError } from './common/exceptions/parse-error';
 import { getEnv } from './common/utils/env';
-import { getRuntimeInfo } from './common/utils/runtime-info';
 import { version as VERSION } from '../package.json' with { type: 'json' };
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
@@ -163,18 +162,8 @@ export class WorkOS {
     this.client = this.createHttpClient(this.options, userAgent);
   }
 
-  private createUserAgent(options: WorkOSOptions): string {
-    let userAgent: string = `workos-node/${VERSION}`;
-
-    const { name: runtimeName, version: runtimeVersion } = getRuntimeInfo();
-    userAgent += ` (${runtimeName}${runtimeVersion ? `/${runtimeVersion}` : ''})`;
-
-    if (options.appInfo) {
-      const { name, version } = options.appInfo;
-      userAgent += ` ${name}: ${version}`;
-    }
-
-    return userAgent;
+  private createUserAgent(_options: WorkOSOptions): string {
+    return `workos-node/${VERSION}`;
   }
 
   createWebhookClient() {


### PR DESCRIPTION
## Description

The outgoing `User-Agent` header is now always `workos-node/{VERSION}` — the canonical WorkOS Node SDK format used through the 6.x line. The 7.x and 8.x lines accumulated several augmentations that no longer conformed (`/fetch` HTTP-client annotation, `(node/v22.0.0)` runtime info, ` appName: appVer` from `appInfo`).

### Behavior changes

- Runtime detection is no longer appended to the header.
- `appInfo` option still parses for backwards compatibility, but the value no longer affects the `User-Agent` header.
- Removed the now-unused HTTP client name plumbing flagged by Greptile.
- Clarified User-Agent test names to reflect the canonical format.

Callers relying on these tokens being present in `User-Agent` will need to set a separate header via the request-options headers mechanism.

### Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test -- src/workos.spec.ts`
- [x] `npm test -- src/workos.spec.ts src/common/net/fetch-client.spec.ts`
- [x] `npx jest` (683 passed, 0 failed)
- [ ] Confirm `User-Agent: workos-node/{VERSION}` on a real outgoing request

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

No WorkOS Docs changes are required for this cleanup.

Link to Devin session: https://app.devin.ai/sessions/7fb05fc5793448acbeb705fc97e36592
Requested by: @gjtorikian