### PR TITLE
docs(events): note that GET /events silently ignores the `order` parameter

### DIFF
--- a/src/events/interfaces/list-events-options.interface.ts
+++ b/src/events/interfaces/list-events-options.interface.ts
@@ -10,7 +10,7 @@ export interface ListEventOptions {
   /**
    * As of 2026-06-11 the `GET /events` endpoint silently ignores this
    * parameter and always returns events oldest-first regardless of whether
-   * `asc`, `desc`, `normal`, or nothing is sent — see
+   * `asc`, `desc`, or nothing is sent — see
    * {@link https://github.com/workos/workos-node/issues/1610}. The SDK
    * continues to serialize the value on the wire so callers automatically
    * pick up the server-side fix when it lands; until then, treat the

--- a/src/events/interfaces/list-events-options.interface.ts
+++ b/src/events/interfaces/list-events-options.interface.ts
@@ -7,6 +7,16 @@ export interface ListEventOptions {
   limit?: number;
   after?: string;
   organizationId?: string;
+  /**
+   * As of 2026-06-11 the `GET /events` endpoint silently ignores this
+   * parameter and always returns events oldest-first regardless of whether
+   * `asc`, `desc`, `normal`, or nothing is sent — see
+   * {@link https://github.com/workos/workos-node/issues/1610}. The SDK
+   * continues to serialize the value on the wire so callers automatically
+   * pick up the server-side fix when it lands; until then, treat the
+   * response as ascending-by-`created_at` and seed cursor pagination from
+   * the oldest end of the stream.
+   */
   order?: 'asc' | 'desc';
 }
 

--- a/src/events/interfaces/list-events-options.interface.ts
+++ b/src/events/interfaces/list-events-options.interface.ts
@@ -27,5 +27,11 @@ export interface SerializedListEventOptions {
   limit?: number;
   after?: string;
   organization_id?: string;
+  /**
+   * Wire-layer mirror of {@link ListEventOptions.order}. The server-side bug
+   * lives at this layer: as of 2026-06-11 `GET /events?order=desc` returns
+   * events oldest-first regardless. See
+   * {@link https://github.com/workos/workos-node/issues/1610}.
+   */
   order?: 'asc' | 'desc';
 }


### PR DESCRIPTION
Refs #1610.

`ListEventOptions.order` was added in #1524 to match the published API reference, but the live `GET /events` endpoint silently ignores the parameter — every value (`asc`, `desc`, `normal`, omitted) returns byte-identical, oldest-first pages, verified with raw curl against a sandbox key on 2026-06-11. So this is a server-side bug, not an SDK serialization one. The consequence for SDK consumers is real: anyone who upgraded for #1524 to fetch the newest event with `order=desc&limit=1` silently gets the oldest event instead, with no error to root-cause from.

This PR adds a JSDoc annotation to the field pointing at #1610, explaining the current ascending behaviour and the cursor-pagination workaround. The wire format is unchanged — callers automatically pick up the server-side fix the moment it ships.

I'd rather not remove the field (that's a breaking change for downstream code that already passes the parameter through), and surfacing it at the type-system level seems like the lowest-friction way to make sure the next person reading intellisense for `listEvents` doesn't waste an afternoon debugging why their `desc` request comes back ascending. Happy to swap to a `@deprecated` tag instead if that's the maintainer preference.