### PR TITLE
feat(authorization): Add group role assignment endpoints

### DIFF
--- a/src/authorization/authorization.spec.ts
+++ b/src/authorization/authorization.spec.ts
@@ -2,6 +2,7 @@ import fetch from 'jest-fetch-mock';
 import {
   fetchOnce,
   fetchURL,
+  fetchMethod,
   fetchSearchParams,
   fetchBody,
 } from '../common/utils/test-utils';
@@ -16,6 +17,8 @@ import authorizationResourceFixture from './fixtures/authorization-resource.json
 import listResourcesFixture from './fixtures/list-resources.json';
 import roleAssignmentFixture from './fixtures/role-assignment.json';
 import listRoleAssignmentsFixture from './fixtures/list-role-assignments.json';
+import groupRoleAssignmentFixture from './fixtures/group-role-assignment.json';
+import listGroupRoleAssignmentsFixture from './fixtures/list-group-role-assignments.json';
 import listOrganizationMembershipsForResourceFixture from './fixtures/list-organization-memberships-for-resource.json';
 import listEffectivePermissionsFixture from './fixtures/list-effective-permissions.json';
 
@@ -24,6 +27,8 @@ const testOrgId = 'org_01HXYZ123ABC456DEF789ABC';
 const testResourceId = 'authz_resource_01HXYZ123ABC456DEF789ABC';
 const testOrgMembershipId = 'om_01HXYZ123ABC456DEF789ABC';
 const testRoleAssignmentId = 'role_assignment_01HXYZ123ABC456DEF789ABC';
+const testGroupId = 'group_01HXYZ123456789ABCDEFGHIJ';
+const testGroupRoleAssignmentId = 'gra_01HXYZ123456789ABCDEFGH';
 
 describe('Authorization', () => {
   beforeEach(() => fetch.resetMocks());
@@ -2717,6 +2722,224 @@ describe('Authorization', () => {
       expect(fetchSearchParams()).toMatchObject({
         order: 'desc',
       });
+    });
+  });
+
+  describe('listGroupRoleAssignments', () => {
+    it('returns paginated results', async () => {
+      fetchOnce(listGroupRoleAssignmentsFixture);
+
+      const { data, listMetadata } =
+        await workos.authorization.listGroupRoleAssignments({
+          groupId: testGroupId,
+          order: 'desc',
+        });
+
+      expect(fetchURL()).toContain(
+        `/authorization/groups/${testGroupId}/role_assignments`,
+      );
+      expect(fetchSearchParams()).toHaveProperty('order', 'desc');
+      expect(data).toHaveLength(1);
+      expect(data[0]).toMatchObject({
+        object: 'group_role_assignment',
+        id: testGroupRoleAssignmentId,
+        groupId: testGroupId,
+        role: { slug: 'editor' },
+        resource: {
+          id: 'authz_resource_01HXYZ123456789ABCDEFGH',
+          externalId: 'workspace-123',
+          resourceTypeSlug: 'workspace',
+        },
+      });
+      expect(listMetadata).toBeDefined();
+    });
+  });
+
+  describe('getGroupRoleAssignment', () => {
+    it('returns the expected result', async () => {
+      fetchOnce(groupRoleAssignmentFixture);
+
+      const assignment = await workos.authorization.getGroupRoleAssignment({
+        groupId: testGroupId,
+        roleAssignmentId: testGroupRoleAssignmentId,
+      });
+
+      expect(fetchURL()).toContain(
+        `/authorization/groups/${testGroupId}/role_assignments/${testGroupRoleAssignmentId}`,
+      );
+      expect(assignment).toMatchObject({
+        object: 'group_role_assignment',
+        id: testGroupRoleAssignmentId,
+        groupId: testGroupId,
+        role: { slug: 'editor' },
+        resource: {
+          id: 'authz_resource_01HXYZ123456789ABCDEFGH',
+          externalId: 'workspace-123',
+          resourceTypeSlug: 'workspace',
+        },
+        createdAt: '2026-01-15T12:00:00.000Z',
+        updatedAt: '2026-01-15T12:00:00.000Z',
+      });
+    });
+  });
+
+  describe('createGroupRoleAssignment', () => {
+    it('assigns a role by resource ID', async () => {
+      fetchOnce(groupRoleAssignmentFixture, { status: 201 });
+
+      const assignment = await workos.authorization.createGroupRoleAssignment({
+        groupId: testGroupId,
+        roleSlug: 'editor',
+        resourceId: 'authz_resource_01HXYZ123456789ABCDEFGH',
+      });
+
+      expect(fetchURL()).toContain(
+        `/authorization/groups/${testGroupId}/role_assignments`,
+      );
+      expect(fetchBody()).toEqual({
+        role_slug: 'editor',
+        resource_id: 'authz_resource_01HXYZ123456789ABCDEFGH',
+      });
+      expect(assignment.object).toBe('group_role_assignment');
+    });
+
+    it('assigns a role by external ID & resourceTypeSlug', async () => {
+      fetchOnce(groupRoleAssignmentFixture, { status: 201 });
+
+      await workos.authorization.createGroupRoleAssignment({
+        groupId: testGroupId,
+        roleSlug: 'editor',
+        resourceExternalId: 'workspace-123',
+        resourceTypeSlug: 'workspace',
+      });
+
+      expect(fetchBody()).toEqual({
+        role_slug: 'editor',
+        resource_external_id: 'workspace-123',
+        resource_type_slug: 'workspace',
+      });
+    });
+
+    it('assigns a role on the organization when no resource is provided', async () => {
+      fetchOnce(groupRoleAssignmentFixture, { status: 201 });
+
+      await workos.authorization.createGroupRoleAssignment({
+        groupId: testGroupId,
+        roleSlug: 'editor',
+      });
+
+      expect(fetchBody()).toEqual({ role_slug: 'editor' });
+    });
+  });
+
+  describe('removeGroupRoleAssignment', () => {
+    it('sends a DELETE request', async () => {
+      fetchOnce({}, { status: 204 });
+
+      await workos.authorization.removeGroupRoleAssignment({
+        groupId: testGroupId,
+        roleAssignmentId: testGroupRoleAssignmentId,
+      });
+
+      expect(fetchURL()).toContain(
+        `/authorization/groups/${testGroupId}/role_assignments/${testGroupRoleAssignmentId}`,
+      );
+    });
+  });
+
+  describe('removeGroupRoleAssignments', () => {
+    it('removes assignments by resource ID', async () => {
+      fetchOnce({}, { status: 204 });
+
+      await workos.authorization.removeGroupRoleAssignments({
+        groupId: testGroupId,
+        roleSlug: 'editor',
+        resourceId: 'authz_resource_01HXYZ123456789ABCDEFGH',
+      });
+
+      expect(fetchURL()).toContain(
+        `/authorization/groups/${testGroupId}/role_assignments`,
+      );
+      expect(fetchBody()).toEqual({
+        role_slug: 'editor',
+        resource_id: 'authz_resource_01HXYZ123456789ABCDEFGH',
+      });
+    });
+
+    it('removes assignments on the organization when no resource is provided', async () => {
+      fetchOnce({}, { status: 204 });
+
+      await workos.authorization.removeGroupRoleAssignments({
+        groupId: testGroupId,
+        roleSlug: 'editor',
+      });
+
+      expect(fetchBody()).toEqual({ role_slug: 'editor' });
+    });
+  });
+
+  describe('replaceGroupRoleAssignments', () => {
+    it('sends a PUT request and returns the resulting list', async () => {
+      fetchOnce(listGroupRoleAssignmentsFixture);
+
+      const { object, data, listMetadata } =
+        await workos.authorization.replaceGroupRoleAssignments({
+          groupId: testGroupId,
+          roleAssignments: [
+            {
+              roleSlug: 'editor',
+              resourceId: 'authz_resource_01HXYZ123456789ABCDEFGH',
+            },
+            {
+              roleSlug: 'viewer',
+              resourceExternalId: 'workspace-123',
+              resourceTypeSlug: 'workspace',
+            },
+            { roleSlug: 'admin' },
+          ],
+        });
+
+      expect(fetchMethod()).toBe('PUT');
+      expect(fetchURL()).toContain(
+        `/authorization/groups/${testGroupId}/role_assignments`,
+      );
+      expect(fetchBody()).toEqual({
+        role_assignments: [
+          {
+            role_slug: 'editor',
+            resource_id: 'authz_resource_01HXYZ123456789ABCDEFGH',
+          },
+          {
+            role_slug: 'viewer',
+            resource_external_id: 'workspace-123',
+            resource_type_slug: 'workspace',
+          },
+          { role_slug: 'admin' },
+        ],
+      });
+      expect(object).toBe('list');
+      expect(data[0]).toMatchObject({
+        object: 'group_role_assignment',
+        id: testGroupRoleAssignmentId,
+        groupId: testGroupId,
+      });
+      expect(listMetadata).toBeDefined();
+    });
+
+    it('clears all assignments with an empty list', async () => {
+      fetchOnce({
+        object: 'list',
+        data: [],
+        list_metadata: { before: null, after: null },
+      });
+
+      const { data } = await workos.authorization.replaceGroupRoleAssignments({
+        groupId: testGroupId,
+        roleAssignments: [],
+      });
+
+      expect(fetchBody()).toEqual({ role_assignments: [] });
+      expect(data).toEqual([]);
     });
   });
 });

--- a/src/authorization/authorization.spec.ts
+++ b/src/authorization/authorization.spec.ts
@@ -2844,6 +2844,7 @@ describe('Authorization', () => {
       expect(fetchURL()).toContain(
         `/authorization/groups/${testGroupId}/role_assignments/${testGroupRoleAssignmentId}`,
       );
+      expect(fetchMethod()).toBe('DELETE');
     });
   });
 
@@ -2863,6 +2864,26 @@ describe('Authorization', () => {
       expect(fetchBody()).toEqual({
         role_slug: 'editor',
         resource_id: 'authz_resource_01HXYZ123456789ABCDEFGH',
+      });
+    });
+
+    it('removes assignments by external ID and resourceTypeSlug', async () => {
+      fetchOnce({}, { status: 204 });
+
+      await workos.authorization.removeGroupRoleAssignments({
+        groupId: testGroupId,
+        roleSlug: 'editor',
+        resourceExternalId: 'workspace-123',
+        resourceTypeSlug: 'workspace',
+      });
+
+      expect(fetchURL()).toContain(
+        `/authorization/groups/${testGroupId}/role_assignments`,
+      );
+      expect(fetchBody()).toEqual({
+        role_slug: 'editor',
+        resource_external_id: 'workspace-123',
+        resource_type_slug: 'workspace',
       });
     });
 

--- a/src/authorization/authorization.spec.ts
+++ b/src/authorization/authorization.spec.ts
@@ -2861,6 +2861,7 @@ describe('Authorization', () => {
       expect(fetchURL()).toContain(
         `/authorization/groups/${testGroupId}/role_assignments`,
       );
+      expect(fetchMethod()).toBe('DELETE');
       expect(fetchBody()).toEqual({
         role_slug: 'editor',
         resource_id: 'authz_resource_01HXYZ123456789ABCDEFGH',
@@ -2880,6 +2881,7 @@ describe('Authorization', () => {
       expect(fetchURL()).toContain(
         `/authorization/groups/${testGroupId}/role_assignments`,
       );
+      expect(fetchMethod()).toBe('DELETE');
       expect(fetchBody()).toEqual({
         role_slug: 'editor',
         resource_external_id: 'workspace-123',
@@ -2895,6 +2897,7 @@ describe('Authorization', () => {
         roleSlug: 'editor',
       });
 
+      expect(fetchMethod()).toBe('DELETE');
       expect(fetchBody()).toEqual({ role_slug: 'editor' });
     });
   });

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -1,6 +1,8 @@
 import { WorkOS } from '../workos';
 import { AutoPaginatable } from '../common/utils/pagination';
 import { fetchAndDeserialize } from '../common/utils/fetch-and-deserialize';
+import { List, ListResponse } from '../common/interfaces';
+import { deserializeList } from '../common/serializers';
 import {
   Role,
   RoleList,
@@ -44,6 +46,14 @@ import {
   RemoveRoleOptions,
   RoleAssignment,
   RoleAssignmentResponse,
+  GroupRoleAssignment,
+  GroupRoleAssignmentResponse,
+  ListGroupRoleAssignmentsOptions,
+  GetGroupRoleAssignmentOptions,
+  CreateGroupRoleAssignmentOptions,
+  RemoveGroupRoleAssignmentOptions,
+  RemoveGroupRoleAssignmentsOptions,
+  ReplaceGroupRoleAssignmentsOptions,
   ListMembershipsForResourceByExternalIdOptions,
   ListMembershipsForResourceOptions,
   ListResourcesForMembershipOptions,
@@ -70,6 +80,10 @@ import {
   serializeListAuthorizationResourcesOptions,
   serializeAuthorizationCheckOptions,
   deserializeRoleAssignment,
+  deserializeGroupRoleAssignment,
+  serializeCreateGroupRoleAssignmentOptions,
+  serializeRemoveGroupRoleAssignmentsOptions,
+  serializeReplaceGroupRoleAssignmentsOptions,
   serializeAssignRoleOptions,
   serializeRemoveRoleOptions,
   serializeListMembershipsForResourceOptions,
@@ -1026,6 +1040,163 @@ export class Authorization {
     await this.workos.delete(
       `/authorization/organization_memberships/${options.organizationMembershipId}/role_assignments/${options.roleAssignmentId}`,
     );
+  }
+
+  /**
+   * List role assignments for a group
+   *
+   * List all role assignments granted to a group. Each assignment represents a role granted to the group on a resource.
+   * @param options - Pagination options.
+   * @param options.groupId - The ID of the group.
+   *
+   * @example
+   * "group_01HXYZ123456789ABCDEFGHIJ"
+   *
+   * @returns {Promise<AutoPaginatable<GroupRoleAssignment>>}
+   * @throws 403 response from the API.
+   * @throws {NotFoundException} 404
+   */
+  async listGroupRoleAssignments(
+    options: ListGroupRoleAssignmentsOptions,
+  ): Promise<AutoPaginatable<GroupRoleAssignment>> {
+    const { groupId, ...paginationOptions } = options;
+    const endpoint = `/authorization/groups/${groupId}/role_assignments`;
+    return new AutoPaginatable(
+      await fetchAndDeserialize<
+        GroupRoleAssignmentResponse,
+        GroupRoleAssignment
+      >(
+        this.workos,
+        endpoint,
+        deserializeGroupRoleAssignment,
+        paginationOptions,
+      ),
+      (params) =>
+        fetchAndDeserialize<GroupRoleAssignmentResponse, GroupRoleAssignment>(
+          this.workos,
+          endpoint,
+          deserializeGroupRoleAssignment,
+          params,
+        ),
+      paginationOptions,
+    );
+  }
+
+  /**
+   * Get a group role assignment
+   *
+   * Get a specific role assignment for a group by its ID.
+   * @param options - Object containing groupId and roleAssignmentId.
+   * @param options.groupId - The ID of the group.
+   *
+   * @example
+   * "group_01HXYZ123456789ABCDEFGHIJ"
+   *
+   * @param options.roleAssignmentId - The ID of the group role assignment.
+   *
+   * @example
+   * "gra_01HXYZ123456789ABCDEFGH"
+   *
+   * @returns {Promise<GroupRoleAssignment>}
+   * @throws 403 response from the API.
+   * @throws {NotFoundException} 404
+   */
+  async getGroupRoleAssignment(
+    options: GetGroupRoleAssignmentOptions,
+  ): Promise<GroupRoleAssignment> {
+    const { data } = await this.workos.get<GroupRoleAssignmentResponse>(
+      `/authorization/groups/${options.groupId}/role_assignments/${options.roleAssignmentId}`,
+    );
+    return deserializeGroupRoleAssignment(data);
+  }
+
+  /**
+   * Assign a role to a group
+   *
+   * Assign a role to a group on a specific resource. Omit the resource fields to assign the role on the organization itself.
+   * @param options - Object containing groupId and roleSlug.
+   * @returns {Promise<GroupRoleAssignment>}
+   * @throws 403 response from the API.
+   * @throws {NotFoundException} 404
+   * @throws {ConflictException} 409
+   * @throws {UnprocessableEntityException} 422
+   */
+  async createGroupRoleAssignment(
+    options: CreateGroupRoleAssignmentOptions,
+  ): Promise<GroupRoleAssignment> {
+    const { data } = await this.workos.post<GroupRoleAssignmentResponse>(
+      `/authorization/groups/${options.groupId}/role_assignments`,
+      serializeCreateGroupRoleAssignmentOptions(options),
+    );
+    return deserializeGroupRoleAssignment(data);
+  }
+
+  /**
+   * Remove a group role assignment
+   *
+   * Remove a specific role assignment from a group by its ID.
+   * @param options - Object containing groupId and roleAssignmentId.
+   * @param options.groupId - The ID of the group.
+   *
+   * @example
+   * "group_01HXYZ123456789ABCDEFGHIJ"
+   *
+   * @param options.roleAssignmentId - The ID of the group role assignment to remove.
+   *
+   * @example
+   * "gra_01HXYZ123456789ABCDEFGH"
+   *
+   * @returns {Promise<void>}
+   * @throws 403 response from the API.
+   * @throws {NotFoundException} 404
+   */
+  async removeGroupRoleAssignment(
+    options: RemoveGroupRoleAssignmentOptions,
+  ): Promise<void> {
+    await this.workos.delete(
+      `/authorization/groups/${options.groupId}/role_assignments/${options.roleAssignmentId}`,
+    );
+  }
+
+  /**
+   * Remove group role assignments by criteria
+   *
+   * Remove role assignments from a group that match the provided role and resource. Omit the resource fields to target the organization itself.
+   * @param options - Object containing groupId and roleSlug.
+   * @returns {Promise<void>}
+   * @throws 403 response from the API.
+   * @throws {NotFoundException} 404
+   * @throws {UnprocessableEntityException} 422
+   */
+  async removeGroupRoleAssignments(
+    options: RemoveGroupRoleAssignmentsOptions,
+  ): Promise<void> {
+    await this.workos.deleteWithBody(
+      `/authorization/groups/${options.groupId}/role_assignments`,
+      serializeRemoveGroupRoleAssignmentsOptions(options),
+    );
+  }
+
+  /**
+   * Replace role assignments for a group
+   *
+   * Replace all of a group's role assignments with the provided list. Assignments not present in the list are removed and new ones are created. Pass an empty `roleAssignments` array to clear all assignments. Returns the resulting set of assignments.
+   * @param options - Object containing groupId and roleAssignments.
+   * @returns {Promise<List<GroupRoleAssignment>>}
+   * @throws 403 response from the API.
+   * @throws {NotFoundException} 404
+   * @throws {UnprocessableEntityException} 422
+   */
+  async replaceGroupRoleAssignments(
+    options: ReplaceGroupRoleAssignmentsOptions,
+  ): Promise<List<GroupRoleAssignment>> {
+    const { data } = await this.workos.put<
+      ListResponse<GroupRoleAssignmentResponse>
+    >(
+      `/authorization/groups/${options.groupId}/role_assignments`,
+      serializeReplaceGroupRoleAssignmentsOptions(options),
+    );
+    return deserializeList(data, deserializeGroupRoleAssignment);
   }
 
   /**

--- a/src/authorization/fixtures/group-role-assignment.json
+++ b/src/authorization/fixtures/group-role-assignment.json
@@ -1,0 +1,15 @@
+{
+  "object": "group_role_assignment",
+  "id": "gra_01HXYZ123456789ABCDEFGH",
+  "group_id": "group_01HXYZ123456789ABCDEFGHIJ",
+  "role": {
+    "slug": "editor"
+  },
+  "resource": {
+    "id": "authz_resource_01HXYZ123456789ABCDEFGH",
+    "external_id": "workspace-123",
+    "resource_type_slug": "workspace"
+  },
+  "created_at": "2026-01-15T12:00:00.000Z",
+  "updated_at": "2026-01-15T12:00:00.000Z"
+}

--- a/src/authorization/fixtures/list-group-role-assignments.json
+++ b/src/authorization/fixtures/list-group-role-assignments.json
@@ -1,0 +1,24 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "group_role_assignment",
+      "id": "gra_01HXYZ123456789ABCDEFGH",
+      "group_id": "group_01HXYZ123456789ABCDEFGHIJ",
+      "role": {
+        "slug": "editor"
+      },
+      "resource": {
+        "id": "authz_resource_01HXYZ123456789ABCDEFGH",
+        "external_id": "workspace-123",
+        "resource_type_slug": "workspace"
+      },
+      "created_at": "2026-01-15T12:00:00.000Z",
+      "updated_at": "2026-01-15T12:00:00.000Z"
+    }
+  ],
+  "list_metadata": {
+    "before": null,
+    "after": "gra_01HXYZ123456789ABCDEFGH"
+  }
+}

--- a/src/authorization/interfaces/create-group-role-assignment-options.interface.ts
+++ b/src/authorization/interfaces/create-group-role-assignment-options.interface.ts
@@ -1,0 +1,39 @@
+import {
+  AuthorizationResourceIdentifierById,
+  AuthorizationResourceIdentifierByExternalId,
+} from './authorization-resource-identifier.interface';
+
+export interface BaseCreateGroupRoleAssignmentOptions {
+  groupId: string;
+  roleSlug: string;
+}
+
+export type CreateGroupRoleAssignmentOptionsForOrganization =
+  BaseCreateGroupRoleAssignmentOptions;
+
+export interface CreateGroupRoleAssignmentOptionsWithResourceId
+  extends
+    BaseCreateGroupRoleAssignmentOptions,
+    AuthorizationResourceIdentifierById {}
+
+export interface CreateGroupRoleAssignmentOptionsWithResourceExternalId
+  extends
+    BaseCreateGroupRoleAssignmentOptions,
+    AuthorizationResourceIdentifierByExternalId {}
+
+/**
+ * Omit the resource fields entirely to assign the role on the organization
+ * itself. Otherwise provide either `resourceId` or both `resourceExternalId`
+ * and `resourceTypeSlug`.
+ */
+export type CreateGroupRoleAssignmentOptions =
+  | CreateGroupRoleAssignmentOptionsForOrganization
+  | CreateGroupRoleAssignmentOptionsWithResourceId
+  | CreateGroupRoleAssignmentOptionsWithResourceExternalId;
+
+export interface SerializedCreateGroupRoleAssignmentOptions {
+  role_slug: string;
+  resource_id?: string;
+  resource_external_id?: string;
+  resource_type_slug?: string;
+}

--- a/src/authorization/interfaces/get-group-role-assignment-options.interface.ts
+++ b/src/authorization/interfaces/get-group-role-assignment-options.interface.ts
@@ -1,0 +1,6 @@
+export interface GetGroupRoleAssignmentOptions {
+  /** The ID of the group. */
+  groupId: string;
+  /** The ID of the group role assignment. */
+  roleAssignmentId: string;
+}

--- a/src/authorization/interfaces/group-role-assignment.interface.ts
+++ b/src/authorization/interfaces/group-role-assignment.interface.ts
@@ -1,0 +1,32 @@
+import {
+  RoleAssignmentRole,
+  RoleAssignmentResource,
+  RoleAssignmentResourceResponse,
+} from './role-assignment.interface';
+
+export interface GroupRoleAssignment {
+  /** Distinguishes the group role assignment object. */
+  object: 'group_role_assignment';
+  /** Unique identifier of the group role assignment. */
+  id: string;
+  /** The ID of the group the role is assigned to. */
+  groupId: string;
+  /** The role included in the assignment. */
+  role: RoleAssignmentRole;
+  /** The resource the role is assigned on. */
+  resource: RoleAssignmentResource;
+  /** An ISO 8601 timestamp. */
+  createdAt: string;
+  /** An ISO 8601 timestamp. */
+  updatedAt: string;
+}
+
+export interface GroupRoleAssignmentResponse {
+  object: 'group_role_assignment';
+  id: string;
+  group_id: string;
+  role: RoleAssignmentRole;
+  resource: RoleAssignmentResourceResponse;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/authorization/interfaces/index.ts
+++ b/src/authorization/interfaces/index.ts
@@ -30,5 +30,12 @@ export * from './list-role-assignments-for-resource-by-external-id-options.inter
 export * from './assign-role-options.interface';
 export * from './remove-role-options.interface';
 export * from './remove-role-assignment-options.interface';
+export * from './group-role-assignment.interface';
+export * from './list-group-role-assignments-options.interface';
+export * from './get-group-role-assignment-options.interface';
+export * from './create-group-role-assignment-options.interface';
+export * from './remove-group-role-assignment-options.interface';
+export * from './remove-group-role-assignments-options.interface';
+export * from './replace-group-role-assignments-options.interface';
 export * from './list-effective-permissions-options.interface';
 export * from './list-effective-permissions-by-external-id-options.interface';

--- a/src/authorization/interfaces/list-group-role-assignments-options.interface.ts
+++ b/src/authorization/interfaces/list-group-role-assignments-options.interface.ts
@@ -1,0 +1,6 @@
+import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
+
+export interface ListGroupRoleAssignmentsOptions extends PaginationOptions {
+  /** The ID of the group. */
+  groupId: string;
+}

--- a/src/authorization/interfaces/remove-group-role-assignment-options.interface.ts
+++ b/src/authorization/interfaces/remove-group-role-assignment-options.interface.ts
@@ -1,0 +1,6 @@
+export interface RemoveGroupRoleAssignmentOptions {
+  /** The ID of the group. */
+  groupId: string;
+  /** The ID of the group role assignment to remove. */
+  roleAssignmentId: string;
+}

--- a/src/authorization/interfaces/remove-group-role-assignments-options.interface.ts
+++ b/src/authorization/interfaces/remove-group-role-assignments-options.interface.ts
@@ -1,0 +1,39 @@
+import {
+  AuthorizationResourceIdentifierById,
+  AuthorizationResourceIdentifierByExternalId,
+} from './authorization-resource-identifier.interface';
+
+export interface BaseRemoveGroupRoleAssignmentsOptions {
+  groupId: string;
+  roleSlug: string;
+}
+
+export type RemoveGroupRoleAssignmentsOptionsForOrganization =
+  BaseRemoveGroupRoleAssignmentsOptions;
+
+export interface RemoveGroupRoleAssignmentsOptionsWithResourceId
+  extends
+    BaseRemoveGroupRoleAssignmentsOptions,
+    AuthorizationResourceIdentifierById {}
+
+export interface RemoveGroupRoleAssignmentsOptionsWithResourceExternalId
+  extends
+    BaseRemoveGroupRoleAssignmentsOptions,
+    AuthorizationResourceIdentifierByExternalId {}
+
+/**
+ * Omit the resource fields entirely to remove the role assignment on the
+ * organization itself. Otherwise provide either `resourceId` or both
+ * `resourceExternalId` and `resourceTypeSlug`.
+ */
+export type RemoveGroupRoleAssignmentsOptions =
+  | RemoveGroupRoleAssignmentsOptionsForOrganization
+  | RemoveGroupRoleAssignmentsOptionsWithResourceId
+  | RemoveGroupRoleAssignmentsOptionsWithResourceExternalId;
+
+export interface SerializedRemoveGroupRoleAssignmentsOptions {
+  role_slug: string;
+  resource_id?: string;
+  resource_external_id?: string;
+  resource_type_slug?: string;
+}

--- a/src/authorization/interfaces/replace-group-role-assignments-options.interface.ts
+++ b/src/authorization/interfaces/replace-group-role-assignments-options.interface.ts
@@ -1,0 +1,50 @@
+import {
+  AuthorizationResourceIdentifierById,
+  AuthorizationResourceIdentifierByExternalId,
+} from './authorization-resource-identifier.interface';
+
+export interface BaseGroupRoleAssignmentEntry {
+  roleSlug: string;
+}
+
+export type GroupRoleAssignmentEntryForOrganization =
+  BaseGroupRoleAssignmentEntry;
+
+export interface GroupRoleAssignmentEntryWithResourceId
+  extends BaseGroupRoleAssignmentEntry, AuthorizationResourceIdentifierById {}
+
+export interface GroupRoleAssignmentEntryWithResourceExternalId
+  extends
+    BaseGroupRoleAssignmentEntry,
+    AuthorizationResourceIdentifierByExternalId {}
+
+/**
+ * Omit the resource fields entirely to assign the role on the organization
+ * itself. Otherwise provide either `resourceId` or both `resourceExternalId`
+ * and `resourceTypeSlug`.
+ */
+export type GroupRoleAssignmentEntry =
+  | GroupRoleAssignmentEntryForOrganization
+  | GroupRoleAssignmentEntryWithResourceId
+  | GroupRoleAssignmentEntryWithResourceExternalId;
+
+export interface ReplaceGroupRoleAssignmentsOptions {
+  groupId: string;
+  /**
+   * The complete list of role assignments that should exist for the group.
+   * Existing assignments absent from this list are removed; pass an empty
+   * array to clear all assignments. At most 100 entries.
+   */
+  roleAssignments: GroupRoleAssignmentEntry[];
+}
+
+export interface SerializedGroupRoleAssignmentEntry {
+  role_slug: string;
+  resource_id?: string;
+  resource_external_id?: string;
+  resource_type_slug?: string;
+}
+
+export interface SerializedReplaceGroupRoleAssignmentsOptions {
+  role_assignments: SerializedGroupRoleAssignmentEntry[];
+}

--- a/src/authorization/serializers/create-group-role-assignment-options.serializer.ts
+++ b/src/authorization/serializers/create-group-role-assignment-options.serializer.ts
@@ -1,0 +1,15 @@
+import {
+  CreateGroupRoleAssignmentOptions,
+  SerializedCreateGroupRoleAssignmentOptions,
+} from '../interfaces/create-group-role-assignment-options.interface';
+
+export const serializeCreateGroupRoleAssignmentOptions = (
+  options: CreateGroupRoleAssignmentOptions,
+): SerializedCreateGroupRoleAssignmentOptions => ({
+  role_slug: options.roleSlug,
+  ...('resourceId' in options && { resource_id: options.resourceId }),
+  ...('resourceExternalId' in options && {
+    resource_external_id: options.resourceExternalId,
+    resource_type_slug: options.resourceTypeSlug,
+  }),
+});

--- a/src/authorization/serializers/group-role-assignment.serializer.ts
+++ b/src/authorization/serializers/group-role-assignment.serializer.ts
@@ -1,0 +1,20 @@
+import {
+  GroupRoleAssignment,
+  GroupRoleAssignmentResponse,
+} from '../interfaces/group-role-assignment.interface';
+
+export const deserializeGroupRoleAssignment = (
+  response: GroupRoleAssignmentResponse,
+): GroupRoleAssignment => ({
+  object: response.object,
+  id: response.id,
+  groupId: response.group_id,
+  role: response.role,
+  resource: {
+    id: response.resource.id,
+    externalId: response.resource.external_id,
+    resourceTypeSlug: response.resource.resource_type_slug,
+  },
+  createdAt: response.created_at,
+  updatedAt: response.updated_at,
+});

--- a/src/authorization/serializers/index.ts
+++ b/src/authorization/serializers/index.ts
@@ -20,4 +20,8 @@ export * from './list-role-assignments-options.serializer';
 export * from './list-role-assignments-for-resource-options.serializer';
 export * from './assign-role-options.serializer';
 export * from './remove-role-options.serializer';
+export * from './group-role-assignment.serializer';
+export * from './create-group-role-assignment-options.serializer';
+export * from './remove-group-role-assignments-options.serializer';
+export * from './replace-group-role-assignments-options.serializer';
 export * from './list-effective-permissions-options.serializer';

--- a/src/authorization/serializers/remove-group-role-assignments-options.serializer.ts
+++ b/src/authorization/serializers/remove-group-role-assignments-options.serializer.ts
@@ -1,0 +1,15 @@
+import {
+  RemoveGroupRoleAssignmentsOptions,
+  SerializedRemoveGroupRoleAssignmentsOptions,
+} from '../interfaces/remove-group-role-assignments-options.interface';
+
+export const serializeRemoveGroupRoleAssignmentsOptions = (
+  options: RemoveGroupRoleAssignmentsOptions,
+): SerializedRemoveGroupRoleAssignmentsOptions => ({
+  role_slug: options.roleSlug,
+  ...('resourceId' in options && { resource_id: options.resourceId }),
+  ...('resourceExternalId' in options && {
+    resource_external_id: options.resourceExternalId,
+    resource_type_slug: options.resourceTypeSlug,
+  }),
+});

--- a/src/authorization/serializers/replace-group-role-assignments-options.serializer.ts
+++ b/src/authorization/serializers/replace-group-role-assignments-options.serializer.ts
@@ -1,0 +1,23 @@
+import {
+  GroupRoleAssignmentEntry,
+  ReplaceGroupRoleAssignmentsOptions,
+  SerializedGroupRoleAssignmentEntry,
+  SerializedReplaceGroupRoleAssignmentsOptions,
+} from '../interfaces/replace-group-role-assignments-options.interface';
+
+const serializeEntry = (
+  entry: GroupRoleAssignmentEntry,
+): SerializedGroupRoleAssignmentEntry => ({
+  role_slug: entry.roleSlug,
+  ...('resourceId' in entry && { resource_id: entry.resourceId }),
+  ...('resourceExternalId' in entry && {
+    resource_external_id: entry.resourceExternalId,
+    resource_type_slug: entry.resourceTypeSlug,
+  }),
+});
+
+export const serializeReplaceGroupRoleAssignmentsOptions = (
+  options: ReplaceGroupRoleAssignmentsOptions,
+): SerializedReplaceGroupRoleAssignmentsOptions => ({
+  role_assignments: options.roleAssignments.map(serializeEntry),
+});


### PR DESCRIPTION
### Summary

Adds SDK support for the group role assignment endpoints under `/authorization/groups/:group_id/role_assignments`, exposed on `workos.authorization`:

| Method | Endpoint |
|---|---|
| `listGroupRoleAssignments` | `GET .../role_assignments` |
| `getGroupRoleAssignment` | `GET .../role_assignments/:id` |
| `createGroupRoleAssignment` | `POST .../role_assignments` |
| `removeGroupRoleAssignment` | `DELETE .../role_assignments/:id` |
| `removeGroupRoleAssignments` | `DELETE .../role_assignments` (by criteria) |
| `replaceGroupRoleAssignments` | `PUT .../role_assignments` (bulk replace) |

Resource targeting mirrors the existing role-assignment options: provide `resourceId`, or `resourceExternalId` + `resourceTypeSlug`, or omit all to target the organization itself. `replaceGroupRoleAssignments` returns the resulting set as a `List<GroupRoleAssignment>`; passing an empty `roleAssignments` array clears all.

### Test plan

- `npx jest src/authorization/authorization.spec.ts` — 147 pass (new tests cover list/get/create/remove/remove-by-criteria/replace, including resource-by-id, by-external-id, org-level, and clear-all cases).
- `npx tsc --noEmit`, `npx eslint src/authorization`, and prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)