### PR TITLE
feat(authkit): Add Radar fields to headless AuthKit methods

### DIFF
--- a/src/user-management/interfaces/authenticate-with-magic-auth-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-magic-auth-options.interface.ts
@@ -8,6 +8,7 @@ export interface AuthenticateWithMagicAuthOptions extends AuthenticateWithOption
   email: string;
   invitationToken?: string;
   linkAuthorizationCode?: string;
+  radarAuthAttemptId?: string;
 }
 
 export interface AuthenticateUserWithMagicAuthCredentials {
@@ -20,4 +21,5 @@ export interface SerializedAuthenticateWithMagicAuthOptions extends SerializedAu
   email: string;
   invitation_token?: string;
   link_authorization_code?: string;
+  radar_auth_attempt_id?: string;
 }

--- a/src/user-management/interfaces/authenticate-with-password-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-password-options.interface.ts
@@ -7,6 +7,7 @@ export interface AuthenticateWithPasswordOptions extends AuthenticateWithOptions
   email: string;
   password: string;
   invitationToken?: string;
+  radarAuthAttemptId?: string;
 }
 
 export interface AuthenticateUserWithPasswordCredentials {
@@ -18,4 +19,5 @@ export interface SerializedAuthenticateWithPasswordOptions extends SerializedAut
   email: string;
   password: string;
   invitation_token?: string;
+  radar_auth_attempt_id?: string;
 }

--- a/src/user-management/interfaces/create-magic-auth-options.interface.ts
+++ b/src/user-management/interfaces/create-magic-auth-options.interface.ts
@@ -1,9 +1,15 @@
 export interface CreateMagicAuthOptions {
   email: string;
   invitationToken?: string;
+  ipAddress?: string;
+  userAgent?: string;
+  radarAuthAttemptId?: string;
 }
 
 export interface SerializedCreateMagicAuthOptions {
   email: string;
   invitation_token?: string;
+  ip_address?: string;
+  user_agent?: string;
+  radar_auth_attempt_id?: string;
 }

--- a/src/user-management/interfaces/create-user-options.interface.ts
+++ b/src/user-management/interfaces/create-user-options.interface.ts
@@ -10,6 +10,8 @@ export interface CreateUserOptions {
   emailVerified?: boolean;
   externalId?: string;
   metadata?: Record<string, string>;
+  ipAddress?: string;
+  userAgent?: string;
 }
 
 export interface SerializedCreateUserOptions {
@@ -22,4 +24,6 @@ export interface SerializedCreateUserOptions {
   email_verified?: boolean;
   external_id?: string;
   metadata?: Record<string, string>;
+  ip_address?: string;
+  user_agent?: string;
 }

--- a/src/user-management/interfaces/magic-auth.interface.ts
+++ b/src/user-management/interfaces/magic-auth.interface.ts
@@ -38,6 +38,14 @@ export interface MagicAuthResponse {
   updated_at: string;
 }
 
+export interface CreateMagicAuthResponse extends MagicAuth {
+  radarAuthAttemptId?: string;
+}
+
+export interface CreateMagicAuthResponseResponse extends MagicAuthResponse {
+  radar_auth_attempt_id?: string;
+}
+
 export interface MagicAuthEventResponse {
   object: 'magic_auth';
   id: string;

--- a/src/user-management/interfaces/user.interface.ts
+++ b/src/user-management/interfaces/user.interface.ts
@@ -43,3 +43,11 @@ export interface UserResponse {
   external_id?: string;
   metadata?: Record<string, string>;
 }
+
+export interface CreateUserResponse extends User {
+  radarAuthAttemptId?: string;
+}
+
+export interface CreateUserResponseResponse extends UserResponse {
+  radar_auth_attempt_id?: string;
+}

--- a/src/user-management/serializers/authenticate-with-magic-auth-options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-magic-auth-options.serializer.ts
@@ -18,4 +18,5 @@ export const serializeAuthenticateWithMagicAuthOptions = (
   link_authorization_code: options.linkAuthorizationCode,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
+  radar_auth_attempt_id: options.radarAuthAttemptId,
 });

--- a/src/user-management/serializers/authenticate-with-password-options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-password-options.serializer.ts
@@ -17,4 +17,5 @@ export const serializeAuthenticateWithPasswordOptions = (
   invitation_token: options.invitationToken,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
+  radar_auth_attempt_id: options.radarAuthAttemptId,
 });

--- a/src/user-management/serializers/create-magic-auth-options.serializer.ts
+++ b/src/user-management/serializers/create-magic-auth-options.serializer.ts
@@ -8,4 +8,7 @@ export const serializeCreateMagicAuthOptions = (
 ): SerializedCreateMagicAuthOptions => ({
   email: options.email,
   invitation_token: options.invitationToken,
+  ip_address: options.ipAddress,
+  user_agent: options.userAgent,
+  radar_auth_attempt_id: options.radarAuthAttemptId,
 });

--- a/src/user-management/serializers/create-user-options.serializer.ts
+++ b/src/user-management/serializers/create-user-options.serializer.ts
@@ -12,4 +12,6 @@ export const serializeCreateUserOptions = (
   email_verified: options.emailVerified,
   external_id: options.externalId,
   metadata: options.metadata,
+  ip_address: options.ipAddress,
+  user_agent: options.userAgent,
 });

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -166,6 +166,44 @@ describe('UserManagement', () => {
         metadata: { key: 'value' },
       });
     });
+
+    it('sends ip_address and user_agent when provided', async () => {
+      fetchOnce(userFixture);
+
+      await workos.userManagement.createUser({
+        email: 'test01@example.com',
+        ipAddress: '203.0.113.42',
+        userAgent: 'Mozilla/5.0',
+      });
+
+      expect(fetchBody()).toMatchObject({
+        ip_address: '203.0.113.42',
+        user_agent: 'Mozilla/5.0',
+      });
+    });
+
+    it('returns radarAuthAttemptId when present in response', async () => {
+      fetchOnce({
+        ...userFixture,
+        radar_auth_attempt_id: 'radar_auth_attempt_01ABC',
+      });
+
+      const user = await workos.userManagement.createUser({
+        email: 'test01@example.com',
+      });
+
+      expect(user.radarAuthAttemptId).toBe('radar_auth_attempt_01ABC');
+    });
+
+    it('omits radarAuthAttemptId when not in response', async () => {
+      fetchOnce(userFixture);
+
+      const user = await workos.userManagement.createUser({
+        email: 'test01@example.com',
+      });
+
+      expect(user.radarAuthAttemptId).toBeUndefined();
+    });
   });
 
   describe('authenticateUserWithMagicAuth', () => {
@@ -183,6 +221,21 @@ describe('UserManagement', () => {
         user: {
           email: 'test01@example.com',
         },
+      });
+    });
+
+    it('sends radar_auth_attempt_id when provided', async () => {
+      fetchOnce({ user: userFixture });
+
+      await workos.userManagement.authenticateWithMagicAuth({
+        clientId: 'proj_whatever',
+        code: '123456',
+        email: userFixture.email,
+        radarAuthAttemptId: 'radar_auth_attempt_01ABC',
+      });
+
+      expect(fetchBody()).toMatchObject({
+        radar_auth_attempt_id: 'radar_auth_attempt_01ABC',
       });
     });
 
@@ -250,6 +303,21 @@ describe('UserManagement', () => {
         user: {
           email: 'test01@example.com',
         },
+      });
+    });
+
+    it('sends radar_auth_attempt_id when provided', async () => {
+      fetchOnce({ user: userFixture });
+
+      await workos.userManagement.authenticateWithPassword({
+        clientId: 'proj_whatever',
+        email: 'test01@example.com',
+        password: 'extra-secure',
+        radarAuthAttemptId: 'radar_auth_attempt_01ABC',
+      });
+
+      expect(fetchBody()).toMatchObject({
+        radar_auth_attempt_id: 'radar_auth_attempt_01ABC',
       });
     });
 
@@ -1521,6 +1589,46 @@ describe('UserManagement', () => {
         createdAt: '2023-07-18T02:07:19.911Z',
         updatedAt: '2023-07-18T02:07:19.911Z',
       });
+    });
+
+    it('sends ip_address, user_agent, and radar_auth_attempt_id when provided', async () => {
+      fetchOnce(magicAuthFixture);
+
+      await workos.userManagement.createMagicAuth({
+        email: 'bob.loblaw@example.com',
+        ipAddress: '203.0.113.42',
+        userAgent: 'Mozilla/5.0',
+        radarAuthAttemptId: 'radar_auth_attempt_01ABC',
+      });
+
+      expect(fetchBody()).toMatchObject({
+        ip_address: '203.0.113.42',
+        user_agent: 'Mozilla/5.0',
+        radar_auth_attempt_id: 'radar_auth_attempt_01ABC',
+      });
+    });
+
+    it('returns radarAuthAttemptId when present in response', async () => {
+      fetchOnce({
+        ...magicAuthFixture,
+        radar_auth_attempt_id: 'radar_auth_attempt_01ABC',
+      });
+
+      const response = await workos.userManagement.createMagicAuth({
+        email: 'bob.loblaw@example.com',
+      });
+
+      expect(response.radarAuthAttemptId).toBe('radar_auth_attempt_01ABC');
+    });
+
+    it('omits radarAuthAttemptId when not in response', async () => {
+      fetchOnce(magicAuthFixture);
+
+      const response = await workos.userManagement.createMagicAuth({
+        email: 'bob.loblaw@example.com',
+      });
+
+      expect(response.radarAuthAttemptId).toBeUndefined();
     });
   });
 

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -285,7 +285,7 @@ export class UserManagement {
    *
    * Create a new user in the current environment.
    * @param payload - Object containing email.
-   * @returns {Promise<User>}
+   * @returns {Promise<CreateUserResponse>}
    * @throws {BadRequestException} 400
    * @throws {NotFoundException} 404
    * @throws {UnprocessableEntityException} 422

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -15,8 +15,12 @@ import {
   AuthenticationResponse,
   AuthenticationResponseResponse,
   CreateMagicAuthOptions,
+  CreateMagicAuthResponse,
+  CreateMagicAuthResponseResponse,
   CreatePasswordResetOptions,
   CreateUserOptions,
+  CreateUserResponse,
+  CreateUserResponseResponse,
   EmailVerification,
   EmailVerificationResponse,
   ListSessionsOptions,
@@ -286,13 +290,19 @@ export class UserManagement {
    * @throws {NotFoundException} 404
    * @throws {UnprocessableEntityException} 422
    */
-  async createUser(payload: CreateUserOptions): Promise<User> {
+  async createUser(payload: CreateUserOptions): Promise<CreateUserResponse> {
     const { data } = await this.workos.post<
-      UserResponse,
+      CreateUserResponseResponse,
       SerializedCreateUserOptions
     >('/user_management/users', serializeCreateUserOptions(payload));
 
-    return deserializeUser(data);
+    const { radar_auth_attempt_id, ...userResponse } = data;
+    return {
+      ...deserializeUser(userResponse),
+      ...(radar_auth_attempt_id
+        ? { radarAuthAttemptId: radar_auth_attempt_id }
+        : undefined),
+    };
   }
 
   /** Authenticate with magic auth. */
@@ -784,9 +794,11 @@ export class UserManagement {
    * @throws {UnprocessableEntityException} 422
    * @throws {RateLimitExceededException} 429
    */
-  async createMagicAuth(options: CreateMagicAuthOptions): Promise<MagicAuth> {
+  async createMagicAuth(
+    options: CreateMagicAuthOptions,
+  ): Promise<CreateMagicAuthResponse> {
     const { data } = await this.workos.post<
-      MagicAuthResponse,
+      CreateMagicAuthResponseResponse,
       SerializedCreateMagicAuthOptions
     >(
       '/user_management/magic_auth',
@@ -795,7 +807,13 @@ export class UserManagement {
       }),
     );
 
-    return deserializeMagicAuth(data);
+    const { radar_auth_attempt_id, ...magicAuthResponse } = data;
+    return {
+      ...deserializeMagicAuth(magicAuthResponse),
+      ...(radar_auth_attempt_id
+        ? { radarAuthAttemptId: radar_auth_attempt_id }
+        : undefined),
+    };
   }
 
   /**

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -789,7 +789,7 @@ export class UserManagement {
    *
    * Creates a one-time authentication code that can be sent to the user's email address. The code expires in 10 minutes. To verify the code, [authenticate the user with Magic Auth](https://workos.com/docs/reference/authkit/authentication/magic-auth).
    * @param options - Object containing email.
-   * @returns {Promise<MagicAuth>}
+   * @returns {Promise<CreateMagicAuthResponse>}
    * @throws {BadRequestException} 400
    * @throws {UnprocessableEntityException} 422
    * @throws {RateLimitExceededException} 429


### PR DESCRIPTION
## Description

Add Radar-specific fields to 4 headless AuthKit SDK methods so the Node SDK can pass through Radar signals when the API-side feature flag (`radar-headless-authkit-enabled`) is active.

**Inputs added:**

| Method | New fields |
|---|---|
| `createUser` | `ipAddress`, `userAgent` |
| `createMagicAuth` | `ipAddress`, `userAgent`, `radarAuthAttemptId` |
| `authenticateWithPassword` | `radarAuthAttemptId` |
| `authenticateWithMagicAuth` | `radarAuthAttemptId` |

**Outputs added:**

| Method | New fields |
|---|---|
| `createUser` | `radarAuthAttemptId` (optional on `CreateUserResponse`) |
| `createMagicAuth` | `radarAuthAttemptId` (optional on `CreateMagicAuthResponse`) |

All new fields are optional — fully backwards compatible.

Fixes RDR-750

## Documentation

Will update soon - trying to validate API with customers before adding to OpenAPI spec.

API reference will need updates for the new optional fields on `createUser`, `createMagicAuth`, `authenticateWithPassword`, and `authenticateWithMagicAuth`.

Link to Devin session: https://app.devin.ai/sessions/cb2afda7b30f47098293d6b6747a4311
Requested by: @blairworkos