### PR TITLE
fix: Prevent handleParseError from double-reading response body

### DIFF
--- a/src/common/interfaces/http-client.interface.ts
+++ b/src/common/interfaces/http-client.interface.ts
@@ -21,5 +21,5 @@ export interface HttpClientResponseInterface {
   getStatusCode: () => number;
   getHeaders: () => ResponseHeaders;
   getRawResponse: () => unknown;
-  toJSON: () => Promise<any> | null;
+  toJSON: () => Promise<any | null>;
 }

--- a/src/common/net/fetch-client.spec.ts
+++ b/src/common/net/fetch-client.spec.ts
@@ -292,9 +292,11 @@ describe('Fetch client', () => {
       );
 
       const res = await client.get('/users', {});
-      const json = res.toJSON();
-      expect(json).not.toBeNull();
-      const error = await json!.catch((e: unknown) => e);
+      // toJSON() always returns a Promise for application/json responses;
+      // the union with null in the interface covers non-JSON content types.
+      const error = await (res.toJSON() as Promise<any>).catch(
+        (e: unknown) => e,
+      );
 
       expect(error).toBeInstanceOf(ParseError);
       const parseError = error as ParseError;

--- a/src/common/net/fetch-client.spec.ts
+++ b/src/common/net/fetch-client.spec.ts
@@ -292,7 +292,9 @@ describe('Fetch client', () => {
       );
 
       const res = await client.get('/users', {});
-      const error = await res.toJSON().catch((e: unknown) => e);
+      const json = res.toJSON();
+      expect(json).not.toBeNull();
+      const error = await json!.catch((e: unknown) => e);
 
       expect(error).toBeInstanceOf(ParseError);
       const parseError = error as ParseError;

--- a/src/common/net/fetch-client.spec.ts
+++ b/src/common/net/fetch-client.spec.ts
@@ -272,6 +272,38 @@ describe('Fetch client', () => {
       }
     });
 
+    it('should throw ParseError on 200 with malformed JSON using real Response (GH-1621)', async () => {
+      const client = new FetchHttpClient(
+        'https://test.workos.com',
+        {
+          headers: {
+            Authorization: 'Bearer sk_test',
+            'User-Agent': 'test-fetch-client',
+          },
+        },
+        async () =>
+          new Response('{ invalid json', {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+              'x-request-id': 'req_real_response',
+            },
+          }),
+      );
+
+      try {
+        const res = await client.get('/users', {});
+        await res.toJSON();
+        fail('Expected ParseError to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ParseError);
+        const parseError = error as ParseError;
+        expect(parseError.rawBody).toBe('{ invalid json');
+        expect(parseError.requestID).toBe('req_real_response');
+        expect(parseError.rawStatus).toBe(200);
+      }
+    });
+
     it('should throw ParseError when X-Request-ID header is missing', async () => {
       fetch.mockResponseOnce('Invalid JSON Response', {
         status: 422,

--- a/src/common/net/fetch-client.spec.ts
+++ b/src/common/net/fetch-client.spec.ts
@@ -291,17 +291,14 @@ describe('Fetch client', () => {
           }),
       );
 
-      try {
-        const res = await client.get('/users', {});
-        await res.toJSON();
-        fail('Expected ParseError to be thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(ParseError);
-        const parseError = error as ParseError;
-        expect(parseError.rawBody).toBe('{ invalid json');
-        expect(parseError.requestID).toBe('req_real_response');
-        expect(parseError.rawStatus).toBe(200);
-      }
+      const res = await client.get('/users', {});
+      const error = await res.toJSON().catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(ParseError);
+      const parseError = error as ParseError;
+      expect(parseError.rawBody).toBe('{ invalid json');
+      expect(parseError.requestID).toBe('req_real_response');
+      expect(parseError.rawStatus).toBe(200);
     });
 
     it('should throw ParseError when X-Request-ID header is missing', async () => {

--- a/src/common/net/fetch-client.spec.ts
+++ b/src/common/net/fetch-client.spec.ts
@@ -292,11 +292,7 @@ describe('Fetch client', () => {
       );
 
       const res = await client.get('/users', {});
-      // toJSON() always returns a Promise for application/json responses;
-      // the union with null in the interface covers non-JSON content types.
-      const error = await (res.toJSON() as Promise<any>).catch(
-        (e: unknown) => e,
-      );
+      const error = await res.toJSON().catch((e: unknown) => e);
 
       expect(error).toBeInstanceOf(ParseError);
       const parseError = error as ParseError;

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -392,11 +392,29 @@ export class FetchHttpClientResponse
     return this._res;
   }
 
-  toJSON(): Promise<any> | null {
+  async toJSON(): Promise<any | null> {
     const contentType = this._res.headers.get('content-type');
     const isJsonResponse = contentType?.includes('application/json');
 
-    return isJsonResponse ? this._res.json() : null;
+    if (!isJsonResponse) {
+      return null;
+    }
+
+    const rawBody = await this._res.text();
+
+    try {
+      return JSON.parse(rawBody);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new ParseError({
+          message: error.message,
+          rawBody,
+          rawStatus: this._res.status,
+          requestID: this._res.headers.get('X-Request-ID') ?? '',
+        });
+      }
+      throw error;
+    }
   }
 
   static _transformHeadersToObject(headers: Headers): ResponseHeaders {

--- a/src/common/net/http-client.ts
+++ b/src/common/net/http-client.ts
@@ -131,7 +131,7 @@ export abstract class HttpClientResponse implements HttpClientResponseInterface 
 
   abstract getRawResponse(): unknown;
 
-  abstract toJSON(): any | null;
+  abstract toJSON(): Promise<any | null>;
 }
 
 // tslint:disable-next-line

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -562,6 +562,28 @@ describe('WorkOS', () => {
     });
   });
 
+  describe('when using a real Response with invalid JSON (GH-1621)', () => {
+    it('throws ParseError instead of body-already-read TypeError', async () => {
+      const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
+        fetchFn: async () =>
+          new Response('{ invalid json', {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+              'x-request-id': 'req_test',
+            },
+          }),
+      });
+
+      const error = await workos.get('/path').catch((e) => e);
+
+      expect(error).toBeInstanceOf(ParseError);
+      expect(error.rawBody).toBe('{ invalid json');
+      expect(error.requestID).toBe('req_test');
+      expect(error.rawStatus).toBe(200);
+    });
+  });
+
   describe('when in a worker environment', () => {
     it('uses the worker client', () => {
       const workos = new WorkOSWorker('sk_test_key');

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -48,7 +48,6 @@ import { Authorization } from './authorization/authorization';
 import { Vault } from './vault/vault';
 import { ConflictException } from './common/exceptions/conflict.exception';
 import { CryptoProvider } from './common/crypto/crypto-provider';
-import { ParseError } from './common/exceptions/parse-error';
 import { getEnv } from './common/utils/env';
 import { version as VERSION } from '../package.json' with { type: 'json' };
 
@@ -254,12 +253,7 @@ export class WorkOS {
       throw error;
     }
 
-    try {
-      return { data: await res.toJSON() };
-    } catch (error) {
-      await this.handleParseError(error);
-      throw error;
-    }
+    return { data: await res.toJSON() };
   }
 
   async get<Result = any>(
@@ -292,12 +286,7 @@ export class WorkOS {
       throw error;
     }
 
-    try {
-      return { data: await res.toJSON() };
-    } catch (error) {
-      await this.handleParseError(error);
-      throw error;
-    }
+    return { data: await res.toJSON() };
   }
 
   async put<Result = any, Entity = any>(
@@ -328,12 +317,7 @@ export class WorkOS {
       throw error;
     }
 
-    try {
-      return { data: await res.toJSON() };
-    } catch (error) {
-      await this.handleParseError(error);
-      throw error;
-    }
+    return { data: await res.toJSON() };
   }
 
   async patch<Result = any, Entity = any>(
@@ -364,12 +348,7 @@ export class WorkOS {
       throw error;
     }
 
-    try {
-      return { data: await res.toJSON() };
-    } catch (error) {
-      await this.handleParseError(error);
-      throw error;
-    }
+    return { data: await res.toJSON() };
   }
 
   async delete(path: string, query?: any): Promise<void> {
@@ -404,12 +383,6 @@ export class WorkOS {
   emitWarning(warning: string) {
     // tslint:disable-next-line:no-console
     console.warn(`WorkOS: ${warning}`);
-  }
-
-  private async handleParseError(error: unknown) {
-    if (error instanceof ParseError) {
-      throw error;
-    }
   }
 
   private handleHttpError({ path, error }: { path: string; error: unknown }) {

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -257,7 +257,7 @@ export class WorkOS {
     try {
       return { data: await res.toJSON() };
     } catch (error) {
-      await this.handleParseError(error, res);
+      await this.handleParseError(error);
       throw error;
     }
   }
@@ -295,7 +295,7 @@ export class WorkOS {
     try {
       return { data: await res.toJSON() };
     } catch (error) {
-      await this.handleParseError(error, res);
+      await this.handleParseError(error);
       throw error;
     }
   }
@@ -331,7 +331,7 @@ export class WorkOS {
     try {
       return { data: await res.toJSON() };
     } catch (error) {
-      await this.handleParseError(error, res);
+      await this.handleParseError(error);
       throw error;
     }
   }
@@ -367,7 +367,7 @@ export class WorkOS {
     try {
       return { data: await res.toJSON() };
     } catch (error) {
-      await this.handleParseError(error, res);
+      await this.handleParseError(error);
       throw error;
     }
   }
@@ -406,21 +406,9 @@ export class WorkOS {
     console.warn(`WorkOS: ${warning}`);
   }
 
-  private async handleParseError(
-    error: unknown,
-    res: HttpClientResponseInterface,
-  ) {
-    if (error instanceof SyntaxError) {
-      const rawResponse = res.getRawResponse() as Response;
-      const requestID = rawResponse.headers.get('X-Request-ID') ?? '';
-      const rawStatus = rawResponse.status;
-      const rawBody = await rawResponse.text();
-      throw new ParseError({
-        message: error.message,
-        rawBody,
-        rawStatus,
-        requestID,
-      });
+  private async handleParseError(error: unknown) {
+    if (error instanceof ParseError) {
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Description

Fixes #1621 — `handleParseError` reads response body twice after JSON parse failure, masking the original `SyntaxError` with `TypeError: Body is unusable: Body has already been read`.

**Root cause:** `FetchHttpClientResponse.toJSON()` consumed the body via `Response.json()`, then `handleParseError()` tried `Response.text()` on the same already-consumed stream.

**Fix:**
- `toJSON()` now reads the body as text first (`Response.text()`), then parses with `JSON.parse()`. On `SyntaxError`, it throws `ParseError` directly with the raw body, status, and request ID — all available without a second read.
- `handleParseError` removed entirely — now that `toJSON()` owns error conversion, the method was dead code (its re-throw was identical to the caller's own `throw`).

```diff
- // Old: two reads — .json() consumes body, then .text() fails
- return isJsonResponse ? this._res.json() : null;
+ // New: single read — .text() first, then JSON.parse()
+ const rawBody = await this._res.text();
+ return JSON.parse(rawBody); // throws ParseError on failure
```

Regression test added using a real `Response` object (not a mock with independent `.json()`/`.text()`) to enforce single-read semantics.

## Documentation

```
[ ] Yes
```

No docs changes needed — this is a bug fix to internal error handling.

Link to Devin session: https://app.devin.ai/sessions/c4f635d973724d9883408c5e4b5751ff
Requested by: @ohjonah