### PR TITLE
feat: Add source to role assignments to distinguish group grants

### DIFF
--- a/src/authorization/authorization.spec.ts
+++ b/src/authorization/authorization.spec.ts
@@ -1629,6 +1629,30 @@ describe('Authorization', () => {
   });
 
   describe('listRoleAssignments', () => {
+    it('deserializes a group-derived source', async () => {
+      fetchOnce({
+        ...listRoleAssignmentsFixture,
+        data: [
+          {
+            ...listRoleAssignmentsFixture.data[0],
+            source: {
+              type: 'group',
+              group_role_assignment_id: testGroupRoleAssignmentId,
+            },
+          },
+        ],
+      });
+
+      const result = await workos.authorization.listRoleAssignments({
+        organizationMembershipId: testOrgMembershipId,
+      });
+
+      expect(result.data[0].source).toEqual({
+        type: 'group',
+        groupRoleAssignmentId: testGroupRoleAssignmentId,
+      });
+    });
+
     it('lists role assignments for an organization membership', async () => {
       fetchOnce(listRoleAssignmentsFixture);
 
@@ -1650,6 +1674,10 @@ describe('Authorization', () => {
           id: 'resource_01HXYZ123ABC456DEF789XYZ',
           externalId: 'doc-123',
           resourceTypeSlug: 'document',
+        },
+        source: {
+          type: 'direct',
+          groupRoleAssignmentId: null,
         },
         createdAt: '2024-01-15T09:30:00.000Z',
         updatedAt: '2024-01-15T09:30:00.000Z',
@@ -1797,6 +1825,10 @@ describe('Authorization', () => {
           externalId: 'doc-123',
           resourceTypeSlug: 'document',
         },
+        source: {
+          type: 'direct',
+          groupRoleAssignmentId: null,
+        },
         createdAt: '2024-01-15T09:30:00.000Z',
         updatedAt: '2024-01-15T09:30:00.000Z',
       });
@@ -1890,6 +1922,10 @@ describe('Authorization', () => {
           id: 'resource_01HXYZ123ABC456DEF789XYZ',
           externalId: 'doc-123',
           resourceTypeSlug: 'document',
+        },
+        source: {
+          type: 'direct',
+          groupRoleAssignmentId: null,
         },
         createdAt: '2024-01-15T09:30:00.000Z',
         updatedAt: '2024-01-15T09:30:00.000Z',
@@ -1992,6 +2028,10 @@ describe('Authorization', () => {
           id: 'resource_01HXYZ123ABC456DEF789XYZ',
           externalId: 'doc-123',
           resourceTypeSlug: 'document',
+        },
+        source: {
+          type: 'direct',
+          groupRoleAssignmentId: null,
         },
         createdAt: '2024-01-15T09:30:00.000Z',
         updatedAt: '2024-01-15T09:30:00.000Z',

--- a/src/authorization/fixtures/list-role-assignments.json
+++ b/src/authorization/fixtures/list-role-assignments.json
@@ -13,6 +13,10 @@
         "external_id": "doc-123",
         "resource_type_slug": "document"
       },
+      "source": {
+        "type": "direct",
+        "group_role_assignment_id": null
+      },
       "created_at": "2024-01-15T09:30:00.000Z",
       "updated_at": "2024-01-15T09:30:00.000Z"
     }

--- a/src/authorization/fixtures/role-assignment.json
+++ b/src/authorization/fixtures/role-assignment.json
@@ -10,6 +10,10 @@
     "external_id": "doc-123",
     "resource_type_slug": "document"
   },
+  "source": {
+    "type": "direct",
+    "group_role_assignment_id": null
+  },
   "created_at": "2024-01-15T09:30:00.000Z",
   "updated_at": "2024-01-15T09:30:00.000Z"
 }

--- a/src/authorization/interfaces/role-assignment.interface.ts
+++ b/src/authorization/interfaces/role-assignment.interface.ts
@@ -14,6 +14,18 @@ export interface RoleAssignmentResourceResponse {
   resource_type_slug: string;
 }
 
+export interface RoleAssignmentSource {
+  /** Whether the role was assigned directly or derived from a group. */
+  type: 'direct' | 'group';
+  /** The ID of the group role assignment the role was derived from, or null if direct. */
+  groupRoleAssignmentId: string | null;
+}
+
+export interface RoleAssignmentSourceResponse {
+  type: 'direct' | 'group';
+  group_role_assignment_id: string | null;
+}
+
 export interface RoleAssignment {
   /** Distinguishes the role assignment object. */
   object: 'role_assignment';
@@ -25,6 +37,8 @@ export interface RoleAssignment {
   role: RoleAssignmentRole;
   /** The resource to which the role is assigned. */
   resource: RoleAssignmentResource;
+  /** The origin of the role assignment. */
+  source: RoleAssignmentSource;
   /** An ISO 8601 timestamp. */
   createdAt: string;
   /** An ISO 8601 timestamp. */
@@ -37,6 +51,7 @@ export interface RoleAssignmentResponse {
   organization_membership_id: string;
   role: RoleAssignmentRole;
   resource: RoleAssignmentResourceResponse;
+  source: RoleAssignmentSourceResponse;
   created_at: string;
   updated_at: string;
 }

--- a/src/authorization/serializers/role-assignment.serializer.ts
+++ b/src/authorization/serializers/role-assignment.serializer.ts
@@ -15,6 +15,10 @@ export const deserializeRoleAssignment = (
     externalId: response.resource.external_id,
     resourceTypeSlug: response.resource.resource_type_slug,
   },
+  source: {
+    type: response.source.type,
+    groupRoleAssignmentId: response.source.group_role_assignment_id,
+  },
   createdAt: response.created_at,
   updatedAt: response.updated_at,
 });


### PR DESCRIPTION
## Summary

Adds Node support for [workos/workos#63214](https://github.com/workos/workos/pull/63214), which adds a `source` object to `UserRoleAssignment` REST responses.

`RoleAssignment` now carries a `source` with a `type` (`"direct"` | `"group"`) and a nullable `groupRoleAssignmentId`, letting callers distinguish directly-assigned roles from those derived from a group role assignment.

## Changes

- New `RoleAssignmentSource` / `RoleAssignmentSourceResponse` interfaces; `source` added to `RoleAssignment` and `RoleAssignmentResponse`
- Serializer maps `group_role_assignment_id` → `groupRoleAssignmentId`
- Fixtures + tests updated; added coverage for the `group`-derived case

🤖 Generated with [Claude Code](https://claude.com/claude-code)