### PR TITLE
fix: ApiKey.owner type missing user variant and organizationId

### DIFF
--- a/src/api-keys/api-keys.spec.ts
+++ b/src/api-keys/api-keys.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '../common/utils/test-utils';
 import { WorkOS } from '../workos';
 import validateApiKeyFixture from './fixtures/validate-api-key.json';
+import validateApiKeyUserOwnerFixture from './fixtures/validate-api-key-user-owner.json';
 import listOrganizationApiKeysFixture from './fixtures/list-organization-api-keys.json';
 import createOrganizationApiKeyFixture from './fixtures/create-organization-api-key.json';
 
@@ -40,6 +41,31 @@ describe('ApiKeys', () => {
             id: 'org_01H5JQDV7R7ATEYZDEG0W5PRYS',
           },
           name: 'Test Api Key',
+          obfuscatedValue: 'sk_…PRYS',
+          lastUsedAt: null,
+          permissions: ['read', 'write'],
+          createdAt: '2023-07-18T02:07:19.911Z',
+          updatedAt: '2023-07-18T02:07:19.911Z',
+        },
+      });
+    });
+
+    it('deserializes a user owner with organizationId', async () => {
+      fetchOnce(validateApiKeyUserOwnerFixture);
+      const response = await workos.apiKeys.createValidation({
+        value: 'sk_123',
+      });
+
+      expect(response).toEqual({
+        apiKey: {
+          object: 'api_key',
+          id: 'api_key_01H5JQDV7R7ATEYZDEG0W5PRYS',
+          owner: {
+            type: 'user',
+            id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+            organizationId: 'org_01H5JQDV7R7ATEYZDEG0W5PRYS',
+          },
+          name: 'Test User Api Key',
           obfuscatedValue: 'sk_…PRYS',
           lastUsedAt: null,
           permissions: ['read', 'write'],

--- a/src/api-keys/fixtures/validate-api-key-user-owner.json
+++ b/src/api-keys/fixtures/validate-api-key-user-owner.json
@@ -1,0 +1,17 @@
+{
+  "api_key": {
+    "object": "api_key",
+    "id": "api_key_01H5JQDV7R7ATEYZDEG0W5PRYS",
+    "owner": {
+      "type": "user",
+      "id": "user_01H5JQDV7R7ATEYZDEG0W5PRYS",
+      "organization_id": "org_01H5JQDV7R7ATEYZDEG0W5PRYS"
+    },
+    "name": "Test User Api Key",
+    "obfuscated_value": "sk_…PRYS",
+    "last_used_at": null,
+    "permissions": ["read", "write"],
+    "created_at": "2023-07-18T02:07:19.911Z",
+    "updated_at": "2023-07-18T02:07:19.911Z"
+  }
+}

--- a/src/api-keys/interfaces/api-key.interface.ts
+++ b/src/api-keys/interfaces/api-key.interface.ts
@@ -5,10 +5,16 @@ export interface ApiKey {
   /** Unique identifier of the API Key. */
   id: string;
   /** The entity that owns the API Key. */
-  owner: {
-    type: 'organization';
-    id: string;
-  };
+  owner:
+    | {
+        type: 'organization';
+        id: string;
+      }
+    | {
+        type: 'user';
+        id: string;
+        organizationId: string;
+      };
   /** A descriptive name for the API Key. */
   name: string;
   /** An obfuscated representation of the API Key value. */
@@ -26,10 +32,16 @@ export interface ApiKey {
 export interface SerializedApiKey {
   object: 'api_key';
   id: string;
-  owner: {
-    type: 'organization';
-    id: string;
-  };
+  owner:
+    | {
+        type: 'organization';
+        id: string;
+      }
+    | {
+        type: 'user';
+        id: string;
+        organization_id: string;
+      };
   name: string;
   obfuscated_value: string;
   last_used_at: string | null;

--- a/src/api-keys/serializers/api-key.serializer.ts
+++ b/src/api-keys/serializers/api-key.serializer.ts
@@ -4,7 +4,14 @@ export function deserializeApiKey(apiKey: SerializedApiKey): ApiKey {
   return {
     object: apiKey.object,
     id: apiKey.id,
-    owner: apiKey.owner,
+    owner:
+      apiKey.owner.type === 'user'
+        ? {
+            type: 'user',
+            id: apiKey.owner.id,
+            organizationId: apiKey.owner.organization_id,
+          }
+        : apiKey.owner,
     name: apiKey.name,
     obfuscatedValue: apiKey.obfuscated_value,
     lastUsedAt: apiKey.last_used_at,


### PR DESCRIPTION
## Summary

- `ApiKey.owner` was typed as `{ type: 'organization'; id: string }` only, but the API can return a `user` owner with `{ type: 'user'; id: string; organization_id: string }`
- Updated `ApiKey` and `SerializedApiKey` interfaces to use a discriminated union covering both variants
- Updated `deserializeApiKey` to convert `organization_id` → `organizationId` for user owners
- Added fixture and test case for the user owner case

## Test plan

- [ ] `npx jest src/api-keys/api-keys.spec.ts` — all 12 tests pass

Reported by customer in T-9253.