### PR TITLE
refactor: Read org_id claim instead of organization_id for agent access tokens

### DIFF
--- a/src/agents/agents.spec.ts
+++ b/src/agents/agents.spec.ts
@@ -15,7 +15,7 @@ const ACCESS_TOKEN_PAYLOAD = {
   aud: 'proj_123',
   sub: 'agent_reg_01EHZNVPK3SFK441A1RGBFSHRT',
   jti: '01EHZNVPK3SFK441A1RGBFSHRT',
-  organization_id: 'org_01EHZNVPK3SFK441A1RGBFSHRT',
+  org_id: 'org_01EHZNVPK3SFK441A1RGBFSHRT',
   scope: 'read write',
   exp: 4102444800, // 2100-01-01T00:00:00Z
   iat: 1689646039,
@@ -225,7 +225,7 @@ describe('Agents', () => {
 
       it('reports invalid for a token missing the agent identity claims', async () => {
         // A token signed by the same JWKS with the right audience but without
-        // the agent claims (sub/jti/organization_id) is not an agent credential.
+        // the agent claims (sub/jti/org_id) is not an agent credential.
         const { sub, ...withoutSub } = ACCESS_TOKEN_PAYLOAD;
         jest
           .mocked(jose.jwtVerify)

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -30,7 +30,7 @@ function hasRequiredAgentClaims(
     (typeof payload.aud === 'string' || Array.isArray(payload.aud)) &&
     typeof payload.sub === 'string' &&
     typeof payload.jti === 'string' &&
-    typeof payload.organization_id === 'string' &&
+    typeof payload.org_id === 'string' &&
     typeof payload.exp === 'number' &&
     typeof payload.iat === 'number'
   );

--- a/src/agents/interfaces/validate-agent-credential.interface.ts
+++ b/src/agents/interfaces/validate-agent-credential.interface.ts
@@ -79,7 +79,7 @@ export interface SerializedAgentAccessTokenClaims {
   aud: string | string[];
   sub: string;
   jti: string;
-  organization_id: string;
+  org_id: string;
   exp: number;
   iat: number;
   scope?: string;

--- a/src/agents/serializers/validate-agent-credential.serializer.ts
+++ b/src/agents/serializers/validate-agent-credential.serializer.ts
@@ -50,7 +50,7 @@ export function deserializeAgentAccessTokenClaims(
     audience: payload.aud,
     registrationId: payload.sub,
     jti: payload.jti,
-    organizationId: payload.organization_id,
+    organizationId: payload.org_id,
     scope: payload.scope,
     actor: payload.act,
     expiresAt: payload.exp,


### PR DESCRIPTION
## Description

The server is switching the canonical agent access token claim from `organization_id` to `org_id` (see [workos/workos#64524](https://github.com/workos/workos/pull/64524)). This PR updates the Node SDK to read `org_id` from the JWT payload.

Changes:
- `SerializedAgentAccessTokenClaims.organization_id` → `org_id`
- `hasRequiredAgentClaims` type guard checks `org_id` instead of `organization_id`
- `deserializeAgentAccessTokenClaims` reads `payload.org_id`
- Tests updated to use `org_id` in the token fixture

The public `AgentAccessTokenClaims.organizationId` field is unchanged — consumers are unaffected.

## Documentation

```
[x] Yes
```

Docs PR: https://github.com/workos/workos/pull/64524

Link to Devin session: https://app.devin.ai/sessions/84b058ead3984651ae5e337002e3a837
Requested by: @m0tzy