### PR TITLE
fix(renovate): explicitly enable minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,59 +1,6 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>workos/renovate-config"
-  ],
-  "dependencyDashboard": false,
-  "schedule": [
-    "on the 15th day of the month before 12pm"
-  ],
-  "timezone": "UTC",
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "automerge": true,
-      "groupName": "minor and patch updates",
-      "enabled": true
-    },
-    {
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "automerge": false
-    },
-    {
-      "matchUpdateTypes": [
-        "digest"
-      ],
-      "automerge": false
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "digest",
-        "pinDigest"
-      ],
-      "groupName": "github actions non-major",
-      "groupSlug": "github-actions-non-major",
-      "automerge": true
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "github actions major",
-      "groupSlug": "github-actions-major",
-      "automerge": false
-    }
+    "github>workos/renovate-config:public"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,8 @@
         "patch"
       ],
       "automerge": true,
-      "groupName": "minor and patch updates"
+      "groupName": "minor and patch updates",
+      "enabled": true
     },
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
## Summary

The shared `workos/renovate-config` preset now explicitly disables `major` and `minor` updates for non-github-actions managers to enforce a patch-only policy on the monorepo.

Renovate applies `packageRules` in order — preset rules first, then repo rules on top. Because the shared preset sets `enabled: false` for minor updates, and this repo's rule sets `automerge: true` but not `enabled: true`, minor updates would silently stop getting PRs.

## Fix

Add `"enabled": true` to the existing minor/patch rule so it explicitly re-enables minor updates after the shared preset disables them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency-management configuration to use the official public preset; several previously inlined top-level settings were removed from the local configuration.
  * No runtime or UI changes—this is an internal config update with no user-facing impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/workos/workos-node/pull/1598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->