### PR TITLE
feat!: remove search param from listResources

### DIFF
--- a/src/authorization/authorization.spec.ts
+++ b/src/authorization/authorization.spec.ts
@@ -1265,19 +1265,6 @@ describe('Authorization', () => {
       });
     });
 
-    it('passes search filter', async () => {
-      fetchOnce(listResourcesFixture);
-
-      await workos.authorization.listResources({
-        search: 'Budget',
-      });
-
-      expect(fetchSearchParams()).toEqual({
-        search: 'Budget',
-        order: 'desc',
-      });
-    });
-
     it('defaults to desc order when order is not specified', async () => {
       fetchOnce(listResourcesFixture);
 

--- a/src/authorization/interfaces/list-authorization-resources-options.interface.ts
+++ b/src/authorization/interfaces/list-authorization-resources-options.interface.ts
@@ -6,7 +6,6 @@ export interface ListAuthorizationResourcesOptions extends PaginationOptions {
   parentResourceId?: string;
   parentResourceTypeSlug?: string;
   parentExternalId?: string;
-  search?: string;
 }
 
 export interface SerializedListAuthorizationResourcesOptions extends PaginationOptions {
@@ -15,5 +14,4 @@ export interface SerializedListAuthorizationResourcesOptions extends PaginationO
   parent_resource_id?: string;
   parent_resource_type_slug?: string;
   parent_external_id?: string;
-  search?: string;
 }

--- a/src/authorization/serializers/list-authorization-resources-options.serializer.ts
+++ b/src/authorization/serializers/list-authorization-resources-options.serializer.ts
@@ -22,6 +22,5 @@ export const serializeListAuthorizationResourcesOptions = (
   ...(options.parentExternalId && {
     parent_external_id: options.parentExternalId,
   }),
-  ...(options.search && { search: options.search }),
   ...serializePaginationOptions(options),
 });


### PR DESCRIPTION
Removing fuzzy `search` parameter due to no production usage and concerns of performance issues for customers with many resource instances.

## Summary
- Removes the `search` parameter from `ListAuthorizationResourcesOptions` and `SerializedListAuthorizationResourcesOptions` interfaces
- Removes the `search` serialization from `serializeListAuthorizationResourcesOptions`
- Removes the corresponding `'passes search filter'` test from the spec

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Existing `listResources` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

BREAKING CHANGE: search parameter removed from listResources