### PR TITLE
fix(connect): Serialize pagination options for auto-pagination

### DIFF
--- a/src/connect/connect.ts
+++ b/src/connect/connect.ts
@@ -107,7 +107,6 @@ export class Connect {
   async listApplications(
     options?: ListApplicationsOptions,
   ): Promise<AutoPaginatable<ConnectApplication, ListApplicationsOptions>> {
-    const paginationOptions = options;
     return new AutoPaginatable(
       await fetchAndDeserialize<ConnectApplicationResponse, ConnectApplication>(
         this.workos,
@@ -122,7 +121,7 @@ export class Connect {
           deserializeConnectApplication,
           params,
         ),
-      paginationOptions,
+      options ? serializeListApplicationsOptions(options) : undefined,
     );
   }
 

--- a/src/connect/connect.ts
+++ b/src/connect/connect.ts
@@ -106,7 +106,7 @@ export class Connect {
    */
   async listApplications(
     options?: ListApplicationsOptions,
-  ): Promise<AutoPaginatable<ConnectApplication, ListApplicationsOptions>> {
+  ): Promise<AutoPaginatable<ConnectApplication, PaginationOptions>> {
     return new AutoPaginatable(
       await fetchAndDeserialize<ConnectApplicationResponse, ConnectApplication>(
         this.workos,


### PR DESCRIPTION
## Summary
- `listApplications` passed raw camelCase options to `AutoPaginatable`,
  so `generatePages` sent `organizationId` instead of `organization_id`
  on re-fetch — the API rejected it with a 422
- Same regression as #1459, reintroduced when the Connect module was
  generated in #1597
- The fix serializes options before passing them to `AutoPaginatable`
  so all subsequent page fetches use snake_case query params

## Test plan
- [x] `await workos.connect.listApplications({ organizationId: '...' }).then(r => r.autoPagination())` no longer throws 422
- [x] `bash scripts/ci` passes

Fixes #1600