### PR TITLE
feat: Add signalsId to user management APIs

### DIFF
--- a/src/user-management/interfaces/authenticate-with-code-and-verifier-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-code-and-verifier-options.interface.ts
@@ -7,6 +7,7 @@ export interface AuthenticateWithCodeAndVerifierOptions extends AuthenticateWith
   codeVerifier: string;
   code: string;
   invitationToken?: string;
+  signalsId?: string;
 }
 
 export interface SerializedAuthenticateWithCodeAndVerifierOptions extends SerializedAuthenticatePublicClientBase {
@@ -14,4 +15,5 @@ export interface SerializedAuthenticateWithCodeAndVerifierOptions extends Serial
   code_verifier: string;
   code: string;
   invitation_token?: string;
+  signals_id?: string;
 }

--- a/src/user-management/interfaces/authenticate-with-code-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-code-options.interface.ts
@@ -7,6 +7,7 @@ export interface AuthenticateWithCodeOptions extends AuthenticateWithOptionsBase
   codeVerifier?: string;
   code: string;
   invitationToken?: string;
+  signalsId?: string;
 }
 
 export interface AuthenticateUserWithCodeCredentials {
@@ -18,4 +19,5 @@ export interface SerializedAuthenticateWithCodeOptions extends SerializedAuthent
   code_verifier?: string;
   code: string;
   invitation_token?: string;
+  signals_id?: string;
 }

--- a/src/user-management/interfaces/authenticate-with-magic-auth-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-magic-auth-options.interface.ts
@@ -9,6 +9,7 @@ export interface AuthenticateWithMagicAuthOptions extends AuthenticateWithOption
   invitationToken?: string;
   linkAuthorizationCode?: string;
   radarAuthAttemptId?: string;
+  signalsId?: string;
 }
 
 export interface AuthenticateUserWithMagicAuthCredentials {
@@ -22,4 +23,5 @@ export interface SerializedAuthenticateWithMagicAuthOptions extends SerializedAu
   invitation_token?: string;
   link_authorization_code?: string;
   radar_auth_attempt_id?: string;
+  signals_id?: string;
 }

--- a/src/user-management/interfaces/authenticate-with-password-options.interface.ts
+++ b/src/user-management/interfaces/authenticate-with-password-options.interface.ts
@@ -8,6 +8,7 @@ export interface AuthenticateWithPasswordOptions extends AuthenticateWithOptions
   password: string;
   invitationToken?: string;
   radarAuthAttemptId?: string;
+  signalsId?: string;
 }
 
 export interface AuthenticateUserWithPasswordCredentials {
@@ -20,4 +21,5 @@ export interface SerializedAuthenticateWithPasswordOptions extends SerializedAut
   password: string;
   invitation_token?: string;
   radar_auth_attempt_id?: string;
+  signals_id?: string;
 }

--- a/src/user-management/interfaces/create-magic-auth-options.interface.ts
+++ b/src/user-management/interfaces/create-magic-auth-options.interface.ts
@@ -4,6 +4,7 @@ export interface CreateMagicAuthOptions {
   ipAddress?: string;
   userAgent?: string;
   radarAuthAttemptId?: string;
+  signalsId?: string;
 }
 
 export interface SerializedCreateMagicAuthOptions {
@@ -12,4 +13,5 @@ export interface SerializedCreateMagicAuthOptions {
   ip_address?: string;
   user_agent?: string;
   radar_auth_attempt_id?: string;
+  signals_id?: string;
 }

--- a/src/user-management/interfaces/create-user-options.interface.ts
+++ b/src/user-management/interfaces/create-user-options.interface.ts
@@ -13,6 +13,7 @@ export interface CreateUserOptions {
   metadata?: Record<string, string>;
   ipAddress?: string;
   userAgent?: string;
+  signalsId?: string;
 }
 
 export interface SerializedCreateUserOptions {
@@ -28,4 +29,5 @@ export interface SerializedCreateUserOptions {
   metadata?: Record<string, string>;
   ip_address?: string;
   user_agent?: string;
+  signals_id?: string;
 }

--- a/src/user-management/serializers/authenticate-with-code-and-verifier-options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-code-and-verifier-options.serializer.ts
@@ -14,4 +14,5 @@ export const serializeAuthenticateWithCodeAndVerifierOptions = (
   invitation_token: options.invitationToken,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
+  signals_id: options.signalsId,
 });

--- a/src/user-management/serializers/authenticate-with-code-options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-code-options.serializer.ts
@@ -17,4 +17,5 @@ export const serializeAuthenticateWithCodeOptions = (
   invitation_token: options.invitationToken,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
+  signals_id: options.signalsId,
 });

--- a/src/user-management/serializers/authenticate-with-magic-auth-options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-magic-auth-options.serializer.ts
@@ -19,4 +19,5 @@ export const serializeAuthenticateWithMagicAuthOptions = (
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
   radar_auth_attempt_id: options.radarAuthAttemptId,
+  signals_id: options.signalsId,
 });

--- a/src/user-management/serializers/authenticate-with-password-options.serializer.ts
+++ b/src/user-management/serializers/authenticate-with-password-options.serializer.ts
@@ -18,4 +18,5 @@ export const serializeAuthenticateWithPasswordOptions = (
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
   radar_auth_attempt_id: options.radarAuthAttemptId,
+  signals_id: options.signalsId,
 });

--- a/src/user-management/serializers/create-magic-auth-options.serializer.ts
+++ b/src/user-management/serializers/create-magic-auth-options.serializer.ts
@@ -11,4 +11,5 @@ export const serializeCreateMagicAuthOptions = (
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
   radar_auth_attempt_id: options.radarAuthAttemptId,
+  signals_id: options.signalsId,
 });

--- a/src/user-management/serializers/create-user-options.serializer.ts
+++ b/src/user-management/serializers/create-user-options.serializer.ts
@@ -15,4 +15,5 @@ export const serializeCreateUserOptions = (
   metadata: options.metadata,
   ip_address: options.ipAddress,
   user_agent: options.userAgent,
+  signals_id: options.signalsId,
 });

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -207,6 +207,19 @@ describe('UserManagement', () => {
 
       expect(user.radarAuthAttemptId).toBeUndefined();
     });
+
+    it('sends signals_id when provided', async () => {
+      fetchOnce(userFixture);
+
+      await workos.userManagement.createUser({
+        email: 'test01@example.com',
+        signalsId: 'signals_01ABC',
+      });
+
+      expect(fetchBody()).toMatchObject({
+        signals_id: 'signals_01ABC',
+      });
+    });
   });
 
   describe('authenticateUserWithMagicAuth', () => {
@@ -239,6 +252,21 @@ describe('UserManagement', () => {
 
       expect(fetchBody()).toMatchObject({
         radar_auth_attempt_id: 'radar_auth_attempt_01ABC',
+      });
+    });
+
+    it('sends signals_id when provided', async () => {
+      fetchOnce({ user: userFixture });
+
+      await workos.userManagement.authenticateWithMagicAuth({
+        clientId: 'proj_whatever',
+        code: '123456',
+        email: userFixture.email,
+        signalsId: 'signals_01ABC',
+      });
+
+      expect(fetchBody()).toMatchObject({
+        signals_id: 'signals_01ABC',
       });
     });
 
@@ -324,6 +352,21 @@ describe('UserManagement', () => {
       });
     });
 
+    it('sends signals_id when provided', async () => {
+      fetchOnce({ user: userFixture });
+
+      await workos.userManagement.authenticateWithPassword({
+        clientId: 'proj_whatever',
+        email: 'test01@example.com',
+        password: 'extra-secure',
+        signalsId: 'signals_01ABC',
+      });
+
+      expect(fetchBody()).toMatchObject({
+        signals_id: 'signals_01ABC',
+      });
+    });
+
     describe('when sealSession = true', () => {
       beforeEach(() => {
         fetchOnce({
@@ -397,6 +440,20 @@ describe('UserManagement', () => {
             email: 'test01@example.com',
           },
         });
+      });
+    });
+
+    it('sends signals_id when provided', async () => {
+      fetchOnce({ user: userFixture });
+
+      await workos.userManagement.authenticateWithCode({
+        clientId: 'proj_whatever',
+        code: 'or this',
+        signalsId: 'signals_01ABC',
+      });
+
+      expect(fetchBody()).toMatchObject({
+        signals_id: 'signals_01ABC',
       });
     });
 
@@ -715,6 +772,21 @@ describe('UserManagement', () => {
         user: {
           email: 'test01@example.com',
         },
+      });
+    });
+
+    it('sends signals_id when provided', async () => {
+      fetchOnce({ user: userFixture });
+
+      await workos.userManagement.authenticateWithCodeAndVerifier({
+        clientId: 'proj_whatever',
+        code: 'auth_code_123',
+        codeVerifier: 'required_code_verifier',
+        signalsId: 'signals_01ABC',
+      });
+
+      expect(fetchBody()).toMatchObject({
+        signals_id: 'signals_01ABC',
       });
     });
 
@@ -1846,6 +1918,19 @@ describe('UserManagement', () => {
       });
 
       expect(response.radarAuthAttemptId).toBeUndefined();
+    });
+
+    it('sends signals_id when provided', async () => {
+      fetchOnce(magicAuthFixture);
+
+      await workos.userManagement.createMagicAuth({
+        email: 'bob.loblaw@example.com',
+        signalsId: 'signals_01ABC',
+      });
+
+      expect(fetchBody()).toMatchObject({
+        signals_id: 'signals_01ABC',
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Adds optional `signalsId` field to all user management methods that interact with Radar-enabled endpoints, matching the backend support added in workos/workos#62383 (RDR-765).

**Methods updated:**
- `createUser` — `POST /user_management/users`
- `authenticateWithCode` — `POST /user_management/authenticate` (`authorization_code` grant, confidential client)
- `authenticateWithCodeAndVerifier` — `POST /user_management/authenticate` (`authorization_code` grant, public client / PKCE)
- `authenticateWithPassword` — `POST /user_management/authenticate` (`password` grant)
- `authenticateWithMagicAuth` — `POST /user_management/authenticate` (`magic-auth:code` grant)
- `createMagicAuth` — `POST /user_management/magic_auth`

**Per method, three changes:**
1. Options interface — add `signalsId?: string`
2. Serialized interface — add `signals_id?: string`
3. Serializer — map `signalsId → signals_id`

All additions are optional and fully backwards compatible. Tests added for each method verifying `signals_id` is sent in the request body.

## Documentation

We will follow with the docs changes when we're ready to announce the release.

Link to Devin session: https://app.devin.ai/sessions/f934ecaac1d84be6bc6713eaa76ba57b
Requested by: @blairworkos