### PR TITLE
feat: Add configurable automatic retries to the HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,29 @@ import { WorkOS } from '@workos-inc/node';
 const workos = new WorkOS('sk_1234');
 ```
 
+### Automatic retries
+
+The SDK automatically retries requests that fail with a transient error — a
+network error, a request timeout (408), a rate limit (429), or a server error
+(500, 502, 503, 504) — using exponential backoff with jitter. When the API
+responds with a `Retry-After` header, the SDK waits for that duration instead
+(capped at 60 seconds). Retried `POST` requests are automatically assigned an
+`Idempotency-Key` header (unless one is already set) so a retried write is not
+applied twice.
+
+The default is 3 retries. Configure it client-wide, or per request on the
+low-level HTTP methods:
+
+```ts
+// Client-wide: up to 5 retries per request
+const workos = new WorkOS('sk_1234', { maxRetries: 5 });
+
+// Per-request override: disable retries for this call only
+await workos.get('/organizations', { maxRetries: 0 });
+```
+
+Set `maxRetries: 0` to disable automatic retries entirely.
+
 ## Public Client Mode (Browser/Mobile/CLI)
 
 For apps that can't securely store secrets, initialize with just a client ID:

--- a/src/common/exceptions/parse-error.ts
+++ b/src/common/exceptions/parse-error.ts
@@ -7,21 +7,25 @@ export class ParseError extends Error implements RequestException {
   readonly rawBody: string;
   readonly rawStatus: number;
   readonly requestID: string;
+  readonly rawHeaders?: Headers;
 
   constructor({
     message,
     rawBody,
     rawStatus,
     requestID,
+    rawHeaders,
   }: {
     message: string;
     rawBody: string;
     requestID: string;
     rawStatus: number;
+    rawHeaders?: Headers;
   }) {
     super(message);
     this.rawBody = rawBody;
     this.rawStatus = rawStatus;
     this.requestID = requestID;
+    this.rawHeaders = rawHeaders;
   }
 }

--- a/src/common/interfaces/get-options.interface.ts
+++ b/src/common/interfaces/get-options.interface.ts
@@ -4,4 +4,6 @@ export interface GetOptions {
   warrantToken?: string;
   /** Skip API key requirement check (for PKCE-safe methods) */
   skipApiKeyCheck?: boolean;
+  /** Maximum number of retries for this request, overriding the client-wide `maxRetries`. */
+  maxRetries?: number;
 }

--- a/src/common/interfaces/http-client.interface.ts
+++ b/src/common/interfaces/http-client.interface.ts
@@ -2,6 +2,11 @@ export type RequestHeaders = Record<string, string | number | string[]>;
 export type RequestOptions = {
   params?: Record<string, any>;
   headers?: RequestHeaders;
+  /**
+   * Maximum number of retries for this request, overriding the client-wide
+   * `maxRetries`. Set to `0` to disable retries for this request.
+   */
+  maxRetries?: number;
 };
 export type ResponseHeaderValue = string | string[];
 export type ResponseHeaders = Record<string, ResponseHeaderValue>;

--- a/src/common/interfaces/patch-options.interface.ts
+++ b/src/common/interfaces/patch-options.interface.ts
@@ -3,4 +3,6 @@ export interface PatchOptions {
   idempotencyKey?: string;
   /** Skip API key requirement check (for PKCE-safe methods) */
   skipApiKeyCheck?: boolean;
+  /** Maximum number of retries for this request, overriding the client-wide `maxRetries`. */
+  maxRetries?: number;
 }

--- a/src/common/interfaces/post-options.interface.ts
+++ b/src/common/interfaces/post-options.interface.ts
@@ -4,4 +4,6 @@ export interface PostOptions {
   warrantToken?: string;
   /** Skip API key requirement check (for PKCE-safe methods) */
   skipApiKeyCheck?: boolean;
+  /** Maximum number of retries for this request, overriding the client-wide `maxRetries`. */
+  maxRetries?: number;
 }

--- a/src/common/interfaces/put-options.interface.ts
+++ b/src/common/interfaces/put-options.interface.ts
@@ -3,4 +3,6 @@ export interface PutOptions {
   idempotencyKey?: string;
   /** Skip API key requirement check (for PKCE-safe methods) */
   skipApiKeyCheck?: boolean;
+  /** Maximum number of retries for this request, overriding the client-wide `maxRetries`. */
+  maxRetries?: number;
 }

--- a/src/common/interfaces/workos-options.interface.ts
+++ b/src/common/interfaces/workos-options.interface.ts
@@ -10,4 +10,11 @@ export interface WorkOSOptions {
   fetchFn?: typeof fetch;
   clientId?: string;
   timeout?: number; // Timeout in milliseconds
+  /**
+   * Maximum number of automatic retries for transient failures (network
+   * errors and 408/429/5xx responses). Retries use exponential backoff with
+   * jitter and honor the `Retry-After` header. Defaults to 3. Set to `0` to
+   * disable automatic retries.
+   */
+  maxRetries?: number;
 }

--- a/src/common/interfaces/workos-options.interface.ts
+++ b/src/common/interfaces/workos-options.interface.ts
@@ -13,8 +13,8 @@ export interface WorkOSOptions {
   /**
    * Maximum number of automatic retries for transient failures (network
    * errors and 408/429/5xx responses). Retries use exponential backoff with
-   * jitter and honor the `Retry-After` header. Defaults to 3. Set to `0` to
-   * disable automatic retries.
+   * jitter and honor the `Retry-After` header (capped at 60 seconds).
+   * Defaults to 3. Set to `0` to disable automatic retries.
    */
   maxRetries?: number;
 }

--- a/src/common/net/fetch-client.spec.ts
+++ b/src/common/net/fetch-client.spec.ts
@@ -231,10 +231,12 @@ describe('Fetch client', () => {
         },
       );
 
-      await expect(fetchClient.get('/users', {})).rejects.toThrow(ParseError);
+      await expect(
+        fetchClient.get('/users', { maxRetries: 0 }),
+      ).rejects.toThrow(ParseError);
 
       try {
-        await fetchClient.get('/users', {});
+        await fetchClient.get('/users', { maxRetries: 0 });
       } catch (error) {
         expect(error).toBeInstanceOf(ParseError);
         const parseError = error as ParseError;
@@ -406,6 +408,21 @@ describe('automatic retries', () => {
     >;
     expect(firstHeaders['Idempotency-Key']).toBe('user-key');
     expect(secondHeaders['Idempotency-Key']).toBe('user-key');
+  });
+
+  it('retries a retryable status with a non-JSON error body', async () => {
+    fetch.mockResponseOnce('<html>503 Service Unavailable</html>', {
+      status: 503,
+      headers: { 'content-type': 'text/html' },
+    });
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    const response = await fetchClient.get('/organizations', {});
+
+    expect(fetch.mock.calls.length).toBe(2);
+    expect(await response.toJSON()).toEqual({ data: 'response' });
   });
 
   it('does not retry when maxRetries is 0', async () => {

--- a/src/common/net/fetch-client.spec.ts
+++ b/src/common/net/fetch-client.spec.ts
@@ -463,6 +463,101 @@ describe('automatic retries', () => {
 
     expect(fetch.mock.calls.length).toBe(2);
   });
+
+  it('honors the Retry-After header (HTTP-date) when retrying', async () => {
+    const fixedNow = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockReturnValue(fixedNow);
+    fetchOnce(
+      {},
+      {
+        status: 429,
+        headers: { 'Retry-After': new Date(fixedNow + 5_000).toUTCString() },
+      },
+    );
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    await fetchClient.get('/organizations', {});
+
+    expect(mockSleep).toHaveBeenCalledTimes(1);
+    expect(mockSleep).toHaveBeenCalledWith(expect.any(Number), 5000);
+  });
+
+  it('caps a server-provided Retry-After delay at 60 seconds', async () => {
+    fetchOnce({}, { status: 429, headers: { 'Retry-After': '3600' } });
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    await fetchClient.get('/organizations', {});
+
+    expect(mockSleep).toHaveBeenCalledTimes(1);
+    expect(mockSleep).toHaveBeenCalledWith(expect.any(Number), 60_000);
+  });
+
+  it('falls back to computed backoff when Retry-After is unparseable', async () => {
+    fetchOnce({}, { status: 429, headers: { 'Retry-After': 'not-a-delay' } });
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    await fetchClient.get('/organizations', {});
+
+    expect(mockSleep).toHaveBeenCalledTimes(1);
+    expect(mockSleep).toHaveBeenCalledWith(expect.any(Number), null);
+  });
+
+  it('retries when the fetch function rejects with a network error', async () => {
+    fetch.mockRejectOnce(new TypeError('Failed to fetch'));
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    const response = await fetchClient.get('/organizations', {});
+
+    expect(fetch.mock.calls.length).toBe(2);
+    expect(await response.toJSON()).toEqual({ data: 'response' });
+  });
+
+  it('retries DELETE requests on transient failures', async () => {
+    fetchOnce({}, { status: 500 });
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    const response = await fetchClient.delete('/organizations/org_123', {});
+
+    expect(fetch.mock.calls.length).toBe(2);
+    expect(await response.toJSON()).toEqual({ data: 'response' });
+  });
+
+  it('does not attach an Idempotency-Key to PUT or PATCH requests', async () => {
+    fetchOnce({}, { status: 500 });
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    await fetchClient.put('/organizations/org_123', { name: 'Test' }, {});
+
+    const putHeaders = fetch.mock.calls[0][1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(putHeaders['Idempotency-Key']).toBeUndefined();
+
+    fetch.resetMocks();
+    fetchOnce({}, { status: 500 });
+    fetchOnce({ data: 'response' });
+
+    await fetchClient.patch('/organizations/org_123', { name: 'Test' }, {});
+
+    const patchHeaders = fetch.mock.calls[0][1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(patchHeaders['Idempotency-Key']).toBeUndefined();
+  });
 });
 
 describe('FetchHttpClient with timeout', () => {

--- a/src/common/net/fetch-client.spec.ts
+++ b/src/common/net/fetch-client.spec.ts
@@ -323,6 +323,116 @@ describe('Fetch client', () => {
   });
 });
 
+describe('automatic retries', () => {
+  beforeEach(() => fetch.resetMocks());
+
+  it('retries requests on non-vault paths by default', async () => {
+    fetchOnce({}, { status: 500 });
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    const response = await fetchClient.get('/organizations', {});
+
+    expect(fetch.mock.calls.length).toBe(2);
+    expect(await response.toJSON()).toEqual({ data: 'response' });
+  });
+
+  it('retries requests on a 429 status code', async () => {
+    fetchOnce({}, { status: 429 });
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    const response = await fetchClient.get('/organizations', {});
+
+    expect(fetch.mock.calls.length).toBe(2);
+    expect(await response.toJSON()).toEqual({ data: 'response' });
+  });
+
+  it('honors the Retry-After header (delay-seconds) when retrying', async () => {
+    fetchOnce({}, { status: 429, headers: { 'Retry-After': '2' } });
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    await fetchClient.get('/organizations', {});
+
+    expect(mockSleep).toHaveBeenCalledTimes(1);
+    expect(mockSleep).toHaveBeenCalledWith(expect.any(Number), 2000);
+  });
+
+  it('attaches an Idempotency-Key to a retried POST that lacks one', async () => {
+    fetchOnce({}, { status: 500 });
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    await fetchClient.post('/organizations', { name: 'Test' }, {});
+
+    const firstHeaders = fetch.mock.calls[0][1]?.headers as Record<
+      string,
+      string
+    >;
+    const secondHeaders = fetch.mock.calls[1][1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(firstHeaders['Idempotency-Key']).toMatch(/^retry-/);
+    expect(secondHeaders['Idempotency-Key']).toBe(
+      firstHeaders['Idempotency-Key'],
+    );
+  });
+
+  it('does not override a caller-provided Idempotency-Key on retry', async () => {
+    fetchOnce({}, { status: 500 });
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    await fetchClient.post(
+      '/organizations',
+      { name: 'Test' },
+      { headers: { 'Idempotency-Key': 'user-key' } },
+    );
+
+    const firstHeaders = fetch.mock.calls[0][1]?.headers as Record<
+      string,
+      string
+    >;
+    const secondHeaders = fetch.mock.calls[1][1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(firstHeaders['Idempotency-Key']).toBe('user-key');
+    expect(secondHeaders['Idempotency-Key']).toBe('user-key');
+  });
+
+  it('does not retry when maxRetries is 0', async () => {
+    const client = new FetchHttpClient('https://test.workos.com', {
+      maxRetries: 0,
+    });
+    fetchOnce({}, { status: 500 });
+
+    await expect(client.get('/organizations', {})).rejects.toThrow();
+
+    expect(fetch.mock.calls.length).toBe(1);
+  });
+
+  it('respects a per-request maxRetries override', async () => {
+    fetchOnce({}, { status: 500 });
+    fetchOnce({}, { status: 500 });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    await expect(
+      fetchClient.get('/organizations', { maxRetries: 1 }),
+    ).rejects.toThrow();
+
+    expect(fetch.mock.calls.length).toBe(2);
+  });
+});
+
 describe('FetchHttpClient with timeout', () => {
   let client: FetchHttpClient;
   let mockFetch: jest.Mock;
@@ -331,7 +441,7 @@ describe('FetchHttpClient with timeout', () => {
     mockFetch = jest.fn();
     client = new FetchHttpClient(
       'https://api.example.com',
-      { timeout: 100 },
+      { timeout: 100, maxRetries: 0 },
       mockFetch,
     );
   });

--- a/src/common/net/fetch-client.spec.ts
+++ b/src/common/net/fetch-client.spec.ts
@@ -425,6 +425,21 @@ describe('automatic retries', () => {
     expect(await response.toJSON()).toEqual({ data: 'response' });
   });
 
+  it('honors Retry-After on a retryable non-JSON error body', async () => {
+    fetch.mockResponseOnce('<html>503 Service Unavailable</html>', {
+      status: 503,
+      headers: { 'content-type': 'text/html', 'Retry-After': '7' },
+    });
+    fetchOnce({ data: 'response' });
+    const mockSleep = jest.spyOn(fetchClient, 'sleep');
+    mockSleep.mockImplementation(() => Promise.resolve());
+
+    await fetchClient.get('/organizations', {});
+
+    expect(fetch.mock.calls.length).toBe(2);
+    expect(mockSleep).toHaveBeenCalledWith(expect.any(Number), 7000);
+  });
+
   it('does not retry when maxRetries is 0', async () => {
     const client = new FetchHttpClient('https://test.workos.com', {
       maxRetries: 0,

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -6,12 +6,15 @@ import {
   RequestOptions,
   ResponseHeaders,
 } from '../interfaces/http-client.interface';
-import { HttpClient, HttpClientError, HttpClientResponse } from './http-client';
+import {
+  HttpClient,
+  HttpClientError,
+  HttpClientOptions,
+  HttpClientResponse,
+} from './http-client';
 import { ParseError } from '../exceptions/parse-error';
 
-interface FetchHttpClientOptions extends RequestInit {
-  timeout?: number;
-}
+type FetchHttpClientOptions = HttpClientOptions;
 
 const DEFAULT_FETCH_TIMEOUT = 60_000; // 60 seconds
 export class FetchHttpClient extends HttpClient implements HttpClientInterface {
@@ -47,16 +50,13 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (HttpClient.isPathRetryable(path)) {
-      return await this.fetchRequestWithRetry(
-        resourceURL,
-        'GET',
-        null,
-        options.headers,
-      );
-    } else {
-      return await this.fetchRequest(resourceURL, 'GET', null, options.headers);
-    }
+    return await this.fetchRequestWithRetry(
+      resourceURL,
+      'GET',
+      null,
+      options.headers,
+      options.maxRetries,
+    );
   }
 
   async post<Entity = any>(
@@ -70,27 +70,16 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (HttpClient.isPathRetryable(path)) {
-      return await this.fetchRequestWithRetry(
-        resourceURL,
-        'POST',
-        HttpClient.getBody(entity),
-        {
-          ...HttpClient.getContentTypeHeader(entity),
-          ...options.headers,
-        },
-      );
-    } else {
-      return await this.fetchRequest(
-        resourceURL,
-        'POST',
-        HttpClient.getBody(entity),
-        {
-          ...HttpClient.getContentTypeHeader(entity),
-          ...options.headers,
-        },
-      );
-    }
+    return await this.fetchRequestWithRetry(
+      resourceURL,
+      'POST',
+      HttpClient.getBody(entity),
+      {
+        ...HttpClient.getContentTypeHeader(entity),
+        ...options.headers,
+      },
+      options.maxRetries,
+    );
   }
 
   async put<Entity = any>(
@@ -104,27 +93,16 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (HttpClient.isPathRetryable(path)) {
-      return await this.fetchRequestWithRetry(
-        resourceURL,
-        'PUT',
-        HttpClient.getBody(entity),
-        {
-          ...HttpClient.getContentTypeHeader(entity),
-          ...options.headers,
-        },
-      );
-    } else {
-      return await this.fetchRequest(
-        resourceURL,
-        'PUT',
-        HttpClient.getBody(entity),
-        {
-          ...HttpClient.getContentTypeHeader(entity),
-          ...options.headers,
-        },
-      );
-    }
+    return await this.fetchRequestWithRetry(
+      resourceURL,
+      'PUT',
+      HttpClient.getBody(entity),
+      {
+        ...HttpClient.getContentTypeHeader(entity),
+        ...options.headers,
+      },
+      options.maxRetries,
+    );
   }
 
   async patch<Entity = any>(
@@ -138,27 +116,16 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (HttpClient.isPathRetryable(path)) {
-      return await this.fetchRequestWithRetry(
-        resourceURL,
-        'PATCH',
-        HttpClient.getBody(entity),
-        {
-          ...HttpClient.getContentTypeHeader(entity),
-          ...options.headers,
-        },
-      );
-    } else {
-      return await this.fetchRequest(
-        resourceURL,
-        'PATCH',
-        HttpClient.getBody(entity),
-        {
-          ...HttpClient.getContentTypeHeader(entity),
-          ...options.headers,
-        },
-      );
-    }
+    return await this.fetchRequestWithRetry(
+      resourceURL,
+      'PATCH',
+      HttpClient.getBody(entity),
+      {
+        ...HttpClient.getContentTypeHeader(entity),
+        ...options.headers,
+      },
+      options.maxRetries,
+    );
   }
 
   async delete(
@@ -171,21 +138,13 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (HttpClient.isPathRetryable(path)) {
-      return await this.fetchRequestWithRetry(
-        resourceURL,
-        'DELETE',
-        null,
-        options.headers,
-      );
-    } else {
-      return await this.fetchRequest(
-        resourceURL,
-        'DELETE',
-        null,
-        options.headers,
-      );
-    }
+    return await this.fetchRequestWithRetry(
+      resourceURL,
+      'DELETE',
+      null,
+      options.headers,
+      options.maxRetries,
+    );
   }
 
   async deleteWithBody<Entity = any>(
@@ -199,27 +158,16 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       options.params,
     );
 
-    if (HttpClient.isPathRetryable(path)) {
-      return await this.fetchRequestWithRetry(
-        resourceURL,
-        'DELETE',
-        HttpClient.getBody(entity),
-        {
-          ...HttpClient.getContentTypeHeader(entity),
-          ...options.headers,
-        },
-      );
-    } else {
-      return await this.fetchRequest(
-        resourceURL,
-        'DELETE',
-        HttpClient.getBody(entity),
-        {
-          ...HttpClient.getContentTypeHeader(entity),
-          ...options.headers,
-        },
-      );
-    }
+    return await this.fetchRequestWithRetry(
+      resourceURL,
+      'DELETE',
+      HttpClient.getBody(entity),
+      {
+        ...HttpClient.getContentTypeHeader(entity),
+        ...options.headers,
+      },
+      options.maxRetries,
+    );
   }
 
   private async fetchRequest(
@@ -322,7 +270,19 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
     method: string,
     body?: any,
     headers?: RequestHeaders,
+    maxRetries?: number,
   ): Promise<HttpClientResponseInterface> {
+    const maxRetryAttempts = maxRetries ?? this.MAX_RETRY_ATTEMPTS;
+
+    // Attach an idempotency key to retryable write requests that don't have
+    // one so retried POST/PUT/PATCH calls are not applied more than once by
+    // the API. Generated once so every attempt shares the same key.
+    const requestHeaders = FetchHttpClient.withIdempotencyKey(
+      method,
+      headers,
+      maxRetryAttempts,
+    );
+
     let response: HttpClientResponseInterface;
     let retryAttempts = 1;
 
@@ -330,14 +290,19 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       let requestError: any = null;
 
       try {
-        response = await this.fetchRequest(url, method, body, headers);
+        response = await this.fetchRequest(url, method, body, requestHeaders);
       } catch (e) {
         requestError = e;
       }
 
-      if (this.shouldRetryRequest(requestError, retryAttempts)) {
+      if (
+        this.shouldRetryRequest(requestError, retryAttempts, maxRetryAttempts)
+      ) {
         retryAttempts++;
-        await this.sleep(retryAttempts);
+        await this.sleep(
+          retryAttempts,
+          FetchHttpClient.getRetryAfterMs(requestError),
+        );
         return makeRequest();
       }
 
@@ -351,8 +316,12 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
     return makeRequest();
   }
 
-  private shouldRetryRequest(requestError: any, retryAttempt: number): boolean {
-    if (retryAttempt > this.MAX_RETRY_ATTEMPTS) {
+  private shouldRetryRequest(
+    requestError: any,
+    retryAttempt: number,
+    maxRetryAttempts: number,
+  ): boolean {
+    if (retryAttempt > maxRetryAttempts) {
       return false;
     }
 
@@ -370,6 +339,57 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
     }
 
     return false;
+  }
+
+  private static withIdempotencyKey(
+    method: string,
+    headers: RequestHeaders | undefined,
+    maxRetryAttempts: number,
+  ): RequestHeaders | undefined {
+    const isWriteMethod =
+      method === 'POST' || method === 'PUT' || method === 'PATCH';
+
+    if (
+      !isWriteMethod ||
+      maxRetryAttempts <= 0 ||
+      FetchHttpClient.hasHeader(headers, 'Idempotency-Key')
+    ) {
+      return headers;
+    }
+
+    return {
+      ...headers,
+      'Idempotency-Key': HttpClient.generateIdempotencyKey(),
+    };
+  }
+
+  private static hasHeader(
+    headers: RequestHeaders | undefined,
+    name: string,
+  ): boolean {
+    if (!headers) {
+      return false;
+    }
+
+    const target = name.toLowerCase();
+    return Object.keys(headers).some((key) => key.toLowerCase() === target);
+  }
+
+  private static getRetryAfterMs(requestError: any): number | null {
+    if (!(requestError instanceof HttpClientError)) {
+      return null;
+    }
+
+    const headers = requestError.response?.headers;
+    let value: string | null | undefined;
+
+    if (headers && typeof headers.get === 'function') {
+      value = headers.get('Retry-After');
+    } else if (headers && typeof headers === 'object') {
+      value = headers['Retry-After'] ?? headers['retry-after'];
+    }
+
+    return HttpClient.parseRetryAfter(value);
   }
 }
 

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -228,6 +228,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
               rawBody,
               requestID,
               rawStatus: res.status,
+              rawHeaders: res.headers,
             });
           }
           throw error;
@@ -386,11 +387,16 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
   }
 
   private static getRetryAfterMs(requestError: any): number | null {
-    if (!(requestError instanceof HttpClientError)) {
+    let headers: any;
+
+    if (requestError instanceof HttpClientError) {
+      headers = requestError.response?.headers;
+    } else if (requestError instanceof ParseError) {
+      headers = requestError.rawHeaders;
+    } else {
       return null;
     }
 
-    const headers = requestError.response?.headers;
     let value: string | null | undefined;
 
     if (headers && typeof headers.get === 'function') {

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -336,6 +336,16 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       ) {
         return true;
       }
+
+      // A retryable status can arrive with a non-JSON body (e.g. an HTML error
+      // page from a proxy), which `fetchRequest` surfaces as a `ParseError`.
+      // Retry those based on the underlying status.
+      if (
+        requestError instanceof ParseError &&
+        this.RETRY_STATUS_CODES.includes(requestError.rawStatus)
+      ) {
+        return true;
+      }
     }
 
     return false;

--- a/src/common/net/fetch-client.ts
+++ b/src/common/net/fetch-client.ts
@@ -275,9 +275,11 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
   ): Promise<HttpClientResponseInterface> {
     const maxRetryAttempts = maxRetries ?? this.MAX_RETRY_ATTEMPTS;
 
-    // Attach an idempotency key to retryable write requests that don't have
-    // one so retried POST/PUT/PATCH calls are not applied more than once by
-    // the API. Generated once so every attempt shares the same key.
+    // Attach an idempotency key to retryable POST requests that don't have
+    // one so retried calls are not applied more than once by the API.
+    // POST-only to match the Kotlin and Go SDKs and the API, which honors
+    // `Idempotency-Key` on create (POST) endpoints. Generated once so every
+    // attempt shares the same key.
     const requestHeaders = FetchHttpClient.withIdempotencyKey(
       method,
       headers,
@@ -357,11 +359,8 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
     headers: RequestHeaders | undefined,
     maxRetryAttempts: number,
   ): RequestHeaders | undefined {
-    const isWriteMethod =
-      method === 'POST' || method === 'PUT' || method === 'PATCH';
-
     if (
-      !isWriteMethod ||
+      method !== 'POST' ||
       maxRetryAttempts <= 0 ||
       FetchHttpClient.hasHeader(headers, 'Idempotency-Key')
     ) {

--- a/src/common/net/http-client.ts
+++ b/src/common/net/http-client.ts
@@ -19,6 +19,13 @@ export interface HttpClientOptions extends RequestInit {
 
 export const DEFAULT_MAX_RETRY_ATTEMPTS = 3;
 
+/**
+ * Upper bound on a server-provided `Retry-After` delay. Caps how long a
+ * single retry can sleep so an aggressive proxy or an HTTP-date far in the
+ * future can't hang the caller indefinitely.
+ */
+export const MAXIMUM_RETRY_AFTER_TIME_IN_MILLISECONDS = 60_000;
+
 export abstract class HttpClient implements HttpClientInterface {
   readonly MAX_RETRY_ATTEMPTS: number;
   readonly BACKOFF_MULTIPLIER = 1.5;
@@ -110,9 +117,9 @@ export abstract class HttpClient implements HttpClientInterface {
 
   /**
    * Generate a random idempotency key used to make retried write requests
-   * safe. Mirrors the behavior of the other WorkOS SDKs (Kotlin, Go, Ruby),
-   * which attach an `Idempotency-Key` header to retried POST/PUT/PATCH
-   * requests that did not already specify one.
+   * safe. Mirrors the behavior of the other WorkOS SDKs (Kotlin, Go), which
+   * attach an `Idempotency-Key` header to POST requests that did not already
+   * specify one, so a retried request is not applied more than once.
    */
   static generateIdempotencyKey(): string {
     return `retry-${globalThis.crypto.randomUUID()}`;
@@ -120,9 +127,10 @@ export abstract class HttpClient implements HttpClientInterface {
 
   /**
    * Parse a `Retry-After` header value into milliseconds. Supports both the
-   * delay-seconds form (e.g. `120`) and the HTTP-date form. Returns `null`
-   * when the value is absent or unparseable so the caller falls back to the
-   * computed exponential backoff.
+   * delay-seconds form (e.g. `120`) and the HTTP-date form. The result is
+   * capped at {@link MAXIMUM_RETRY_AFTER_TIME_IN_MILLISECONDS}. Returns
+   * `null` when the value is absent or unparseable so the caller falls back
+   * to the computed exponential backoff.
    */
   static parseRetryAfter(
     headerValue: string | null | undefined,
@@ -136,15 +144,22 @@ export abstract class HttpClient implements HttpClientInterface {
       return null;
     }
 
-    const asSeconds = Number(trimmed);
-    if (!Number.isNaN(asSeconds)) {
-      return asSeconds < 0 ? 0 : asSeconds * 1000;
+    // RFC 9110 delay-seconds: a non-negative decimal integer. Using a strict
+    // pattern instead of Number() avoids honoring exotic forms like
+    // `Infinity`, hex, or exponent notation.
+    if (/^\d+$/.test(trimmed)) {
+      return Math.min(
+        Number(trimmed) * 1000,
+        MAXIMUM_RETRY_AFTER_TIME_IN_MILLISECONDS,
+      );
     }
 
     const asDate = Date.parse(trimmed);
     if (!Number.isNaN(asDate)) {
       const delta = asDate - Date.now();
-      return delta < 0 ? 0 : delta;
+      return delta < 0
+        ? 0
+        : Math.min(delta, MAXIMUM_RETRY_AFTER_TIME_IN_MILLISECONDS);
     }
 
     return null;

--- a/src/common/net/http-client.ts
+++ b/src/common/net/http-client.ts
@@ -7,16 +7,31 @@ import {
   ResponseHeaders,
 } from '../interfaces/http-client.interface';
 
+export interface HttpClientOptions extends RequestInit {
+  /** Per-request timeout in milliseconds. */
+  timeout?: number;
+  /**
+   * Maximum number of retries for transient failures. Set to `0` to disable
+   * automatic retries entirely. Defaults to {@link DEFAULT_MAX_RETRY_ATTEMPTS}.
+   */
+  maxRetries?: number;
+}
+
+export const DEFAULT_MAX_RETRY_ATTEMPTS = 3;
+
 export abstract class HttpClient implements HttpClientInterface {
-  readonly MAX_RETRY_ATTEMPTS = 3;
+  readonly MAX_RETRY_ATTEMPTS: number;
   readonly BACKOFF_MULTIPLIER = 1.5;
   readonly MINIMUM_SLEEP_TIME_IN_MILLISECONDS = 500;
-  readonly RETRY_STATUS_CODES = [408, 500, 502, 504];
+  readonly MAXIMUM_SLEEP_TIME_IN_MILLISECONDS = 8_000;
+  readonly RETRY_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 
   constructor(
     readonly baseURL: string,
-    readonly options?: RequestInit,
-  ) {}
+    readonly options?: HttpClientOptions,
+  ) {
+    this.MAX_RETRY_ATTEMPTS = options?.maxRetries ?? DEFAULT_MAX_RETRY_ATTEMPTS;
+  }
 
   abstract get(
     path: string,
@@ -93,21 +108,66 @@ export abstract class HttpClient implements HttpClientInterface {
     return JSON.stringify(entity);
   }
 
-  static isPathRetryable(path: string): boolean {
-    return path.startsWith('/vault/') || path.startsWith('/audit_logs/events');
+  /**
+   * Generate a random idempotency key used to make retried write requests
+   * safe. Mirrors the behavior of the other WorkOS SDKs (Kotlin, Go, Ruby),
+   * which attach an `Idempotency-Key` header to retried POST/PUT/PATCH
+   * requests that did not already specify one.
+   */
+  static generateIdempotencyKey(): string {
+    return `retry-${globalThis.crypto.randomUUID()}`;
+  }
+
+  /**
+   * Parse a `Retry-After` header value into milliseconds. Supports both the
+   * delay-seconds form (e.g. `120`) and the HTTP-date form. Returns `null`
+   * when the value is absent or unparseable so the caller falls back to the
+   * computed exponential backoff.
+   */
+  static parseRetryAfter(
+    headerValue: string | null | undefined,
+  ): number | null {
+    if (headerValue == null) {
+      return null;
+    }
+
+    const trimmed = headerValue.trim();
+    if (trimmed === '') {
+      return null;
+    }
+
+    const asSeconds = Number(trimmed);
+    if (!Number.isNaN(asSeconds)) {
+      return asSeconds < 0 ? 0 : asSeconds * 1000;
+    }
+
+    const asDate = Date.parse(trimmed);
+    if (!Number.isNaN(asDate)) {
+      const delta = asDate - Date.now();
+      return delta < 0 ? 0 : delta;
+    }
+
+    return null;
   }
 
   private getSleepTimeInMilliseconds(retryAttempt: number): number {
-    const sleepTime =
+    const sleepTime = Math.min(
       this.MINIMUM_SLEEP_TIME_IN_MILLISECONDS *
-      Math.pow(this.BACKOFF_MULTIPLIER, retryAttempt);
+        Math.pow(this.BACKOFF_MULTIPLIER, retryAttempt),
+      this.MAXIMUM_SLEEP_TIME_IN_MILLISECONDS,
+    );
     const jitter = Math.random() + 0.5;
     return sleepTime * jitter;
   }
 
-  sleep = (retryAttempt: number) =>
+  sleep = (retryAttempt: number, retryAfterMs?: number | null) =>
     new Promise((resolve) =>
-      setTimeout(resolve, this.getSleepTimeInMilliseconds(retryAttempt)),
+      setTimeout(
+        resolve,
+        retryAfterMs != null
+          ? retryAfterMs
+          : this.getSleepTimeInMilliseconds(retryAttempt),
+      ),
     );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ class WorkOSNode extends WorkOS {
     const opts = {
       ...options.config,
       timeout: options.timeout,
+      maxRetries: options.maxRetries,
       headers,
     };
 

--- a/src/index.worker.ts
+++ b/src/index.worker.ts
@@ -56,6 +56,7 @@ class WorkOSWorker extends WorkOS {
 
     return new FetchHttpClient(this.baseURL, {
       ...options.config,
+      maxRetries: options.maxRetries,
       headers,
     });
   }

--- a/src/workos.spec.ts
+++ b/src/workos.spec.ts
@@ -326,7 +326,10 @@ describe('WorkOS', () => {
           },
         );
 
-        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+        const workos = new WorkOS({
+          apiKey: 'sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU',
+          maxRetries: 0,
+        });
 
         await expect(workos.post('/path', {})).rejects.toStrictEqual(
           new GenericServerException(500, undefined, {}, 'a-request-id'),
@@ -448,7 +451,10 @@ describe('WorkOS', () => {
           },
         );
 
-        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+        const workos = new WorkOS({
+          apiKey: 'sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU',
+          maxRetries: 0,
+        });
 
         await expect(workos.get('/path')).rejects.toStrictEqual(
           new RateLimitExceededException(

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -205,6 +205,7 @@ export class WorkOS {
     return new FetchHttpClient(this.baseURL, {
       ...options.config,
       timeout: options.timeout,
+      maxRetries: options.maxRetries,
       headers,
     }) as HttpClient;
   }
@@ -249,6 +250,7 @@ export class WorkOS {
       res = await this.client.post<Entity>(path, entity, {
         params: options.query,
         headers: requestHeaders,
+        maxRetries: options.maxRetries,
       });
     } catch (error) {
       this.handleHttpError({ path, error });
@@ -281,6 +283,7 @@ export class WorkOS {
       res = await this.client.get(path, {
         params: options.query,
         headers: requestHeaders,
+        maxRetries: options.maxRetries,
       });
     } catch (error) {
       this.handleHttpError({ path, error });
@@ -312,6 +315,7 @@ export class WorkOS {
       res = await this.client.put<Entity>(path, entity, {
         params: options.query,
         headers: requestHeaders,
+        maxRetries: options.maxRetries,
       });
     } catch (error) {
       this.handleHttpError({ path, error });
@@ -343,6 +347,7 @@ export class WorkOS {
       res = await this.client.patch<Entity>(path, entity, {
         params: options.query,
         headers: requestHeaders,
+        maxRetries: options.maxRetries,
       });
     } catch (error) {
       this.handleHttpError({ path, error });


### PR DESCRIPTION
## Summary

Brings the Node SDK's automatic retry behavior to parity with the Kotlin, Go, Ruby, and Python SDKs.

Previously the Node SDK had retry machinery, but it was effectively dormant: retries only fired for two path prefixes (`/vault/*` and `/audit_logs/events`), never retried `429`, ignored `Retry-After`, added no idempotency safety for retried writes, and weren't configurable. Every other WorkOS SDK retries all requests on transient failures with backoff + jitter.

This PR makes retries apply to **all** requests and configurable, while keeping default behavior transparent to existing callers (default is still 3 attempts, backoff + jitter unchanged).

### What changed

- **Retries apply to every request**, not just the two allowlisted path prefixes. The per-verb `isPathRetryable(path)` branch is removed; all verbs go through `fetchRequestWithRetry`.
- **Retryable statuses** now include `429` and `503` (was `[408, 500, 502, 504]`, now `[408, 429, 500, 502, 503, 504]`). Transport errors (`TypeError`) are still retried.
- **`Retry-After` is honored, capped at 60 seconds.** When a retryable response carries a `Retry-After` header, the SDK sleeps for that duration instead of the computed backoff — capped at `MAXIMUM_RETRY_AFTER_TIME_IN_MILLISECONDS = 60_000` so a large server-provided delay can't hang callers. Supports both delay-seconds (strict RFC 9110 integer) and HTTP-date forms:

  ```ts
  await this.sleep(attempt, HttpClient.parseRetryAfter(retryAfterHeader));
  // parseRetryAfter('120') -> 120000; parseRetryAfter('3600') -> 60000 (capped);
  // parseRetryAfter('<http-date>') -> ms until date (capped); else null (fall back to backoff)
  ```

- **Idempotency-Key auto-injection** for retried `POST` requests. A generated key (`retry-<uuid>`) is attached once to `POST` requests that don't already have one, and reused across attempts so a retried write is not applied twice. A caller-provided key is always preserved. POST-only to match the Kotlin and Go SDKs and the API, which honors `Idempotency-Key` on create (POST) endpoints.
- **Backoff is now capped** (`MAXIMUM_SLEEP_TIME_IN_MILLISECONDS = 8_000`) to avoid unbounded delays, matching Kotlin's `maxDelayMs`.
- **Configurable `maxRetries`**, client-wide and per-request, `0` disables retries:

  ```ts
  const workos = new WorkOS({ apiKey, maxRetries: 5 });   // client-wide
  await workos.get('/path', { maxRetries: 0 });           // per-request override
  ```

  Wired through `WorkOSOptions`, the per-call option interfaces (`GetOptions`/`PostOptions`/`PutOptions`/`PatchOptions`), and `RequestOptions`. Per-request wins over client-wide, which falls back to the default of 3.

### Notes

- Because `408`/`429`/`5xx` are now retried by default, a couple of existing error-mapping tests that asserted a single terminal `500`/`429` response now construct their client with `maxRetries: 0` to isolate the mapping from retry behavior.

## Test plan

- Extended `src/common/net/fetch-client.spec.ts`: retries on non-allowlisted paths, `429`, `Retry-After` honored (delay-seconds and HTTP-date, 60s cap, unparseable fallback), idempotency key generated + reused on POST (and not on PUT/PATCH), caller key preserved, network-error retry, DELETE retry, `maxRetries: 0` disables, per-request override.
- `npm run lint`, `npm run typecheck`, `npm test` (888 passing), and `npm run build` all pass locally.
- A retries section was added to the README documenting the default behavior and `maxRetries` configuration.


Link to Devin session: https://app.devin.ai/sessions/45217aff3c0248e083c27dd69b391ca5
Requested by: @awolfden
