### PR TITLE
refactor(feature-flags): replace eventemitter3 with internal typed emitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@workos-inc/node",
       "version": "10.2.1",
       "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^5.0.4"
-      },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",
         "@babel/plugin-transform-modules-commonjs": "^7.26.3",
@@ -6307,12 +6304,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "inlinedDependencies": {
     "iron-webcrypto": "2.0.0",
-    "jose": "6.2.3",
+    "jose": "6.2.2",
     "uint8array-extras": "1.5.0"
   },
   "dependencies": {}

--- a/package.json
+++ b/package.json
@@ -90,10 +90,8 @@
   },
   "inlinedDependencies": {
     "iron-webcrypto": "2.0.0",
-    "jose": "6.2.2",
+    "jose": "6.2.3",
     "uint8array-extras": "1.5.0"
   },
-  "dependencies": {
-    "eventemitter3": "^5.0.4"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -92,6 +92,5 @@
     "iron-webcrypto": "2.0.0",
     "jose": "6.2.2",
     "uint8array-extras": "1.5.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/src/feature-flags/event-emitter.spec.ts
+++ b/src/feature-flags/event-emitter.spec.ts
@@ -60,6 +60,23 @@ describe('EventEmitter', () => {
       expect(calls).toBe(1);
       expect(emitter.listenerCount('ping')).toBe(0);
     });
+
+    it('auto-removal does not also remove a sibling on() listener sharing the reference', () => {
+      // The same fn is registered both persistently and once. Auto-removing
+      // the once-listener must target that one registration, not every entry
+      // with a matching fn — otherwise the persistent on() listener is lost.
+      const received: number[] = [];
+      const fn = (n: number) => received.push(n);
+
+      emitter.on('ping', fn);
+      emitter.once('ping', fn);
+
+      emitter.emit('ping', 1); // both fire
+      emitter.emit('ping', 2); // only the persistent on() listener fires
+
+      expect(received).toEqual([1, 1, 2]);
+      expect(emitter.listenerCount('ping')).toBe(1);
+    });
   });
 
   describe('off', () => {

--- a/src/feature-flags/event-emitter.spec.ts
+++ b/src/feature-flags/event-emitter.spec.ts
@@ -1,0 +1,209 @@
+import { EventEmitter } from './event-emitter';
+
+interface TestEvents {
+  ping: [number];
+  data: [string, number];
+}
+
+describe('EventEmitter', () => {
+  let emitter: EventEmitter<TestEvents>;
+
+  beforeEach(() => {
+    emitter = new EventEmitter<TestEvents>();
+  });
+
+  describe('on / emit', () => {
+    it('invokes the listener with the emitted args', () => {
+      const received: number[] = [];
+      emitter.on('ping', (n) => received.push(n));
+
+      emitter.emit('ping', 42);
+
+      expect(received).toEqual([42]);
+    });
+
+    it('returns true when a listener ran, false when none did', () => {
+      expect(emitter.emit('ping', 1)).toBe(false);
+
+      emitter.on('ping', () => {});
+      expect(emitter.emit('ping', 1)).toBe(true);
+    });
+
+    it('invokes multiple listeners in registration order', () => {
+      const order: string[] = [];
+      emitter.on('ping', () => order.push('first'));
+      emitter.on('ping', () => order.push('second'));
+
+      emitter.emit('ping', 0);
+
+      expect(order).toEqual(['first', 'second']);
+    });
+
+    it('only invokes listeners for the emitted event', () => {
+      const pings: number[] = [];
+      emitter.on('ping', (n) => pings.push(n));
+
+      emitter.emit('data', 'x', 1);
+
+      expect(pings).toEqual([]);
+    });
+  });
+
+  describe('once', () => {
+    it('fires exactly once, then auto-removes', () => {
+      let calls = 0;
+      emitter.once('ping', () => calls++);
+
+      emitter.emit('ping', 1);
+      emitter.emit('ping', 2);
+
+      expect(calls).toBe(1);
+      expect(emitter.listenerCount('ping')).toBe(0);
+    });
+  });
+
+  describe('off', () => {
+    it('removes a listener registered with on()', () => {
+      const received: number[] = [];
+      const listener = (n: number) => received.push(n);
+
+      emitter.on('ping', listener);
+      emitter.off('ping', listener);
+      emitter.emit('ping', 1);
+
+      expect(received).toEqual([]);
+      expect(emitter.listenerCount('ping')).toBe(0);
+    });
+
+    it('removes a once()-registered listener by its original reference before it fires', () => {
+      let calls = 0;
+      const listener = () => calls++;
+
+      emitter.once('ping', listener);
+      emitter.off('ping', listener);
+      emitter.emit('ping', 1);
+
+      expect(calls).toBe(0);
+      expect(emitter.listenerCount('ping')).toBe(0);
+    });
+
+    it('leaves other listeners intact when removing one', () => {
+      const order: string[] = [];
+      const a = () => order.push('a');
+      const b = () => order.push('b');
+
+      emitter.on('ping', a);
+      emitter.on('ping', b);
+      emitter.off('ping', a);
+      emitter.emit('ping', 1);
+
+      expect(order).toEqual(['b']);
+    });
+  });
+
+  describe('dispatch safety', () => {
+    it('still fires a later listener removed mid-dispatch, then honors the removal next round', () => {
+      const order: string[] = [];
+      const b = () => order.push('b');
+      // `a` removes the later listener `b` mid-dispatch; the snapshot must keep
+      // `b` firing this round, with the removal taking effect next round.
+      const a = () => {
+        order.push('a');
+        emitter.off('ping', b);
+      };
+
+      emitter.on('ping', a);
+      emitter.on('ping', b);
+      emitter.emit('ping', 1);
+
+      expect(order).toEqual(['a', 'b']);
+      order.length = 0;
+      emitter.emit('ping', 2);
+      expect(order).toEqual(['a']);
+    });
+
+    it('does not fire a listener added during the same dispatch', () => {
+      const order: string[] = [];
+      const late = () => order.push('late');
+      // `first` registers `late` mid-dispatch. Because add() pushes onto the
+      // live handler array, only the snapshot taken at emit start prevents
+      // `late` from firing this round — this is the case that proves the snapshot.
+      const first = () => {
+        order.push('first');
+        emitter.on('ping', late);
+      };
+
+      emitter.on('ping', first);
+      emitter.emit('ping', 1);
+
+      expect(order).toEqual(['first']);
+      expect(emitter.listenerCount('ping')).toBe(2);
+
+      order.length = 0;
+      emitter.emit('ping', 2);
+      expect(order).toEqual(['first', 'late']);
+    });
+  });
+
+  describe('listenerCount', () => {
+    it('reflects adds and removes', () => {
+      expect(emitter.listenerCount('ping')).toBe(0);
+
+      const listener = () => {};
+      emitter.on('ping', listener);
+      emitter.on('ping', () => {});
+      expect(emitter.listenerCount('ping')).toBe(2);
+
+      emitter.off('ping', listener);
+      expect(emitter.listenerCount('ping')).toBe(1);
+    });
+  });
+
+  describe('removeAllListeners', () => {
+    it('clears listeners for a single event only', () => {
+      emitter.on('ping', () => {});
+      emitter.on('data', () => {});
+
+      emitter.removeAllListeners('ping');
+
+      expect(emitter.listenerCount('ping')).toBe(0);
+      expect(emitter.listenerCount('data')).toBe(1);
+    });
+
+    it('clears every event when called with no argument', () => {
+      emitter.on('ping', () => {});
+      emitter.on('data', () => {});
+
+      emitter.removeAllListeners();
+
+      expect(emitter.listenerCount('ping')).toBe(0);
+      expect(emitter.listenerCount('data')).toBe(0);
+    });
+  });
+
+  describe("unhandled 'error'", () => {
+    let errorEmitter: EventEmitter<{ error: [unknown] }>;
+
+    beforeEach(() => {
+      errorEmitter = new EventEmitter<{ error: [unknown] }>();
+    });
+
+    it('throws the emitted Error when there is no listener', () => {
+      const boom = new Error('boom');
+      expect(() => errorEmitter.emit('error', boom)).toThrow(boom);
+    });
+
+    it('wraps a non-Error value in an Error when there is no listener', () => {
+      expect(() => errorEmitter.emit('error', 'kaboom')).toThrow('kaboom');
+    });
+
+    it('does not throw when a listener is attached', () => {
+      const received: unknown[] = [];
+      errorEmitter.on('error', (err) => received.push(err));
+
+      const boom = new Error('boom');
+      expect(() => errorEmitter.emit('error', boom)).not.toThrow();
+      expect(received).toEqual([boom]);
+    });
+  });
+});

--- a/src/feature-flags/event-emitter.spec.ts
+++ b/src/feature-flags/event-emitter.spec.ts
@@ -206,4 +206,48 @@ describe('EventEmitter', () => {
       expect(received).toEqual([boom]);
     });
   });
+
+  describe('eventemitter3-compatible aliases', () => {
+    it('addListener registers a listener like on', () => {
+      const received: number[] = [];
+      emitter.addListener('ping', (n) => received.push(n));
+
+      emitter.emit('ping', 7);
+
+      expect(received).toEqual([7]);
+    });
+
+    it('removeListener removes a listener like off', () => {
+      const received: number[] = [];
+      const fn = (n: number) => received.push(n);
+      emitter.addListener('ping', fn);
+      emitter.removeListener('ping', fn);
+
+      emitter.emit('ping', 1);
+
+      expect(received).toEqual([]);
+    });
+
+    it('listeners returns the registered listener functions for an event', () => {
+      const a = (): void => {};
+      const b = (): void => {};
+      emitter.on('ping', a);
+      emitter.on('ping', b);
+
+      expect(emitter.listeners('ping')).toEqual([a, b]);
+      expect(emitter.listeners('data')).toEqual([]);
+    });
+
+    it('eventNames returns only events that currently have listeners', () => {
+      expect(emitter.eventNames()).toEqual([]);
+
+      const fn = (): void => {};
+      emitter.on('ping', fn);
+      emitter.on('data', () => {});
+      expect(emitter.eventNames()).toEqual(['ping', 'data']);
+
+      emitter.off('ping', fn);
+      expect(emitter.eventNames()).toEqual(['data']);
+    });
+  });
 });

--- a/src/feature-flags/event-emitter.spec.ts
+++ b/src/feature-flags/event-emitter.spec.ts
@@ -116,6 +116,23 @@ describe('EventEmitter', () => {
 
       expect(order).toEqual(['b']);
     });
+
+    it('removes every registration of a fn added more than once (eventemitter3 parity)', () => {
+      // eventemitter3's removeListener drops ALL entries for a fn (not just
+      // one), so off() does the same to keep the base-class swap non-breaking.
+      const received: number[] = [];
+      const fn = (n: number) => received.push(n);
+
+      emitter.on('ping', fn);
+      emitter.on('ping', fn);
+      expect(emitter.listenerCount('ping')).toBe(2);
+
+      emitter.off('ping', fn);
+
+      expect(emitter.listenerCount('ping')).toBe(0);
+      emitter.emit('ping', 1);
+      expect(received).toEqual([]);
+    });
   });
 
   describe('dispatch safety', () => {

--- a/src/feature-flags/event-emitter.ts
+++ b/src/feature-flags/event-emitter.ts
@@ -72,6 +72,32 @@ export class EventEmitter<Events extends Record<keyof Events, unknown[]>> {
     return this;
   }
 
+  // ── eventemitter3-compatible aliases ────────────────────────────────────
+  // FeatureFlagsRuntimeClient previously extended eventemitter3, whose
+  // EventEmitter also exposed these. They are kept so the runtime client's
+  // public surface stays a superset of the old one — swapping the base class
+  // off eventemitter3 is then non-breaking for consumers.
+  addListener<E extends keyof Events>(event: E, fn: Listener<Events[E]>): this {
+    return this.on(event, fn);
+  }
+
+  removeListener<E extends keyof Events>(
+    event: E,
+    fn: Listener<Events[E]>,
+  ): this {
+    return this.off(event, fn);
+  }
+
+  listeners<E extends keyof Events>(event: E): Array<Listener<Events[E]>> {
+    return (this.handlers.get(event) ?? []).map(
+      (h) => h.fn as Listener<Events[E]>,
+    );
+  }
+
+  eventNames(): Array<keyof Events> {
+    return [...this.handlers.keys()];
+  }
+
   private add<E extends keyof Events>(
     event: E,
     fn: Listener<Events[E]>,

--- a/src/feature-flags/event-emitter.ts
+++ b/src/feature-flags/event-emitter.ts
@@ -1,0 +1,85 @@
+type Listener<Args extends unknown[]> = (...args: Args) => void;
+
+/**
+ * Minimal, runtime-agnostic, typed event emitter.
+ *
+ * Replaces eventemitter3 so the SDK carries no event dependency and works in
+ * edge runtimes where `node:events` is not available. Generic over an event
+ * map (`{ eventName: [arg1, arg2, ...] }`) for compile-time-checked event
+ * names and payloads.
+ *
+ * Unlike eventemitter3, an unhandled `'error'` event throws instead of being
+ * silently dropped — matching Node's `EventEmitter` so failures are never
+ * swallowed.
+ */
+// `Record<keyof Events, unknown[]>` (rather than `Record<string, unknown[]>`)
+// lets the event map be declared as an `interface` as well as a `type` —
+// interfaces have no implicit string index signature, so the looser form
+// would reject them.
+export class EventEmitter<Events extends Record<keyof Events, unknown[]>> {
+  // Store the ORIGINAL listener fn (not a wrapper) so off() can remove
+  // once-listeners by the reference the caller passed. The internal fn type
+  // is (...args: any[]) => void — assignable both to and from the typed
+  // public signatures, so no casts are needed at the call sites. Public
+  // type-safety lives in the generic method signatures below.
+  private handlers = new Map<
+    keyof Events,
+    Array<{ fn: (...args: any[]) => void; once: boolean }>
+  >();
+
+  on<E extends keyof Events>(event: E, fn: Listener<Events[E]>): this {
+    return this.add(event, fn, false);
+  }
+
+  once<E extends keyof Events>(event: E, fn: Listener<Events[E]>): this {
+    return this.add(event, fn, true);
+  }
+
+  off<E extends keyof Events>(event: E, fn: Listener<Events[E]>): this {
+    const list = this.handlers.get(event);
+    if (list) {
+      const next = list.filter((h) => h.fn !== fn);
+      if (next.length) this.handlers.set(event, next);
+      else this.handlers.delete(event);
+    }
+    return this;
+  }
+
+  emit<E extends keyof Events>(event: E, ...args: Events[E]): boolean {
+    const list = this.handlers.get(event);
+    if (!list || list.length === 0) {
+      // Node semantics: an unhandled 'error' must not be silently dropped.
+      if (event === 'error') {
+        throw args[0] instanceof Error ? args[0] : new Error(String(args[0]));
+      }
+      return false;
+    }
+    // Snapshot so once-removal / off() during dispatch is safe.
+    for (const h of [...list]) {
+      if (h.once) this.off(event, h.fn);
+      h.fn(...args);
+    }
+    return true;
+  }
+
+  listenerCount(event: keyof Events): number {
+    return this.handlers.get(event)?.length ?? 0;
+  }
+
+  removeAllListeners(event?: keyof Events): this {
+    if (event === undefined) this.handlers.clear();
+    else this.handlers.delete(event);
+    return this;
+  }
+
+  private add<E extends keyof Events>(
+    event: E,
+    fn: Listener<Events[E]>,
+    once: boolean,
+  ): this {
+    const list = this.handlers.get(event) ?? [];
+    list.push({ fn, once });
+    this.handlers.set(event, list);
+    return this;
+  }
+}

--- a/src/feature-flags/event-emitter.ts
+++ b/src/feature-flags/event-emitter.ts
@@ -1,5 +1,12 @@
 type Listener<Args extends unknown[]> = (...args: Args) => void;
 
+// Internal registration record. `fn` is stored loosely typed
+// (`(...args: any[]) => void`) so it is assignable both to and from the typed
+// public signatures — call sites need no casts, and public type-safety lives in
+// the generic method signatures. The ORIGINAL listener fn is stored (not a
+// wrapper) so off() matches the reference the caller passed.
+type Handler = { fn: (...args: any[]) => void; once: boolean };
+
 /**
  * Minimal, runtime-agnostic, typed event emitter.
  *
@@ -17,15 +24,7 @@ type Listener<Args extends unknown[]> = (...args: Args) => void;
 // interfaces have no implicit string index signature, so the looser form
 // would reject them.
 export class EventEmitter<Events extends Record<keyof Events, unknown[]>> {
-  // Store the ORIGINAL listener fn (not a wrapper) so off() can remove
-  // once-listeners by the reference the caller passed. The internal fn type
-  // is (...args: any[]) => void — assignable both to and from the typed
-  // public signatures, so no casts are needed at the call sites. Public
-  // type-safety lives in the generic method signatures below.
-  private handlers = new Map<
-    keyof Events,
-    Array<{ fn: (...args: any[]) => void; once: boolean }>
-  >();
+  private handlers = new Map<keyof Events, Handler[]>();
 
   on<E extends keyof Events>(event: E, fn: Listener<Events[E]>): this {
     return this.add(event, fn, false);
@@ -36,12 +35,7 @@ export class EventEmitter<Events extends Record<keyof Events, unknown[]>> {
   }
 
   off<E extends keyof Events>(event: E, fn: Listener<Events[E]>): this {
-    const list = this.handlers.get(event);
-    if (list) {
-      const next = list.filter((h) => h.fn !== fn);
-      if (next.length) this.handlers.set(event, next);
-      else this.handlers.delete(event);
-    }
+    this.remove(event, (h) => h.fn !== fn);
     return this;
   }
 
@@ -56,7 +50,9 @@ export class EventEmitter<Events extends Record<keyof Events, unknown[]>> {
     }
     // Snapshot so once-removal / off() during dispatch is safe.
     for (const h of [...list]) {
-      if (h.once) this.off(event, h.fn);
+      // Remove the once-registration by identity, not by fn: the same fn may
+      // also be registered with on(), and only this entry should be dropped.
+      if (h.once) this.remove(event, (existing) => existing !== h);
       h.fn(...args);
     }
     return true;
@@ -107,5 +103,15 @@ export class EventEmitter<Events extends Record<keyof Events, unknown[]>> {
     list.push({ fn, once });
     this.handlers.set(event, list);
     return this;
+  }
+
+  // Single owner of the "filter the list, then keep-or-delete the slot" logic
+  // shared by off() and once auto-removal.
+  private remove(event: keyof Events, keep: (h: Handler) => boolean): void {
+    const list = this.handlers.get(event);
+    if (!list) return;
+    const next = list.filter(keep);
+    if (next.length) this.handlers.set(event, next);
+    else this.handlers.delete(event);
   }
 }

--- a/src/feature-flags/event-emitter.ts
+++ b/src/feature-flags/event-emitter.ts
@@ -34,6 +34,8 @@ export class EventEmitter<Events extends Record<keyof Events, unknown[]>> {
     return this.add(event, fn, true);
   }
 
+  // Removes every registration of `fn`, matching eventemitter3's
+  // removeListener (which, called without a context, also drops all matches).
   off<E extends keyof Events>(event: E, fn: Listener<Events[E]>): this {
     this.remove(event, (h) => h.fn !== fn);
     return this;

--- a/src/feature-flags/interfaces/flag-change.interface.ts
+++ b/src/feature-flags/interfaces/flag-change.interface.ts
@@ -1,0 +1,7 @@
+import { FlagPollEntry } from './flag-poll-response.interface';
+
+export interface FlagChange {
+  key: string;
+  previous: FlagPollEntry | null;
+  current: FlagPollEntry | null;
+}

--- a/src/feature-flags/interfaces/flag-poll-response.interface.ts
+++ b/src/feature-flags/interfaces/flag-poll-response.interface.ts
@@ -14,3 +14,9 @@ export interface FlagPollEntry {
 }
 
 export type FlagPollResponse = Record<string, FlagPollEntry>;
+
+export interface FlagChange {
+  key: string;
+  previous: FlagPollEntry | null;
+  current: FlagPollEntry | null;
+}

--- a/src/feature-flags/interfaces/flag-poll-response.interface.ts
+++ b/src/feature-flags/interfaces/flag-poll-response.interface.ts
@@ -14,9 +14,3 @@ export interface FlagPollEntry {
 }
 
 export type FlagPollResponse = Record<string, FlagPollEntry>;
-
-export interface FlagChange {
-  key: string;
-  previous: FlagPollEntry | null;
-  current: FlagPollEntry | null;
-}

--- a/src/feature-flags/interfaces/index.ts
+++ b/src/feature-flags/interfaces/index.ts
@@ -1,6 +1,7 @@
 export * from './add-flag-target-options.interface';
 export * from './evaluation-context.interface';
 export * from './feature-flag.interface';
+export * from './flag-change.interface';
 export * from './flag-poll-response.interface';
 export * from './list-feature-flags-options.interface';
 export * from './remove-flag-target-options.interface';

--- a/src/feature-flags/runtime-client.spec.ts
+++ b/src/feature-flags/runtime-client.spec.ts
@@ -502,5 +502,22 @@ describe('FeatureFlagsRuntimeClient', () => {
 
       client.close();
     });
+
+    it('throws on an error event when no listener is attached', () => {
+      // poll()'s catch block emits 'error'. With no listener, the emitter must
+      // throw (Node semantics) rather than silently drop it — the behavior
+      // eventemitter3 lacked and the old emit() override restored. Every other
+      // error test attaches a listener first, so this is the only guard against
+      // re-introducing silent error-dropping. Asserted on the inherited emit
+      // directly: via the real poll path the throw would surface as an
+      // unhandled promise rejection (poll runs in a setTimeout), which can't be
+      // observed deterministically.
+      const client = workos.featureFlags.createRuntimeClient();
+
+      const boom = new Error('boom');
+      expect(() => client.emit('error', boom)).toThrow(boom);
+
+      client.close();
+    });
   });
 });

--- a/src/feature-flags/runtime-client.ts
+++ b/src/feature-flags/runtime-client.ts
@@ -1,10 +1,11 @@
-import { EventEmitter } from 'eventemitter3';
+import { EventEmitter } from './event-emitter';
 import { WorkOS } from '../workos';
 import { UnauthorizedException } from '../common/exceptions';
 import { InMemoryStore } from './in-memory-store';
 import { Evaluator } from './evaluator';
 import {
   EvaluationContext,
+  FlagChange,
   FlagPollEntry,
   FlagPollResponse,
   FlagTarget,
@@ -12,6 +13,12 @@ import {
   RuntimeClientLogger,
   RuntimeClientStats,
 } from './interfaces';
+
+interface RuntimeClientEvents {
+  change: [FlagChange];
+  error: [Error];
+  failed: [Error];
+}
 
 const DEFAULT_POLLING_INTERVAL_MS = 30_000;
 const MIN_POLLING_INTERVAL_MS = 5_000;
@@ -22,7 +29,7 @@ const INITIAL_RETRY_MS = 1_000;
 const MAX_RETRY_MS = 60_000;
 const BACKOFF_MULTIPLIER = 2;
 
-export class FeatureFlagsRuntimeClient extends EventEmitter {
+export class FeatureFlagsRuntimeClient extends EventEmitter<RuntimeClientEvents> {
   private readonly store: InMemoryStore;
   private readonly evaluator: Evaluator;
   private readonly pollingIntervalMs: number;
@@ -103,16 +110,6 @@ export class FeatureFlagsRuntimeClient extends EventEmitter {
     });
   }
 
-  // eventemitter3 silently drops 'error' events with no listeners.
-  // Restore Node's EventEmitter behavior: throw so poll failures
-  // are never silently swallowed.
-  override emit(event: string | symbol, ...args: unknown[]): boolean {
-    if (event === 'error' && this.listenerCount(event as string) === 0) {
-      throw args[0] instanceof Error ? args[0] : new Error(String(args[0]));
-    }
-    return super.emit(event, ...args);
-  }
-
   close(): void {
     this.closed = true;
     this.pollAbortController?.abort();
@@ -183,15 +180,17 @@ export class FeatureFlagsRuntimeClient extends EventEmitter {
     } catch (error) {
       if (this.closed) return;
 
+      const err = error instanceof Error ? error : new Error(String(error));
+
       this.consecutiveErrors++;
       this.stats.pollErrorCount++;
-      this.emit('error', error);
-      this.logger?.error('Poll failed', error);
+      this.emit('error', err);
+      this.logger?.error('Poll failed', err);
 
-      if (error instanceof UnauthorizedException) {
-        this.emit('failed', error);
+      if (err instanceof UnauthorizedException) {
+        this.emit('failed', err);
         if (!this.initialized && this.readyReject) {
-          this.readyReject(error);
+          this.readyReject(err);
           this.readyReject = null;
         }
         return;


### PR DESCRIPTION
## What

Removes the `eventemitter3` runtime dependency and replaces it with a small, first-party typed `EventEmitter` (`src/feature-flags/event-emitter.ts`). `FeatureFlagsRuntimeClient` now extends this internal emitter and declares a typed event map (`change` / `error` / `failed`), so event names and payloads are compile-checked.

After this change the SDK has **zero runtime dependencies** (`dependencies: {}`).

## Why

`eventemitter3` lived in `dependencies` and was **not** on tsdown's `onlyAllowBundle` whitelist, so every build artifact — including the `workerd` / `edge-light` / `convex` entries — emitted a bare `import { EventEmitter } from 'eventemitter3'`. That external specifier had to be resolved by the consumer's bundler/runtime, which is what made it leak into client/edge bundles. As inlined first-party code there is no external module to resolve, no `exports`-map condition matching, and no dual-package hazard — the emitter is compiled directly into each artifact.

(`eventemitter3` is edge-safe at runtime; the problem was packaging, not the library.)

## Behavior notes

- **Unhandled `error` throws.** The internal emitter throws on an emitted `error` with no listener (matching Node's `EventEmitter`), replacing the old `override emit` shim on the client. Poll failures are never silently dropped.
- **Public surface is a superset of eventemitter3's.** In addition to `on`/`once`/`off`/`emit`/`listenerCount`/`removeAllListeners`, the emitter keeps `addListener`/`removeListener`/`listeners`/`eventNames` aliases so swapping the base class is non-breaking for consumers that used them.
- **Dispatch safety:** listeners are snapshotted at `emit` time, so adding/removing listeners (including `once` auto-removal) mid-dispatch is well-defined and covered by tests.

## Testing

- New `event-emitter.spec.ts` — on/once/off, registration order, dispatch-during-dispatch safety, unhandled-`error` throwing, and the eventemitter3 aliases.
- `runtime-client.spec.ts` — added a guard test that `emit('error')` with no listener throws.
- `npx tsc --noEmit`, prettier, and eslint all clean; full feature-flags suite green.

## Follow-up (not in this PR)

Pre-existing: in `poll()`, `emit('error')` with no listener attached throws from inside the catch block, which skips `scheduleNextPoll()` and can halt polling (and surface as an unhandled rejection, since `poll` runs in a timer). This behavior predates this PR — it carried over from the old `override emit` — but is worth a separate look at whether a background poller should be able to be wedged by a missing observer.
