### PR TITLE
fix: Surface the error field and request ID on 422 exceptions

### DIFF
--- a/src/common/exceptions/unprocessable-entity.exception.ts
+++ b/src/common/exceptions/unprocessable-entity.exception.ts
@@ -13,11 +13,13 @@ export class UnprocessableEntityException
 
   constructor({
     code,
+    error,
     errors,
     message,
     requestID,
   }: {
     code?: string;
+    error?: string;
     errors?: UnprocessableEntityError[];
     message?: string;
     requestID: string;
@@ -28,6 +30,8 @@ export class UnprocessableEntityException
 
     if (message) {
       this.message = message;
+    } else if (error) {
+      this.message = `Error: ${error}`;
     }
 
     if (code) {

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -307,7 +307,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
           message: `Request timeout after ${timeout}ms`,
           response: {
             status: 408,
-            headers: {},
+            headers: new Headers(),
             data: { error: 'Request timeout' },
           },
         });

--- a/src/common/net/http-client.ts
+++ b/src/common/net/http-client.ts
@@ -138,7 +138,7 @@ export abstract class HttpClientResponse implements HttpClientResponseInterface 
 export class HttpClientError<T> extends Error {
   readonly name: string = 'HttpClientError';
   readonly message: string = 'The request could not be completed.';
-  readonly response: { status: number; headers: any; data: T };
+  readonly response: { status: number; headers: Headers; data: T };
 
   constructor({
     message,

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -316,6 +316,54 @@ describe('WorkOS', () => {
       });
     });
 
+    describe('when the api responds with a 422 and an error but no message', () => {
+      it('surfaces the error in the exception message', async () => {
+        fetchOnce(
+          { error: 'Maximum unique keys reached' },
+          { status: 422, headers: { 'X-Request-ID': 'a-request-id' } },
+        );
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        await expect(workos.post('/path', {})).rejects.toMatchObject({
+          message: 'Error: Maximum unique keys reached',
+          requestID: 'a-request-id',
+          status: 422,
+        });
+      });
+
+      it('prefers the message over the error when both are present', async () => {
+        fetchOnce(
+          { error: 'an-error', message: 'A message' },
+          { status: 422, headers: { 'X-Request-ID': 'a-request-id' } },
+        );
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        await expect(workos.post('/path', {})).rejects.toMatchObject({
+          message: 'A message',
+          status: 422,
+        });
+      });
+
+      it('still formats field errors when present', async () => {
+        fetchOnce(
+          {
+            error: 'an-error',
+            errors: [{ field: 'a-field', code: 'a-requirement' }],
+          },
+          { status: 422, headers: { 'X-Request-ID': 'a-request-id' } },
+        );
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        await expect(workos.post('/path', {})).rejects.toMatchObject({
+          message: 'The following requirement must be met:\n\ta-requirement\n',
+          status: 422,
+        });
+      });
+    });
+
     describe('when the api responds with a 500 and no error/error_description', () => {
       it('throws an GenericServerException', async () => {
         fetchOnce(

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -364,6 +364,33 @@ describe('WorkOS', () => {
       });
     });
 
+    describe('when the request times out', () => {
+      it('surfaces the timeout rather than a headers TypeError', async () => {
+        const neverResolvingFetch = jest.fn(
+          (_url: any, init: any) =>
+            new Promise((_resolve, reject) => {
+              init?.signal?.addEventListener('abort', () => {
+                const abortError = new Error('Aborted');
+                abortError.name = 'AbortError';
+                reject(abortError);
+              });
+            }) as any,
+        );
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
+          timeout: 1,
+          fetchFn: neverResolvingFetch as any,
+        });
+
+        await expect(workos.post('/path', {})).rejects.toMatchObject({
+          name: 'OauthException',
+          status: 408,
+          requestID: '',
+          message: 'Error: Request timeout',
+        });
+      }, 20000);
+    });
+
     describe('when the api responds with a 500 and no error/error_description', () => {
       it('throws an GenericServerException', async () => {
         fetchOnce(

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -397,7 +397,7 @@ export class WorkOS {
     if (response) {
       const { status, data, headers } = response;
 
-      const requestID = headers['X-Request-ID'] ?? '';
+      const requestID = headers.get('X-Request-ID') ?? '';
       const {
         code,
         error_description: errorDescription,
@@ -416,6 +416,7 @@ export class WorkOS {
         case 422: {
           throw new UnprocessableEntityException({
             code,
+            error,
             errors,
             message,
             requestID,


### PR DESCRIPTION
## Description

Some WorkOS API 422 responses carry only an `error` field (for example, Vault's `{"error": "Maximum unique keys reached"}`). `UnprocessableEntityException` ignored that field, so applications saw only the generic `Unprocessable entity` message and had to reproduce the request with raw HTTP to learn the actual reason. `ConflictException` (409) already forwards `error` — this brings the 422 path in line with it. Precedence is unchanged: `message` wins over `error`, and a structured `errors` array still takes priority over both.

Also fixes `requestID` being empty on every exception thrown from `handleHttpError`: it read the request ID with bracket access (`headers['X-Request-ID']`) on a fetch `Headers` instance, which always returns `undefined` — the same function already uses `headers.get('Retry-After')` correctly for 429s. Support relies on request IDs, so exceptions now carry them.

Tests cover the new 422 cases (error-only body, message precedence, errors-array precedence) — the error-only case also locks in the `requestID` fix, since it asserts the value that bracket access silently dropped.

## Documentation

```
[ ] No
```


Devin shepherd: https://app.devin.ai/sessions/bbb48b72a3544efaa196436ee81ac731
