### PR TITLE
feat: Add widgets:pipes:manage to WidgetScope type

### DIFF
--- a/src/widgets/interfaces/get-token.ts
+++ b/src/widgets/interfaces/get-token.ts
@@ -4,7 +4,8 @@ export type WidgetScope =
   | 'widgets:domain-verification:manage'
   | 'widgets:dsync:manage'
   | 'widgets:api-keys:manage'
-  | 'widgets:audit-log-streaming:manage';
+  | 'widgets:audit-log-streaming:manage'
+  | 'widgets:pipes:manage';
 export interface GetTokenOptions {
   organizationId: string;
   userId?: string;


### PR DESCRIPTION
## Description

Add `widgets:pipes:manage` to the `WidgetScope` type to support the Pipes management widget scope.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

Link to Devin session: https://app.devin.ai/sessions/1aa6c55dd1334c63baef303ea0ebd7de
Requested by: @thompsongl