### PR TITLE
fix(webhooks): accept raw request bytes for signature verification

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1,6 +1,9 @@
 // @oagen-ignore-file
 import { CryptoProvider } from '../common/crypto/crypto-provider';
-import { type WebhookPayload } from '../common/crypto/decode-payload';
+import {
+  type WebhookPayload,
+  decodePayloadToString,
+} from '../common/crypto/decode-payload';
 import { SignatureProvider } from '../common/crypto/signature-provider';
 import { unreachable } from '../common/utils/unreachable';
 import { ActionContext, ActionPayload } from './interfaces/action.interface';
@@ -86,6 +89,13 @@ export class Actions {
     const options = { payload, sigHeader, secret, tolerance };
     await this.verifyHeader(options);
 
-    return deserializeAction(payload as unknown as ActionPayload);
+    const parsed: ActionPayload =
+      typeof payload === 'string' ||
+      payload instanceof Uint8Array ||
+      payload instanceof ArrayBuffer
+        ? (JSON.parse(decodePayloadToString(payload)) as ActionPayload)
+        : (payload as unknown as ActionPayload);
+
+    return deserializeAction(parsed);
   }
 }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1,5 +1,6 @@
 // @oagen-ignore-file
 import { CryptoProvider } from '../common/crypto/crypto-provider';
+import { type WebhookPayload } from '../common/crypto/decode-payload';
 import { SignatureProvider } from '../common/crypto/signature-provider';
 import { unreachable } from '../common/utils/unreachable';
 import { ActionContext, ActionPayload } from './interfaces/action.interface';
@@ -63,7 +64,7 @@ export class Actions {
       payload: responsePayload,
       signature: await this.computeSignature(
         responsePayload.timestamp,
-        responsePayload,
+        responsePayload as unknown as Record<string, unknown>,
         secret,
       ),
     };
@@ -77,7 +78,7 @@ export class Actions {
     secret,
     tolerance = 30000,
   }: {
-    payload: unknown;
+    payload: WebhookPayload;
     sigHeader: string;
     secret: string;
     tolerance?: number;
@@ -85,6 +86,6 @@ export class Actions {
     const options = { payload, sigHeader, secret, tolerance };
     await this.verifyHeader(options);
 
-    return deserializeAction(payload as ActionPayload);
+    return deserializeAction(payload as unknown as ActionPayload);
   }
 }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -3,6 +3,7 @@ import { CryptoProvider } from '../common/crypto/crypto-provider';
 import {
   type WebhookPayload,
   decodePayloadToString,
+  isBinaryPayload,
 } from '../common/crypto/decode-payload';
 import { SignatureProvider } from '../common/crypto/signature-provider';
 import { unreachable } from '../common/utils/unreachable';
@@ -90,9 +91,7 @@ export class Actions {
     await this.verifyHeader(options);
 
     const parsed: ActionPayload =
-      typeof payload === 'string' ||
-      payload instanceof Uint8Array ||
-      payload instanceof ArrayBuffer
+      typeof payload === 'string' || isBinaryPayload(payload)
         ? (JSON.parse(decodePayloadToString(payload)) as ActionPayload)
         : (payload as unknown as ActionPayload);
 

--- a/src/common/crypto/decode-payload.ts
+++ b/src/common/crypto/decode-payload.ts
@@ -4,6 +4,15 @@ export type WebhookPayload =
   | ArrayBuffer
   | Record<string, unknown>;
 
+// Realm-agnostic check for binary payloads. `instanceof` fails when the
+// value originates from a different JS realm (Workers, iframes, VM contexts).
+export function isBinaryPayload(payload: WebhookPayload): boolean {
+  return (
+    ArrayBuffer.isView(payload) ||
+    Object.prototype.toString.call(payload) === '[object ArrayBuffer]'
+  );
+}
+
 // Decodes raw byte payloads to a UTF-8 string without stripping a BOM prefix.
 // Used by both signature verification (HMAC input) and post-verification
 // parsing (JSON.parse input) to guarantee the same bytes are signed and parsed.
@@ -11,13 +20,12 @@ export function decodePayloadToString(payload: WebhookPayload): string {
   if (typeof payload === 'string') {
     return payload;
   }
-  if (payload instanceof ArrayBuffer) {
-    return new TextDecoder('utf-8', { ignoreBOM: true }).decode(
-      new Uint8Array(payload),
-    );
-  }
-  if (payload instanceof Uint8Array) {
-    return new TextDecoder('utf-8', { ignoreBOM: true }).decode(payload);
+  if (isBinaryPayload(payload)) {
+    const bytes =
+      Object.prototype.toString.call(payload) === '[object ArrayBuffer]'
+        ? new Uint8Array(payload as ArrayBuffer)
+        : (payload as Uint8Array);
+    return new TextDecoder('utf-8', { ignoreBOM: true }).decode(bytes);
   }
   return JSON.stringify(payload);
 }

--- a/src/common/crypto/decode-payload.ts
+++ b/src/common/crypto/decode-payload.ts
@@ -1,8 +1,4 @@
-export type WebhookPayload =
-  | string
-  | Uint8Array
-  | ArrayBuffer
-  | object;
+export type WebhookPayload = string | Uint8Array | ArrayBuffer | object;
 
 // Realm-agnostic check for binary payloads. `instanceof` fails when the
 // value originates from a different JS realm (Workers, iframes, VM contexts).

--- a/src/common/crypto/decode-payload.ts
+++ b/src/common/crypto/decode-payload.ts
@@ -2,7 +2,7 @@ export type WebhookPayload =
   | string
   | Uint8Array
   | ArrayBuffer
-  | Record<string, unknown>;
+  | object;
 
 // Realm-agnostic check for binary payloads. `instanceof` fails when the
 // value originates from a different JS realm (Workers, iframes, VM contexts).

--- a/src/common/crypto/decode-payload.ts
+++ b/src/common/crypto/decode-payload.ts
@@ -1,0 +1,23 @@
+export type WebhookPayload =
+  | string
+  | Uint8Array
+  | ArrayBuffer
+  | Record<string, unknown>;
+
+// Decodes raw byte payloads to a UTF-8 string without stripping a BOM prefix.
+// Used by both signature verification (HMAC input) and post-verification
+// parsing (JSON.parse input) to guarantee the same bytes are signed and parsed.
+export function decodePayloadToString(payload: WebhookPayload): string {
+  if (typeof payload === 'string') {
+    return payload;
+  }
+  if (payload instanceof ArrayBuffer) {
+    return new TextDecoder('utf-8', { ignoreBOM: true }).decode(
+      new Uint8Array(payload),
+    );
+  }
+  if (payload instanceof Uint8Array) {
+    return new TextDecoder('utf-8', { ignoreBOM: true }).decode(payload);
+  }
+  return JSON.stringify(payload);
+}

--- a/src/common/crypto/signature-provider.ts
+++ b/src/common/crypto/signature-provider.ts
@@ -107,10 +107,12 @@ function toSignableString(
     return payload;
   }
   if (payload instanceof Uint8Array) {
-    return new TextDecoder('utf-8').decode(payload);
+    return new TextDecoder('utf-8', { ignoreBOM: true }).decode(payload);
   }
   if (payload instanceof ArrayBuffer) {
-    return new TextDecoder('utf-8').decode(new Uint8Array(payload));
+    return new TextDecoder('utf-8', { ignoreBOM: true }).decode(
+      new Uint8Array(payload),
+    );
   }
   return JSON.stringify(payload);
 }

--- a/src/common/crypto/signature-provider.ts
+++ b/src/common/crypto/signature-provider.ts
@@ -72,7 +72,12 @@ export class SignatureProvider {
 
   async computeSignature(
     timestamp: any,
-    payload: string | Uint8Array | ArrayBuffer | Record<string, unknown> | unknown,
+    payload:
+      | string
+      | Uint8Array
+      | ArrayBuffer
+      | Record<string, unknown>
+      | unknown,
     secret: string,
   ): Promise<string> {
     const signable = toSignableString(payload);
@@ -91,7 +96,12 @@ export class SignatureProvider {
 // JSON.stringify to the same canonical form (whitespace, key order, \uXXXX
 // escapes, duplicate keys).
 function toSignableString(
-  payload: string | Uint8Array | ArrayBuffer | Record<string, unknown> | unknown,
+  payload:
+    | string
+    | Uint8Array
+    | ArrayBuffer
+    | Record<string, unknown>
+    | unknown,
 ): string {
   if (typeof payload === 'string') {
     return payload;

--- a/src/common/crypto/signature-provider.ts
+++ b/src/common/crypto/signature-provider.ts
@@ -1,6 +1,7 @@
 // @oagen-ignore-file
 import { SignatureVerificationException } from '../exceptions';
 import { CryptoProvider } from './crypto-provider';
+import { type WebhookPayload, decodePayloadToString } from './decode-payload';
 
 export class SignatureProvider {
   private cryptoProvider: CryptoProvider;
@@ -15,16 +16,7 @@ export class SignatureProvider {
     secret,
     tolerance = 180000,
   }: {
-    // Accepts raw request bytes (string/Uint8Array/Buffer) — preferred — or a
-    // parsed object for back-compat. Raw-bytes path HMACs the exact bytes the
-    // server signed; object path falls back to JSON.stringify (unsafe to
-    // mutation that round-trips through JSON.parse → JSON.stringify).
-    payload:
-      | string
-      | Uint8Array
-      | ArrayBuffer
-      | Record<string, unknown>
-      | unknown;
+    payload: WebhookPayload;
     sigHeader: string;
     secret: string;
     tolerance?: number;
@@ -72,15 +64,10 @@ export class SignatureProvider {
 
   async computeSignature(
     timestamp: any,
-    payload:
-      | string
-      | Uint8Array
-      | ArrayBuffer
-      | Record<string, unknown>
-      | unknown,
+    payload: WebhookPayload,
     secret: string,
   ): Promise<string> {
-    const signable = toSignableString(payload);
+    const signable = decodePayloadToString(payload);
     const signedPayload = `${timestamp}.${signable}`;
 
     return await this.cryptoProvider.computeHMACSignatureAsync(
@@ -88,31 +75,4 @@ export class SignatureProvider {
       secret,
     );
   }
-}
-
-// Raw bytes path (string / Uint8Array / ArrayBuffer) reproduces the exact
-// bytes WorkOS signed on emit. Object path is legacy back-compat — vulnerable
-// to any on-the-wire mutation that round-trips through JSON.parse →
-// JSON.stringify to the same canonical form (whitespace, key order, \uXXXX
-// escapes, duplicate keys).
-function toSignableString(
-  payload:
-    | string
-    | Uint8Array
-    | ArrayBuffer
-    | Record<string, unknown>
-    | unknown,
-): string {
-  if (typeof payload === 'string') {
-    return payload;
-  }
-  if (payload instanceof Uint8Array) {
-    return new TextDecoder('utf-8', { ignoreBOM: true }).decode(payload);
-  }
-  if (payload instanceof ArrayBuffer) {
-    return new TextDecoder('utf-8', { ignoreBOM: true }).decode(
-      new Uint8Array(payload),
-    );
-  }
-  return JSON.stringify(payload);
 }

--- a/src/common/crypto/signature-provider.ts
+++ b/src/common/crypto/signature-provider.ts
@@ -15,7 +15,16 @@ export class SignatureProvider {
     secret,
     tolerance = 180000,
   }: {
-    payload: any;
+    // Accepts raw request bytes (string/Uint8Array/Buffer) — preferred — or a
+    // parsed object for back-compat. Raw-bytes path HMACs the exact bytes the
+    // server signed; object path falls back to JSON.stringify (unsafe to
+    // mutation that round-trips through JSON.parse → JSON.stringify).
+    payload:
+      | string
+      | Uint8Array
+      | ArrayBuffer
+      | Record<string, unknown>
+      | unknown;
     sigHeader: string;
     secret: string;
     tolerance?: number;
@@ -63,15 +72,35 @@ export class SignatureProvider {
 
   async computeSignature(
     timestamp: any,
-    payload: any,
+    payload: string | Uint8Array | ArrayBuffer | Record<string, unknown> | unknown,
     secret: string,
   ): Promise<string> {
-    payload = JSON.stringify(payload);
-    const signedPayload = `${timestamp}.${payload}`;
+    const signable = toSignableString(payload);
+    const signedPayload = `${timestamp}.${signable}`;
 
     return await this.cryptoProvider.computeHMACSignatureAsync(
       signedPayload,
       secret,
     );
   }
+}
+
+// Raw bytes path (string / Uint8Array / ArrayBuffer) reproduces the exact
+// bytes WorkOS signed on emit. Object path is legacy back-compat — vulnerable
+// to any on-the-wire mutation that round-trips through JSON.parse →
+// JSON.stringify to the same canonical form (whitespace, key order, \uXXXX
+// escapes, duplicate keys).
+function toSignableString(
+  payload: string | Uint8Array | ArrayBuffer | Record<string, unknown> | unknown,
+): string {
+  if (typeof payload === 'string') {
+    return payload;
+  }
+  if (payload instanceof Uint8Array) {
+    return new TextDecoder('utf-8').decode(payload);
+  }
+  if (payload instanceof ArrayBuffer) {
+    return new TextDecoder('utf-8').decode(new Uint8Array(payload));
+  }
+  return JSON.stringify(payload);
 }

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -319,6 +319,25 @@ describe('Webhooks', () => {
       ).rejects.toThrow(SignatureVerificationException);
     });
 
+    it('rejects Buffer with a prepended UTF-8 BOM', async () => {
+      const signedBytes = JSON.stringify(mockWebhook);
+      const bomBuffer = Buffer.concat([
+        Buffer.from([0xef, 0xbb, 0xbf]),
+        Buffer.from(signedBytes, 'utf-8'),
+      ]);
+
+      const hash = signRaw(signedBytes, timestamp, secret);
+      const sigHeader = `t=${timestamp}, v1=${hash}`;
+
+      await expect(
+        workos.webhooks.constructEvent({
+          payload: bomBuffer,
+          sigHeader,
+          secret,
+        }),
+      ).rejects.toThrow(SignatureVerificationException);
+    });
+
     it('legacy object path still verifies (back-compat)', async () => {
       // Existing caller shape: pre-parsed object, SDK re-stringifies internally.
       // Unsafe to byte-level mutation but must keep working until we deprecate.

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -210,4 +210,128 @@ describe('Webhooks', () => {
       expect(spy).toHaveBeenCalled();
     });
   });
+
+  describe('raw-bytes payload path (non-breaking overload)', () => {
+    // Sign the exact bytes WorkOS would send on the wire. The SDK should HMAC
+    // those same bytes (not a re-stringified round-trip), matching the pattern
+    // used by Stripe, GitHub, and Svix.
+    const signRaw = (rawBody: string, ts: number, sec: string): string =>
+      crypto
+        .createHmac('sha256', sec)
+        .update(`${ts}.${rawBody}`)
+        .digest('hex');
+
+    it('verifies when payload is a raw JSON string matching the signed bytes', async () => {
+      const rawBody = JSON.stringify(mockWebhook);
+      const hash = signRaw(rawBody, timestamp, secret);
+      const sigHeader = `t=${timestamp}, v1=${hash}`;
+
+      const webhook = await workos.webhooks.constructEvent({
+        payload: rawBody,
+        sigHeader,
+        secret,
+      });
+
+      expect(webhook.id).toEqual('wh_123');
+    });
+
+    it('verifies when payload is a Buffer matching the signed bytes', async () => {
+      const rawBody = JSON.stringify(mockWebhook);
+      const hash = signRaw(rawBody, timestamp, secret);
+      const sigHeader = `t=${timestamp}, v1=${hash}`;
+
+      const webhook = await workos.webhooks.constructEvent({
+        payload: Buffer.from(rawBody, 'utf-8'),
+        sigHeader,
+        secret,
+      });
+
+      expect(webhook.id).toEqual('wh_123');
+    });
+
+    it('verifies when payload is a Uint8Array matching the signed bytes', async () => {
+      const rawBody = JSON.stringify(mockWebhook);
+      const hash = signRaw(rawBody, timestamp, secret);
+      const sigHeader = `t=${timestamp}, v1=${hash}`;
+      const bytes = new TextEncoder().encode(rawBody);
+
+      const webhook = await workos.webhooks.constructEvent({
+        payload: bytes,
+        sigHeader,
+        secret,
+      });
+
+      expect(webhook.id).toEqual('wh_123');
+    });
+
+    it('rejects mutated bytes that round-trip through JSON.parse to the same object (whitespace)', async () => {
+      // Server signs canonical bytes; attacker forwards bytes with injected
+      // whitespace that parse to the same object.
+      const signedBytes = JSON.stringify(mockWebhook);
+      const mutatedBytes = JSON.stringify(mockWebhook, null, 2); // pretty-printed
+      expect(JSON.parse(signedBytes)).toEqual(JSON.parse(mutatedBytes));
+      expect(signedBytes).not.toEqual(mutatedBytes);
+
+      const hash = signRaw(signedBytes, timestamp, secret);
+      const sigHeader = `t=${timestamp}, v1=${hash}`;
+
+      await expect(
+        workos.webhooks.constructEvent({
+          payload: mutatedBytes,
+          sigHeader,
+          secret,
+        }),
+      ).rejects.toThrow(SignatureVerificationException);
+    });
+
+    it('rejects mutated bytes with unicode-escaped characters (same parsed object)', async () => {
+      const signedBytes = '{"event":"dsync.user.created","data":{"name":"hello"}}';
+      // hello parses to "hello" — same object, different bytes
+      const mutatedBytes =
+        '{"event":"dsync.user.created","data":{"name":"\\u0068\\u0065\\u006c\\u006c\\u006f"}}';
+      expect(JSON.parse(signedBytes)).toEqual(JSON.parse(mutatedBytes));
+      expect(signedBytes).not.toEqual(mutatedBytes);
+
+      const hash = signRaw(signedBytes, timestamp, secret);
+      const sigHeader = `t=${timestamp}, v1=${hash}`;
+
+      await expect(
+        workos.webhooks.constructEvent({
+          payload: mutatedBytes,
+          sigHeader,
+          secret,
+        }),
+      ).rejects.toThrow(SignatureVerificationException);
+    });
+
+    it('rejects mutated bytes with reordered keys (same parsed object)', async () => {
+      const signedBytes = '{"a":1,"b":2}';
+      const mutatedBytes = '{"b":2,"a":1}';
+      expect(JSON.parse(signedBytes)).toEqual(JSON.parse(mutatedBytes));
+
+      const hash = signRaw(signedBytes, timestamp, secret);
+      const sigHeader = `t=${timestamp}, v1=${hash}`;
+
+      await expect(
+        workos.webhooks.verifyHeader({
+          payload: mutatedBytes,
+          sigHeader,
+          secret,
+        }),
+      ).rejects.toThrow(SignatureVerificationException);
+    });
+
+    it('legacy object path still verifies (back-compat)', async () => {
+      // Existing caller shape: pre-parsed object, SDK re-stringifies internally.
+      // Unsafe to byte-level mutation but must keep working until we deprecate.
+      const sigHeader = `t=${timestamp}, v1=${signatureHash}`;
+      const webhook = await workos.webhooks.constructEvent({
+        payload: mockWebhook as unknown as Record<string, unknown>,
+        sigHeader,
+        secret,
+      });
+
+      expect(webhook.id).toEqual('wh_123');
+    });
+  });
 });

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -261,6 +261,25 @@ describe('Webhooks', () => {
       expect(webhook.id).toEqual('wh_123');
     });
 
+    it('verifies when payload is an ArrayBuffer matching the signed bytes', async () => {
+      const rawBody = JSON.stringify(mockWebhook);
+      const hash = signRaw(rawBody, timestamp, secret);
+      const sigHeader = `t=${timestamp}, v1=${hash}`;
+      const bytes = new TextEncoder().encode(rawBody);
+      const arrayBuffer = bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      );
+
+      const webhook = await workos.webhooks.constructEvent({
+        payload: arrayBuffer,
+        sigHeader,
+        secret,
+      });
+
+      expect(webhook.id).toEqual('wh_123');
+    });
+
     it('rejects mutated bytes that round-trip through JSON.parse to the same object (whitespace)', async () => {
       // Server signs canonical bytes; attacker forwards bytes with injected
       // whitespace that parse to the same object.

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -216,10 +216,7 @@ describe('Webhooks', () => {
     // those same bytes (not a re-stringified round-trip), matching the pattern
     // used by Stripe, GitHub, and Svix.
     const signRaw = (rawBody: string, ts: number, sec: string): string =>
-      crypto
-        .createHmac('sha256', sec)
-        .update(`${ts}.${rawBody}`)
-        .digest('hex');
+      crypto.createHmac('sha256', sec).update(`${ts}.${rawBody}`).digest('hex');
 
     it('verifies when payload is a raw JSON string matching the signed bytes', async () => {
       const rawBody = JSON.stringify(mockWebhook);
@@ -285,7 +282,8 @@ describe('Webhooks', () => {
     });
 
     it('rejects mutated bytes with unicode-escaped characters (same parsed object)', async () => {
-      const signedBytes = '{"event":"dsync.user.created","data":{"name":"hello"}}';
+      const signedBytes =
+        '{"event":"dsync.user.created","data":{"name":"hello"}}';
       // hello parses to "hello" — same object, different bytes
       const mutatedBytes =
         '{"event":"dsync.user.created","data":{"name":"\\u0068\\u0065\\u006c\\u006c\\u006f"}}';

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -11,7 +11,11 @@ import {
 // Parse only after verification succeeds — a malformed body never reaches
 // JSON.parse on an unauthenticated request.
 function parseVerifiedPayload(payload: WebhookPayload): EventResponse {
-  if (typeof payload === 'object' && !(payload instanceof Uint8Array) && !(payload instanceof ArrayBuffer)) {
+  if (
+    typeof payload === 'object' &&
+    !(payload instanceof Uint8Array) &&
+    !(payload instanceof ArrayBuffer)
+  ) {
     return payload as unknown as EventResponse;
   }
   return JSON.parse(decodePayloadToString(payload)) as EventResponse;

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -3,28 +3,18 @@ import { deserializeEvent } from '../common/serializers';
 import { Event, EventResponse } from '../common/interfaces';
 import { SignatureProvider } from '../common/crypto/signature-provider';
 import { CryptoProvider } from '../common/crypto/crypto-provider';
+import {
+  type WebhookPayload,
+  decodePayloadToString,
+} from '../common/crypto/decode-payload';
 
 // Parse only after verification succeeds — a malformed body never reaches
 // JSON.parse on an unauthenticated request.
-function parseVerifiedPayload(
-  payload: string | Uint8Array | ArrayBuffer | Record<string, unknown>,
-): EventResponse {
-  if (typeof payload === 'string') {
-    return JSON.parse(payload) as EventResponse;
+function parseVerifiedPayload(payload: WebhookPayload): EventResponse {
+  if (typeof payload === 'object' && !(payload instanceof Uint8Array) && !(payload instanceof ArrayBuffer)) {
+    return payload as unknown as EventResponse;
   }
-  if (payload instanceof Uint8Array) {
-    return JSON.parse(
-      new TextDecoder('utf-8', { ignoreBOM: true }).decode(payload),
-    ) as EventResponse;
-  }
-  if (payload instanceof ArrayBuffer) {
-    return JSON.parse(
-      new TextDecoder('utf-8', { ignoreBOM: true }).decode(
-        new Uint8Array(payload),
-      ),
-    ) as EventResponse;
-  }
-  return payload as unknown as EventResponse;
+  return JSON.parse(decodePayloadToString(payload)) as EventResponse;
 }
 
 export class Webhooks {
@@ -54,11 +44,7 @@ export class Webhooks {
     secret,
     tolerance = 180000,
   }: {
-    // Prefer raw request bytes (string / Uint8Array / Buffer / ArrayBuffer) so
-    // the HMAC is computed over the exact bytes WorkOS signed. Parsed objects
-    // are still accepted for back-compat but fall through a JSON.stringify
-    // round-trip that can disagree with the on-the-wire bytes.
-    payload: string | Uint8Array | ArrayBuffer | Record<string, unknown>;
+    payload: WebhookPayload;
     sigHeader: string;
     secret: string;
     tolerance?: number;

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -6,16 +6,13 @@ import { CryptoProvider } from '../common/crypto/crypto-provider';
 import {
   type WebhookPayload,
   decodePayloadToString,
+  isBinaryPayload,
 } from '../common/crypto/decode-payload';
 
 // Parse only after verification succeeds — a malformed body never reaches
 // JSON.parse on an unauthenticated request.
 function parseVerifiedPayload(payload: WebhookPayload): EventResponse {
-  if (
-    typeof payload === 'object' &&
-    !(payload instanceof Uint8Array) &&
-    !(payload instanceof ArrayBuffer)
-  ) {
+  if (typeof payload === 'object' && !isBinaryPayload(payload)) {
     return payload as unknown as EventResponse;
   }
   return JSON.parse(decodePayloadToString(payload)) as EventResponse;

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -4,6 +4,25 @@ import { Event, EventResponse } from '../common/interfaces';
 import { SignatureProvider } from '../common/crypto/signature-provider';
 import { CryptoProvider } from '../common/crypto/crypto-provider';
 
+// Parse only after verification succeeds — a malformed body never reaches
+// JSON.parse on an unauthenticated request.
+function parseVerifiedPayload(
+  payload: string | Uint8Array | ArrayBuffer | Record<string, unknown>,
+): EventResponse {
+  if (typeof payload === 'string') {
+    return JSON.parse(payload) as EventResponse;
+  }
+  if (payload instanceof Uint8Array) {
+    return JSON.parse(new TextDecoder('utf-8').decode(payload)) as EventResponse;
+  }
+  if (payload instanceof ArrayBuffer) {
+    return JSON.parse(
+      new TextDecoder('utf-8').decode(new Uint8Array(payload)),
+    ) as EventResponse;
+  }
+  return payload as unknown as EventResponse;
+}
+
 export class Webhooks {
   private signatureProvider: SignatureProvider;
 
@@ -31,7 +50,15 @@ export class Webhooks {
     secret,
     tolerance = 180000,
   }: {
-    payload: Record<string, unknown>;
+    // Prefer raw request bytes (string / Uint8Array / Buffer / ArrayBuffer) so
+    // the HMAC is computed over the exact bytes WorkOS signed. Parsed objects
+    // are still accepted for back-compat but fall through a JSON.stringify
+    // round-trip that can disagree with the on-the-wire bytes.
+    payload:
+      | string
+      | Uint8Array
+      | ArrayBuffer
+      | Record<string, unknown>;
     sigHeader: string;
     secret: string;
     tolerance?: number;
@@ -39,7 +66,7 @@ export class Webhooks {
     const options = { payload, sigHeader, secret, tolerance };
     await this.verifyHeader(options);
 
-    const webhookPayload = payload as unknown as EventResponse;
+    const webhookPayload = parseVerifiedPayload(payload);
 
     return deserializeEvent(webhookPayload);
   }

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -13,7 +13,9 @@ function parseVerifiedPayload(
     return JSON.parse(payload) as EventResponse;
   }
   if (payload instanceof Uint8Array) {
-    return JSON.parse(new TextDecoder('utf-8').decode(payload)) as EventResponse;
+    return JSON.parse(
+      new TextDecoder('utf-8').decode(payload),
+    ) as EventResponse;
   }
   if (payload instanceof ArrayBuffer) {
     return JSON.parse(
@@ -54,11 +56,7 @@ export class Webhooks {
     // the HMAC is computed over the exact bytes WorkOS signed. Parsed objects
     // are still accepted for back-compat but fall through a JSON.stringify
     // round-trip that can disagree with the on-the-wire bytes.
-    payload:
-      | string
-      | Uint8Array
-      | ArrayBuffer
-      | Record<string, unknown>;
+    payload: string | Uint8Array | ArrayBuffer | Record<string, unknown>;
     sigHeader: string;
     secret: string;
     tolerance?: number;

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -14,12 +14,14 @@ function parseVerifiedPayload(
   }
   if (payload instanceof Uint8Array) {
     return JSON.parse(
-      new TextDecoder('utf-8').decode(payload),
+      new TextDecoder('utf-8', { ignoreBOM: true }).decode(payload),
     ) as EventResponse;
   }
   if (payload instanceof ArrayBuffer) {
     return JSON.parse(
-      new TextDecoder('utf-8').decode(new Uint8Array(payload)),
+      new TextDecoder('utf-8', { ignoreBOM: true }).decode(
+        new Uint8Array(payload),
+      ),
     ) as EventResponse;
   }
   return payload as unknown as EventResponse;


### PR DESCRIPTION
## Summary
- Widens `constructEvent` and `verifyHeader` payload type to accept `string | Uint8Array | ArrayBuffer` in addition to parsed objects
- Raw-bytes paths HMAC the exact bytes passed in; object path preserves existing `JSON.stringify` behavior for back-compat
- `constructEvent` parses after verification on raw-bytes paths
- Shared `decodePayloadToString` helper ensures signing and parsing always use identical decoding
- Uses realm-agnostic binary detection (`ArrayBuffer.isView` / `Object.prototype.toString.call`) instead of `instanceof` checks, so payloads from Workers, iframes, or VM contexts are handled correctly

## Test plan
- [x] Existing webhook tests pass (legacy object path)
- [x] New tests for raw string, Buffer, Uint8Array, and ArrayBuffer payloads
- [x] Divergence regression tests (whitespace, unicode escapes, key reordering, BOM injection)

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

WorkOS Docs webhook snippets need updating to pass raw request bodies instead of `JSON.parse`-ing before `constructEvent` (separate docs PR).

Link to Devin session: https://app.devin.ai/sessions/1170d117f26f431bbc866077728682f6
Requested by: @nicknisi