### PR TITLE
feat: Add resource role assignments methods

### DIFF
--- a/src/authorization/authorization.spec.ts
+++ b/src/authorization/authorization.spec.ts
@@ -1651,6 +1651,7 @@ describe('Authorization', () => {
       expect(result.data[0]).toMatchObject({
         object: 'role_assignment',
         id: 'role_assignment_01HXYZ123ABC456DEF789ABC',
+        organizationMembershipId: testOrgMembershipId,
         role: { slug: 'editor' },
         resource: {
           id: 'resource_01HXYZ123ABC456DEF789XYZ',
@@ -1739,6 +1740,170 @@ describe('Authorization', () => {
     });
   });
 
+  describe('listRoleAssignmentsForResource', () => {
+    it('lists role assignments for a resource by internal ID', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      const result = await workos.authorization.listRoleAssignmentsForResource({
+        resourceId: testResourceId,
+      });
+
+      expect(fetchURL()).toContain(
+        `/authorization/resources/${testResourceId}/role_assignments`,
+      );
+      expect(result.object).toEqual('list');
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        object: 'role_assignment',
+        id: 'role_assignment_01HXYZ123ABC456DEF789ABC',
+        organizationMembershipId: testOrgMembershipId,
+        role: { slug: 'editor' },
+        resource: {
+          id: 'resource_01HXYZ123ABC456DEF789XYZ',
+          externalId: 'doc-123',
+          resourceTypeSlug: 'document',
+        },
+        createdAt: '2024-01-15T09:30:00.000Z',
+        updatedAt: '2024-01-15T09:30:00.000Z',
+      });
+      expect(result.listMetadata).toEqual({
+        before: null,
+        after: 'role_assignment_01HXYZ123ABC456DEF789ABC',
+      });
+    });
+
+    it('passes pagination parameters', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      await workos.authorization.listRoleAssignmentsForResource({
+        resourceId: testResourceId,
+        limit: 10,
+        after: 'ra_cursor123',
+        order: 'desc',
+      });
+
+      expect(fetchSearchParams()).toEqual({
+        limit: '10',
+        after: 'ra_cursor123',
+        order: 'desc',
+      });
+    });
+
+    it('passes before pagination parameter', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      await workos.authorization.listRoleAssignmentsForResource({
+        resourceId: testResourceId,
+        limit: 10,
+        before: 'ra_cursor456',
+        order: 'asc',
+      });
+
+      expect(fetchSearchParams()).toEqual({
+        limit: '10',
+        before: 'ra_cursor456',
+        order: 'asc',
+      });
+    });
+
+    it('defaults to desc order when order is not specified', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      await workos.authorization.listRoleAssignmentsForResource({
+        resourceId: testResourceId,
+      });
+
+      expect(fetchSearchParams()).toMatchObject({
+        order: 'desc',
+      });
+    });
+  });
+
+  describe('listResourceRoleAssignments', () => {
+    it('lists role assignments for a resource by external ID', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      const result = await workos.authorization.listResourceRoleAssignments({
+        organizationId: testOrgId,
+        resourceTypeSlug: 'document',
+        externalId: 'doc-456',
+      });
+
+      expect(fetchURL()).toContain(
+        `/authorization/organizations/${testOrgId}/resources/document/doc-456/role_assignments`,
+      );
+      expect(result.object).toEqual('list');
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        object: 'role_assignment',
+        id: 'role_assignment_01HXYZ123ABC456DEF789ABC',
+        organizationMembershipId: testOrgMembershipId,
+        role: { slug: 'editor' },
+        resource: {
+          id: 'resource_01HXYZ123ABC456DEF789XYZ',
+          externalId: 'doc-123',
+          resourceTypeSlug: 'document',
+        },
+        createdAt: '2024-01-15T09:30:00.000Z',
+        updatedAt: '2024-01-15T09:30:00.000Z',
+      });
+      expect(result.listMetadata).toEqual({
+        before: null,
+        after: 'role_assignment_01HXYZ123ABC456DEF789ABC',
+      });
+    });
+
+    it('passes pagination parameters', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      await workos.authorization.listResourceRoleAssignments({
+        organizationId: testOrgId,
+        resourceTypeSlug: 'document',
+        externalId: 'doc-456',
+        limit: 10,
+        after: 'ra_cursor123',
+        order: 'desc',
+      });
+
+      expect(fetchSearchParams()).toEqual({
+        limit: '10',
+        after: 'ra_cursor123',
+        order: 'desc',
+      });
+    });
+
+    it('passes before cursor for backward pagination', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      await workos.authorization.listResourceRoleAssignments({
+        organizationId: testOrgId,
+        resourceTypeSlug: 'document',
+        externalId: 'doc-456',
+        before: 'ra_cursor789',
+        order: 'asc',
+      });
+
+      expect(fetchSearchParams()).toMatchObject({
+        before: 'ra_cursor789',
+        order: 'asc',
+      });
+    });
+
+    it('defaults to desc order when order is not specified', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      await workos.authorization.listResourceRoleAssignments({
+        organizationId: testOrgId,
+        resourceTypeSlug: 'document',
+        externalId: 'doc-456',
+      });
+
+      expect(fetchSearchParams()).toMatchObject({
+        order: 'desc',
+      });
+    });
+  });
+
   describe('assignRole', () => {
     it('assigns a role by resource ID', async () => {
       fetchOnce(roleAssignmentFixture, { status: 201 });
@@ -1759,6 +1924,7 @@ describe('Authorization', () => {
       expect(assignment).toMatchObject({
         object: 'role_assignment',
         id: 'role_assignment_01HXYZ123ABC456DEF789ABC',
+        organizationMembershipId: testOrgMembershipId,
         role: { slug: 'editor' },
         resource: {
           id: 'resource_01HXYZ123ABC456DEF789XYZ',

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -47,6 +47,8 @@ import {
   ListMembershipsForResourceByExternalIdOptions,
   ListMembershipsForResourceOptions,
   ListResourcesForMembershipOptions,
+  ListRoleAssignmentsForResourceOptions,
+  ListRoleAssignmentsForResourceByExternalIdOptions,
   ListEffectivePermissionsOptions,
   ListEffectivePermissionsByExternalIdOptions,
 } from './interfaces';
@@ -855,6 +857,91 @@ export class Authorization {
   ): Promise<AutoPaginatable<RoleAssignment>> {
     const { organizationMembershipId, ...queryOptions } = options;
     const endpoint = `/authorization/organization_memberships/${organizationMembershipId}/role_assignments`;
+    return new AutoPaginatable(
+      await fetchAndDeserialize<RoleAssignmentResponse, RoleAssignment>(
+        this.workos,
+        endpoint,
+        deserializeRoleAssignment,
+        queryOptions,
+      ),
+      (params) =>
+        fetchAndDeserialize<RoleAssignmentResponse, RoleAssignment>(
+          this.workos,
+          endpoint,
+          deserializeRoleAssignment,
+          params,
+        ),
+      queryOptions,
+    );
+  }
+
+  /**
+   * List role assignments for a resource
+   *
+   * List all role assignments granted on a resource. This returns every role assignment scoped to the resource, regardless of which organization membership received it.
+   * @param resourceId - The ID of the authorization resource.
+   *
+   * @example
+   * "authz_resource_01HXYZ123456789ABCDEFGHIJ"
+   *
+   * @param options - Pagination and filter options.
+   * @returns {Promise<AutoPaginatable<RoleAssignment>>}
+   * @throws 403 response from the API.
+   * @throws {NotFoundException} 404
+   */
+  async listRoleAssignmentsForResource(
+    options: ListRoleAssignmentsForResourceOptions,
+  ): Promise<AutoPaginatable<RoleAssignment>> {
+    const { resourceId, ...queryOptions } = options;
+    const endpoint = `/authorization/resources/${resourceId}/role_assignments`;
+    return new AutoPaginatable(
+      await fetchAndDeserialize<RoleAssignmentResponse, RoleAssignment>(
+        this.workos,
+        endpoint,
+        deserializeRoleAssignment,
+        queryOptions,
+      ),
+      (params) =>
+        fetchAndDeserialize<RoleAssignmentResponse, RoleAssignment>(
+          this.workos,
+          endpoint,
+          deserializeRoleAssignment,
+          params,
+        ),
+      queryOptions,
+    );
+  }
+
+  /**
+   * List role assignments for a resource by external ID
+   *
+   * List all role assignments granted on a resource identified by its external ID, organization, and resource type. This returns every role assignment scoped to the resource, regardless of which organization membership received it.
+   * @param organizationId - The ID of the organization that owns the resource.
+   *
+   * @example
+   * "org_01EHZNVPK3SFK441A1RGBFSHRT"
+   *
+   * @param resourceTypeSlug - The slug of the resource type this resource belongs to.
+   *
+   * @example
+   * "project"
+   *
+   * @param externalId - An identifier you provide to reference the resource in your system.
+   *
+   * @example
+   * "proj-456"
+   *
+   * @param options - Pagination and filter options.
+   * @returns {Promise<AutoPaginatable<RoleAssignment>>}
+   * @throws 403 response from the API.
+   * @throws {NotFoundException} 404
+   */
+  async listResourceRoleAssignments(
+    options: ListRoleAssignmentsForResourceByExternalIdOptions,
+  ): Promise<AutoPaginatable<RoleAssignment>> {
+    const { organizationId, resourceTypeSlug, externalId, ...queryOptions } =
+      options;
+    const endpoint = `/authorization/organizations/${organizationId}/resources/${resourceTypeSlug}/${externalId}/role_assignments`;
     return new AutoPaginatable(
       await fetchAndDeserialize<RoleAssignmentResponse, RoleAssignment>(
         this.workos,

--- a/src/authorization/fixtures/list-role-assignments.json
+++ b/src/authorization/fixtures/list-role-assignments.json
@@ -1,24 +1,24 @@
 {
-    "object": "list",
-    "data": [
-      {
-        "object": "role_assignment",
-        "id": "role_assignment_01HXYZ123ABC456DEF789ABC",
-        "organization_membership_id": "om_01HXYZ123ABC456DEF789ABC",
-        "role": {
-          "slug": "editor"
-        },
-        "resource": {
-          "id": "resource_01HXYZ123ABC456DEF789XYZ",
-          "external_id": "doc-123",
-          "resource_type_slug": "document"
-        },
-        "created_at": "2024-01-15T09:30:00.000Z",
-        "updated_at": "2024-01-15T09:30:00.000Z"
-      }
-    ],
-    "list_metadata": {
-      "before": null,
-      "after": "role_assignment_01HXYZ123ABC456DEF789ABC"
+  "object": "list",
+  "data": [
+    {
+      "object": "role_assignment",
+      "id": "role_assignment_01HXYZ123ABC456DEF789ABC",
+      "organization_membership_id": "om_01HXYZ123ABC456DEF789ABC",
+      "role": {
+        "slug": "editor"
+      },
+      "resource": {
+        "id": "resource_01HXYZ123ABC456DEF789XYZ",
+        "external_id": "doc-123",
+        "resource_type_slug": "document"
+      },
+      "created_at": "2024-01-15T09:30:00.000Z",
+      "updated_at": "2024-01-15T09:30:00.000Z"
     }
+  ],
+  "list_metadata": {
+    "before": null,
+    "after": "role_assignment_01HXYZ123ABC456DEF789ABC"
   }
+}

--- a/src/authorization/fixtures/list-role-assignments.json
+++ b/src/authorization/fixtures/list-role-assignments.json
@@ -4,6 +4,7 @@
       {
         "object": "role_assignment",
         "id": "role_assignment_01HXYZ123ABC456DEF789ABC",
+        "organization_membership_id": "om_01HXYZ123ABC456DEF789ABC",
         "role": {
           "slug": "editor"
         },

--- a/src/authorization/fixtures/role-assignment.json
+++ b/src/authorization/fixtures/role-assignment.json
@@ -1,6 +1,7 @@
 {
     "object": "role_assignment",
     "id": "role_assignment_01HXYZ123ABC456DEF789ABC",
+    "organization_membership_id": "om_01HXYZ123ABC456DEF789ABC",
     "role": {
       "slug": "editor"
     },

--- a/src/authorization/fixtures/role-assignment.json
+++ b/src/authorization/fixtures/role-assignment.json
@@ -1,15 +1,15 @@
 {
-    "object": "role_assignment",
-    "id": "role_assignment_01HXYZ123ABC456DEF789ABC",
-    "organization_membership_id": "om_01HXYZ123ABC456DEF789ABC",
-    "role": {
-      "slug": "editor"
-    },
-    "resource": {
-      "id": "resource_01HXYZ123ABC456DEF789XYZ",
-      "external_id": "doc-123",
-      "resource_type_slug": "document"
-    },
-    "created_at": "2024-01-15T09:30:00.000Z",
-    "updated_at": "2024-01-15T09:30:00.000Z"
-  }
+  "object": "role_assignment",
+  "id": "role_assignment_01HXYZ123ABC456DEF789ABC",
+  "organization_membership_id": "om_01HXYZ123ABC456DEF789ABC",
+  "role": {
+    "slug": "editor"
+  },
+  "resource": {
+    "id": "resource_01HXYZ123ABC456DEF789XYZ",
+    "external_id": "doc-123",
+    "resource_type_slug": "document"
+  },
+  "created_at": "2024-01-15T09:30:00.000Z",
+  "updated_at": "2024-01-15T09:30:00.000Z"
+}

--- a/src/authorization/interfaces/index.ts
+++ b/src/authorization/interfaces/index.ts
@@ -25,6 +25,8 @@ export * from './list-memberships-for-resource-options.interface';
 export * from './list-memberships-for-resource-by-external-id-options.interface';
 export * from './role-assignment.interface';
 export * from './list-role-assignments-options.interface';
+export * from './list-role-assignments-for-resource-options.interface';
+export * from './list-role-assignments-for-resource-by-external-id-options.interface';
 export * from './assign-role-options.interface';
 export * from './remove-role-options.interface';
 export * from './remove-role-assignment-options.interface';

--- a/src/authorization/interfaces/list-role-assignments-for-resource-by-external-id-options.interface.ts
+++ b/src/authorization/interfaces/list-role-assignments-for-resource-by-external-id-options.interface.ts
@@ -1,0 +1,8 @@
+import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
+
+export interface ListRoleAssignmentsForResourceByExternalIdOptions
+  extends PaginationOptions {
+  organizationId: string;
+  resourceTypeSlug: string;
+  externalId: string;
+}

--- a/src/authorization/interfaces/list-role-assignments-for-resource-by-external-id-options.interface.ts
+++ b/src/authorization/interfaces/list-role-assignments-for-resource-by-external-id-options.interface.ts
@@ -1,7 +1,6 @@
 import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
 
-export interface ListRoleAssignmentsForResourceByExternalIdOptions
-  extends PaginationOptions {
+export interface ListRoleAssignmentsForResourceByExternalIdOptions extends PaginationOptions {
   organizationId: string;
   resourceTypeSlug: string;
   externalId: string;

--- a/src/authorization/interfaces/list-role-assignments-for-resource-options.interface.ts
+++ b/src/authorization/interfaces/list-role-assignments-for-resource-options.interface.ts
@@ -1,0 +1,5 @@
+import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
+
+export interface ListRoleAssignmentsForResourceOptions extends PaginationOptions {
+  resourceId: string;
+}

--- a/src/authorization/interfaces/role-assignment.interface.ts
+++ b/src/authorization/interfaces/role-assignment.interface.ts
@@ -19,6 +19,8 @@ export interface RoleAssignment {
   object: 'role_assignment';
   /** Unique identifier of the role assignment. */
   id: string;
+  /** The ID of the organization membership the role is assigned to. */
+  organizationMembershipId: string;
   /** The role included in the assignment. */
   role: RoleAssignmentRole;
   /** The resource to which the role is assigned. */
@@ -32,6 +34,7 @@ export interface RoleAssignment {
 export interface RoleAssignmentResponse {
   object: 'role_assignment';
   id: string;
+  organization_membership_id: string;
   role: RoleAssignmentRole;
   resource: RoleAssignmentResourceResponse;
   created_at: string;

--- a/src/authorization/serializers/role-assignment.serializer.ts
+++ b/src/authorization/serializers/role-assignment.serializer.ts
@@ -8,6 +8,7 @@ export const deserializeRoleAssignment = (
 ): RoleAssignment => ({
   object: response.object,
   id: response.id,
+  organizationMembershipId: response.organization_membership_id,
   role: response.role,
   resource: {
     id: response.resource.id,


### PR DESCRIPTION
## Description
Adds two new methods on `Authorization` for listing every role assignment granted on a resource.
- `GET /authorization/resources/:resource_id/role_assignments`
- `GET /authorization/organizations/:organization_id/resources/:resource_type_slug/:external_id/role_assignments`
Both return the same shape as `listOrganizationMembershipRoleAssignments`. The `RoleAssignment` response object now also includes `organizationMembershipId` so callers can identify the membership a given assignment belongs to without an extra lookup.
## Changes
- `Authorization.listRoleAssignmentsForResource(options)` — lists role assignments by internal `resourceId`, supports pagination.
- `Authorization.listResourceRoleAssignments(options)` — lists role assignments by `organizationId` + `resourceTypeSlug` + `externalId`, supports pagination.
- Added `organizationMembershipId` to `RoleAssignment` (and `organization_membership_id` to `RoleAssignmentResponse`) and updated `deserializeRoleAssignment` to map it.
- Added `ListRoleAssignmentsForResourceOptions` and `ListRoleAssignmentsForResourceByExternalIdOptions` interfaces.
- Updated `role-assignment.json` and `list-role-assignments.json` fixtures with the new field.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/workos-node/pull/1580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new role-assignment listing methods: by resource ID and by organization + external resource ID. Both support cursor-based pagination.
  * Role assignment objects now include organization membership ID.

* **Tests**
  * Expanded test coverage for the new listing methods, validating returned list structure, organization membership ID presence, and pagination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->