### PR TITLE
feat: Add resource and role_slug filter params to list role assignments

### DIFF
--- a/src/authorization/authorization.spec.ts
+++ b/src/authorization/authorization.spec.ts
@@ -1739,6 +1739,47 @@ describe('Authorization', () => {
         order: 'desc',
       });
     });
+
+    it('filters by resource id', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      await workos.authorization.listRoleAssignments({
+        organizationMembershipId: testOrgMembershipId,
+        resourceId: testResourceId,
+      });
+
+      expect(fetchSearchParams()).toMatchObject({
+        resource_id: testResourceId,
+      });
+    });
+
+    it('filters by resource external id and resource type slug', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      await workos.authorization.listRoleAssignments({
+        organizationMembershipId: testOrgMembershipId,
+        resourceExternalId: 'doc-456',
+        resourceTypeSlug: 'document',
+      });
+
+      expect(fetchSearchParams()).toMatchObject({
+        resource_external_id: 'doc-456',
+        resource_type_slug: 'document',
+      });
+    });
+
+    it('filters by resource type slug only', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      await workos.authorization.listRoleAssignments({
+        organizationMembershipId: testOrgMembershipId,
+        resourceTypeSlug: 'document',
+      });
+
+      expect(fetchSearchParams()).toMatchObject({
+        resource_type_slug: 'document',
+      });
+    });
   });
 
   describe('listRoleAssignmentsForResource', () => {
@@ -1816,6 +1857,19 @@ describe('Authorization', () => {
 
       expect(fetchSearchParams()).toMatchObject({
         order: 'desc',
+      });
+    });
+
+    it('filters by role slug', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      await workos.authorization.listRoleAssignmentsForResource({
+        resourceId: testResourceId,
+        roleSlug: 'editor',
+      });
+
+      expect(fetchSearchParams()).toMatchObject({
+        role_slug: 'editor',
       });
     });
   });
@@ -1901,6 +1955,21 @@ describe('Authorization', () => {
 
       expect(fetchSearchParams()).toMatchObject({
         order: 'desc',
+      });
+    });
+
+    it('filters by role slug', async () => {
+      fetchOnce(listRoleAssignmentsFixture);
+
+      await workos.authorization.listResourceRoleAssignments({
+        organizationId: testOrgId,
+        resourceTypeSlug: 'document',
+        externalId: 'doc-456',
+        roleSlug: 'editor',
+      });
+
+      expect(fetchSearchParams()).toMatchObject({
+        role_slug: 'editor',
       });
     });
   });

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -75,6 +75,8 @@ import {
   serializeListMembershipsForResourceOptions,
   serializeListResourcesForMembershipOptions,
   serializeListEffectivePermissionsOptions,
+  serializeListRoleAssignmentsOptions,
+  serializeListRoleAssignmentsForResourceOptions,
 } from './serializers';
 import {
   AuthorizationOrganizationMembership,
@@ -857,12 +859,13 @@ export class Authorization {
   ): Promise<AutoPaginatable<RoleAssignment>> {
     const { organizationMembershipId, ...queryOptions } = options;
     const endpoint = `/authorization/organization_memberships/${organizationMembershipId}/role_assignments`;
+    const serializedOptions = serializeListRoleAssignmentsOptions(queryOptions);
     return new AutoPaginatable(
       await fetchAndDeserialize<RoleAssignmentResponse, RoleAssignment>(
         this.workos,
         endpoint,
         deserializeRoleAssignment,
-        queryOptions,
+        serializedOptions,
       ),
       (params) =>
         fetchAndDeserialize<RoleAssignmentResponse, RoleAssignment>(
@@ -871,7 +874,7 @@ export class Authorization {
           deserializeRoleAssignment,
           params,
         ),
-      queryOptions,
+      serializedOptions,
     );
   }
 
@@ -894,12 +897,14 @@ export class Authorization {
   ): Promise<AutoPaginatable<RoleAssignment>> {
     const { resourceId, ...queryOptions } = options;
     const endpoint = `/authorization/resources/${resourceId}/role_assignments`;
+    const serializedOptions =
+      serializeListRoleAssignmentsForResourceOptions(queryOptions);
     return new AutoPaginatable(
       await fetchAndDeserialize<RoleAssignmentResponse, RoleAssignment>(
         this.workos,
         endpoint,
         deserializeRoleAssignment,
-        queryOptions,
+        serializedOptions,
       ),
       (params) =>
         fetchAndDeserialize<RoleAssignmentResponse, RoleAssignment>(
@@ -908,7 +913,7 @@ export class Authorization {
           deserializeRoleAssignment,
           params,
         ),
-      queryOptions,
+      serializedOptions,
     );
   }
 
@@ -942,12 +947,14 @@ export class Authorization {
     const { organizationId, resourceTypeSlug, externalId, ...queryOptions } =
       options;
     const endpoint = `/authorization/organizations/${organizationId}/resources/${resourceTypeSlug}/${externalId}/role_assignments`;
+    const serializedOptions =
+      serializeListRoleAssignmentsForResourceOptions(queryOptions);
     return new AutoPaginatable(
       await fetchAndDeserialize<RoleAssignmentResponse, RoleAssignment>(
         this.workos,
         endpoint,
         deserializeRoleAssignment,
-        queryOptions,
+        serializedOptions,
       ),
       (params) =>
         fetchAndDeserialize<RoleAssignmentResponse, RoleAssignment>(
@@ -956,7 +963,7 @@ export class Authorization {
           deserializeRoleAssignment,
           params,
         ),
-      queryOptions,
+      serializedOptions,
     );
   }
 

--- a/src/authorization/interfaces/list-role-assignments-for-resource-by-external-id-options.interface.ts
+++ b/src/authorization/interfaces/list-role-assignments-for-resource-by-external-id-options.interface.ts
@@ -1,7 +1,10 @@
 import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
 
-export interface ListRoleAssignmentsForResourceByExternalIdOptions extends PaginationOptions {
+export interface ListRoleAssignmentsForResourceByExternalIdOptions
+  extends PaginationOptions {
   organizationId: string;
   resourceTypeSlug: string;
   externalId: string;
+  /** Filter role assignments to only those that grant this role. */
+  roleSlug?: string;
 }

--- a/src/authorization/interfaces/list-role-assignments-for-resource-by-external-id-options.interface.ts
+++ b/src/authorization/interfaces/list-role-assignments-for-resource-by-external-id-options.interface.ts
@@ -1,7 +1,6 @@
 import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
 
-export interface ListRoleAssignmentsForResourceByExternalIdOptions
-  extends PaginationOptions {
+export interface ListRoleAssignmentsForResourceByExternalIdOptions extends PaginationOptions {
   organizationId: string;
   resourceTypeSlug: string;
   externalId: string;

--- a/src/authorization/interfaces/list-role-assignments-for-resource-options.interface.ts
+++ b/src/authorization/interfaces/list-role-assignments-for-resource-options.interface.ts
@@ -6,7 +6,6 @@ export interface ListRoleAssignmentsForResourceOptions extends PaginationOptions
   roleSlug?: string;
 }
 
-export interface SerializedListRoleAssignmentsForResourceOptions
-  extends PaginationOptions {
+export interface SerializedListRoleAssignmentsForResourceOptions extends PaginationOptions {
   role_slug?: string;
 }

--- a/src/authorization/interfaces/list-role-assignments-for-resource-options.interface.ts
+++ b/src/authorization/interfaces/list-role-assignments-for-resource-options.interface.ts
@@ -2,4 +2,11 @@ import { PaginationOptions } from '../../common/interfaces/pagination-options.in
 
 export interface ListRoleAssignmentsForResourceOptions extends PaginationOptions {
   resourceId: string;
+  /** Filter role assignments to only those that grant this role. */
+  roleSlug?: string;
+}
+
+export interface SerializedListRoleAssignmentsForResourceOptions
+  extends PaginationOptions {
+  role_slug?: string;
 }

--- a/src/authorization/interfaces/list-role-assignments-options.interface.ts
+++ b/src/authorization/interfaces/list-role-assignments-options.interface.ts
@@ -1,4 +1,17 @@
 import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
+
 export interface ListRoleAssignmentsOptions extends PaginationOptions {
   organizationMembershipId: string;
+  /** Filter role assignments to only those granted on the resource with this ID. */
+  resourceId?: string;
+  /** Filter role assignments to only those granted on the resource with this external ID. Can be used on its own or combined with `resourceTypeSlug`. */
+  resourceExternalId?: string;
+  /** Filter role assignments to only those granted on resources of this type. Can be used on its own or combined with `resourceExternalId`. */
+  resourceTypeSlug?: string;
+}
+
+export interface SerializedListRoleAssignmentsOptions extends PaginationOptions {
+  resource_id?: string;
+  resource_external_id?: string;
+  resource_type_slug?: string;
 }

--- a/src/authorization/serializers/index.ts
+++ b/src/authorization/serializers/index.ts
@@ -16,6 +16,8 @@ export * from './authorization-check-options.serializer';
 export * from './list-resources-for-membership-options.serializer';
 export * from './list-memberships-for-resource-options.serializer';
 export * from './role-assignment.serializer';
+export * from './list-role-assignments-options.serializer';
+export * from './list-role-assignments-for-resource-options.serializer';
 export * from './assign-role-options.serializer';
 export * from './remove-role-options.serializer';
 export * from './list-effective-permissions-options.serializer';

--- a/src/authorization/serializers/list-role-assignments-for-resource-options.serializer.ts
+++ b/src/authorization/serializers/list-role-assignments-for-resource-options.serializer.ts
@@ -1,0 +1,14 @@
+import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
+import { serializePaginationOptions } from '../../common/serializers';
+import { SerializedListRoleAssignmentsForResourceOptions } from '../interfaces/list-role-assignments-for-resource-options.interface';
+
+interface ListRoleAssignmentsForResourceQueryOptions extends PaginationOptions {
+  roleSlug?: string;
+}
+
+export const serializeListRoleAssignmentsForResourceOptions = (
+  options: ListRoleAssignmentsForResourceQueryOptions,
+): SerializedListRoleAssignmentsForResourceOptions => ({
+  ...(options.roleSlug && { role_slug: options.roleSlug }),
+  ...serializePaginationOptions(options),
+});

--- a/src/authorization/serializers/list-role-assignments-options.serializer.ts
+++ b/src/authorization/serializers/list-role-assignments-options.serializer.ts
@@ -1,0 +1,18 @@
+import { serializePaginationOptions } from '../../common/serializers';
+import {
+  ListRoleAssignmentsOptions,
+  SerializedListRoleAssignmentsOptions,
+} from '../interfaces/list-role-assignments-options.interface';
+
+export const serializeListRoleAssignmentsOptions = (
+  options: Omit<ListRoleAssignmentsOptions, 'organizationMembershipId'>,
+): SerializedListRoleAssignmentsOptions => ({
+  ...(options.resourceId && { resource_id: options.resourceId }),
+  ...(options.resourceExternalId && {
+    resource_external_id: options.resourceExternalId,
+  }),
+  ...(options.resourceTypeSlug && {
+    resource_type_slug: options.resourceTypeSlug,
+  }),
+  ...serializePaginationOptions(options),
+});


### PR DESCRIPTION
## Description

Adds optional query filters to the authorization role-assignment listing endpoints, matching the new backend support:

+ `listRoleAssignments` (membership-scoped) gains `resourceId`, `resourceExternalId`, and `resourceTypeSlug` filters.
+ `listRoleAssignmentsForResource` and `listResourceRoleAssignments` (resource-scoped, by ID and by external ID respectively) gain a `roleSlug` filter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role-assignment listing APIs now support filtering by resource internal ID, resource external ID, resource type slug, and role slug.

* **Tests**
  * Added test coverage validating the new filtering options for role-assignment listing endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/workos/workos-node/pull/1585)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->