### PR TITLE
feat: Surface agent registration id on API key validation

### DIFF
--- a/src/api-keys/api-keys.spec.ts
+++ b/src/api-keys/api-keys.spec.ts
@@ -62,14 +62,14 @@ describe('ApiKeys', () => {
     it('returns the agent registration id for an agent-assigned key', async () => {
       fetchOnce({
         ...validateApiKeyFixture,
-        agent_registration_id: 'agent_registration_01EHZNVPK3SFK441A1RGBFSHRT',
+        agent_registration_id: 'agent_reg_01EHZNVPK3SFK441A1RGBFSHRT',
       });
       const response = await workos.apiKeys.createValidation({
         value: 'sk_123',
       });
 
       expect(response.agentRegistrationId).toEqual(
-        'agent_registration_01EHZNVPK3SFK441A1RGBFSHRT',
+        'agent_reg_01EHZNVPK3SFK441A1RGBFSHRT',
       );
     });
 

--- a/src/api-keys/api-keys.spec.ts
+++ b/src/api-keys/api-keys.spec.ts
@@ -58,6 +58,29 @@ describe('ApiKeys', () => {
       expect(fetchURL()).toContain('/api_keys/validations');
       expect(response).toEqual({ apiKey: null });
     });
+
+    it('returns the agent registration id for an agent-assigned key', async () => {
+      fetchOnce({
+        ...validateApiKeyFixture,
+        agent_registration_id: 'agent_registration_01EHZNVPK3SFK441A1RGBFSHRT',
+      });
+      const response = await workos.apiKeys.createValidation({
+        value: 'sk_123',
+      });
+
+      expect(response.agentRegistrationId).toEqual(
+        'agent_registration_01EHZNVPK3SFK441A1RGBFSHRT',
+      );
+    });
+
+    it('omits the agent registration id for a non-agent key', async () => {
+      fetchOnce(validateApiKeyFixture);
+      const response = await workos.apiKeys.createValidation({
+        value: 'sk_123',
+      });
+
+      expect(response).not.toHaveProperty('agentRegistrationId');
+    });
   });
 
   describe('deleteApiKey', () => {

--- a/src/api-keys/interfaces/validate-api-key.interface.ts
+++ b/src/api-keys/interfaces/validate-api-key.interface.ts
@@ -6,8 +6,14 @@ export interface ValidateApiKeyOptions {
 
 export interface ValidateApiKeyResponse {
   apiKey: ApiKey | null;
+  /**
+   * The ID of the agent registration this API key was issued for. Present only
+   * when the API key is assigned to an agent registration.
+   */
+  agentRegistrationId?: string;
 }
 
 export interface SerializedValidateApiKeyResponse {
   api_key: SerializedApiKey | null;
+  agent_registration_id?: string;
 }

--- a/src/api-keys/serializers/validate-api-key.serializer.ts
+++ b/src/api-keys/serializers/validate-api-key.serializer.ts
@@ -9,5 +9,8 @@ export function deserializeValidateApiKeyResponse(
 ): ValidateApiKeyResponse {
   return {
     apiKey: response.api_key ? deserializeApiKey(response.api_key) : null,
+    ...(typeof response.agent_registration_id === 'undefined'
+      ? undefined
+      : { agentRegistrationId: response.agent_registration_id }),
   };
 }


### PR DESCRIPTION
## Summary

Adapts the SDK to [workos/workos#63786](https://github.com/workos/workos/pull/63786), which expands the `POST /api_keys/validations` response with an optional top-level `agent_registration_id` — present only when the validated API key is assigned to an agent registration, omitted otherwise.

`workos.apiKeys.createValidation` now surfaces this as an optional `agentRegistrationId`:

- `ValidateApiKeyResponse` gains `agentRegistrationId?: string` (and the serialized type gains `agent_registration_id?`).
- The deserializer conditionally spreads the field, so it is **omitted** (not `null`) for non-agent keys — mirroring the server's "present only when set" semantics and matching the existing optional-field convention (e.g. `stripeCustomerId` in the organization serializer).

The shared `ApiKey` object (list/create/get) is unchanged; the new field lives on the validation response only.

## Testing

- `jest src/api-keys` — 11 pass (added: agent-assigned key returns the registration id; non-agent key omits the field; existing cases untouched)
- `tsc --noEmit`, `eslint`, and `prettier --check` all clean

Closes AUTH-6624

🤖 Generated with [Claude Code](https://claude.com/claude-code)
