### PR TITLE
fix: `totp` on list-path `AuthenticationFactor` is now optional to match the API

### DIFF
--- a/src/multi-factor-auth/fixtures/list-factors.json
+++ b/src/multi-factor-auth/fixtures/list-factors.json
@@ -10,7 +10,27 @@
       "totp": {
         "issuer": "WorkOS",
         "user": "some_user"
-      }
+      },
+      "user_id": "user_01H5JQDV7R7ATEYZDEG0W5PRYS"
+    },
+    {
+      "object": "authentication_factor",
+      "id": "auth_factor_5678",
+      "created_at": "2022-03-15T20:39:19.892Z",
+      "updated_at": "2022-03-15T20:39:19.892Z",
+      "type": "sms",
+      "sms": {
+        "phone_number": "+15555555555"
+      },
+      "user_id": "user_01H5JQDV7R7ATEYZDEG0W5PRYS"
+    },
+    {
+      "object": "authentication_factor",
+      "id": "auth_factor_9012",
+      "created_at": "2022-03-15T20:39:19.892Z",
+      "updated_at": "2022-03-15T20:39:19.892Z",
+      "type": "generic_otp",
+      "user_id": "user_01H5JQDV7R7ATEYZDEG0W5PRYS"
     }
   ],
   "list_metadata": {

--- a/src/multi-factor-auth/interfaces/factor.interface.ts
+++ b/src/multi-factor-auth/interfaces/factor.interface.ts
@@ -6,7 +6,7 @@ import {
   TotpWithSecretsResponse,
 } from './totp.interface';
 
-type FactorType = 'sms' | 'totp' | 'generic_otp';
+export type FactorType = 'sms' | 'totp' | 'generic_otp';
 
 export interface Factor {
   object: 'authentication_factor';

--- a/src/multi-factor-auth/multi-factor-auth.spec.ts
+++ b/src/multi-factor-auth/multi-factor-auth.spec.ts
@@ -520,6 +520,26 @@ describe('MFA', () => {
               issuer: 'WorkOS',
               user: 'some_user',
             },
+            userId: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+          },
+          {
+            object: 'authentication_factor',
+            id: 'auth_factor_5678',
+            createdAt: '2022-03-15T20:39:19.892Z',
+            updatedAt: '2022-03-15T20:39:19.892Z',
+            type: 'sms',
+            sms: {
+              phoneNumber: '+15555555555',
+            },
+            userId: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+          },
+          {
+            object: 'authentication_factor',
+            id: 'auth_factor_9012',
+            createdAt: '2022-03-15T20:39:19.892Z',
+            updatedAt: '2022-03-15T20:39:19.892Z',
+            type: 'generic_otp',
+            userId: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
           },
         ],
         listMetadata: {

--- a/src/user-management/fixtures/list-factors.json
+++ b/src/user-management/fixtures/list-factors.json
@@ -10,7 +10,27 @@
       "totp": {
         "issuer": "WorkOS",
         "user": "some_user"
-      }
+      },
+      "user_id": "user_01H5JQDV7R7ATEYZDEG0W5PRYS"
+    },
+    {
+      "object": "authentication_factor",
+      "id": "auth_factor_5678",
+      "created_at": "2022-03-15T20:39:19.892Z",
+      "updated_at": "2022-03-15T20:39:19.892Z",
+      "type": "sms",
+      "sms": {
+        "phone_number": "+15555555555"
+      },
+      "user_id": "user_01H5JQDV7R7ATEYZDEG0W5PRYS"
+    },
+    {
+      "object": "authentication_factor",
+      "id": "auth_factor_9012",
+      "created_at": "2022-03-15T20:39:19.892Z",
+      "updated_at": "2022-03-15T20:39:19.892Z",
+      "type": "generic_otp",
+      "user_id": "user_01H5JQDV7R7ATEYZDEG0W5PRYS"
     }
   ],
   "list_metadata": {

--- a/src/user-management/interfaces/authentication-factor.interface.ts
+++ b/src/user-management/interfaces/authentication-factor.interface.ts
@@ -1,17 +1,24 @@
 import {
+  Sms,
+  SmsResponse,
+} from '../../multi-factor-auth/interfaces/sms.interface';
+import {
   Totp,
   TotpResponse,
   TotpWithSecrets,
   TotpWithSecretsResponse,
 } from '../../multi-factor-auth/interfaces/totp.interface';
 
+export type AuthenticationFactorType = 'sms' | 'totp' | 'generic_otp';
+
 export interface AuthenticationFactor {
   object: 'authentication_factor';
   id: string;
   createdAt: string;
   updatedAt: string;
-  type: 'totp';
-  totp: Totp;
+  type: AuthenticationFactorType;
+  sms?: Sms;
+  totp?: Totp;
   userId: string;
 }
 
@@ -20,8 +27,9 @@ export interface AuthenticationFactorWithSecrets {
   id: string;
   createdAt: string;
   updatedAt: string;
-  type: 'totp';
-  totp: TotpWithSecrets;
+  type: AuthenticationFactorType;
+  sms?: Sms;
+  totp?: TotpWithSecrets;
   userId: string;
 }
 
@@ -30,8 +38,9 @@ export interface AuthenticationFactorResponse {
   id: string;
   created_at: string;
   updated_at: string;
-  type: 'totp';
-  totp: TotpResponse;
+  type: AuthenticationFactorType;
+  sms?: SmsResponse;
+  totp?: TotpResponse;
   user_id: string;
 }
 
@@ -40,7 +49,8 @@ export interface AuthenticationFactorWithSecretsResponse {
   id: string;
   created_at: string;
   updated_at: string;
-  type: 'totp';
-  totp: TotpWithSecretsResponse;
+  type: AuthenticationFactorType;
+  sms?: SmsResponse;
+  totp?: TotpWithSecretsResponse;
   user_id: string;
 }

--- a/src/user-management/interfaces/authentication-factor.interface.ts
+++ b/src/user-management/interfaces/authentication-factor.interface.ts
@@ -1,3 +1,4 @@
+import { FactorType } from '../../multi-factor-auth/interfaces/factor.interface';
 import {
   Sms,
   SmsResponse,
@@ -9,7 +10,7 @@ import {
   TotpWithSecretsResponse,
 } from '../../multi-factor-auth/interfaces/totp.interface';
 
-export type AuthenticationFactorType = 'sms' | 'totp' | 'generic_otp';
+export type AuthenticationFactorType = FactorType;
 
 export interface AuthenticationFactor {
   object: 'authentication_factor';
@@ -27,9 +28,8 @@ export interface AuthenticationFactorWithSecrets {
   id: string;
   createdAt: string;
   updatedAt: string;
-  type: AuthenticationFactorType;
-  sms?: Sms;
-  totp?: TotpWithSecrets;
+  type: 'totp';
+  totp: TotpWithSecrets;
   userId: string;
 }
 
@@ -49,8 +49,7 @@ export interface AuthenticationFactorWithSecretsResponse {
   id: string;
   created_at: string;
   updated_at: string;
-  type: AuthenticationFactorType;
-  sms?: SmsResponse;
-  totp?: TotpWithSecretsResponse;
+  type: 'totp';
+  totp: TotpWithSecretsResponse;
   user_id: string;
 }

--- a/src/user-management/serializers/authentication-factor.serializer.spec.ts
+++ b/src/user-management/serializers/authentication-factor.serializer.spec.ts
@@ -8,7 +8,7 @@ describe('deserializeFactor', () => {
       deserializeFactor(factor as AuthenticationFactorResponse),
     );
 
-    expect(factors).toEqual([
+    expect(factors).toStrictEqual([
       {
         object: 'authentication_factor',
         id: 'auth_factor_1234',

--- a/src/user-management/serializers/authentication-factor.serializer.spec.ts
+++ b/src/user-management/serializers/authentication-factor.serializer.spec.ts
@@ -1,0 +1,45 @@
+import { deserializeFactor } from './authentication-factor.serializer';
+import { AuthenticationFactorResponse } from '../interfaces/authentication-factor.interface';
+import listFactorsFixture from '../fixtures/list-factors.json';
+
+describe('deserializeFactor', () => {
+  it('deserializes totp, sms, and generic_otp factors', () => {
+    const factors = listFactorsFixture.data.map((factor) =>
+      deserializeFactor(factor as AuthenticationFactorResponse),
+    );
+
+    expect(factors).toEqual([
+      {
+        object: 'authentication_factor',
+        id: 'auth_factor_1234',
+        createdAt: '2022-03-15T20:39:19.892Z',
+        updatedAt: '2022-03-15T20:39:19.892Z',
+        type: 'totp',
+        totp: {
+          issuer: 'WorkOS',
+          user: 'some_user',
+        },
+        userId: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+      },
+      {
+        object: 'authentication_factor',
+        id: 'auth_factor_5678',
+        createdAt: '2022-03-15T20:39:19.892Z',
+        updatedAt: '2022-03-15T20:39:19.892Z',
+        type: 'sms',
+        sms: {
+          phoneNumber: '+15555555555',
+        },
+        userId: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+      },
+      {
+        object: 'authentication_factor',
+        id: 'auth_factor_9012',
+        createdAt: '2022-03-15T20:39:19.892Z',
+        updatedAt: '2022-03-15T20:39:19.892Z',
+        type: 'generic_otp',
+        userId: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
+      },
+    ]);
+  });
+});

--- a/src/user-management/serializers/authentication-factor.serializer.ts
+++ b/src/user-management/serializers/authentication-factor.serializer.ts
@@ -4,6 +4,7 @@ import {
   AuthenticationFactorWithSecrets,
   AuthenticationFactorWithSecretsResponse,
 } from '../interfaces/authentication-factor.interface';
+import { deserializeSms } from '../../multi-factor-auth/serializers/sms.serializer';
 import {
   deserializeTotp,
   deserializeTotpWithSecrets,
@@ -17,7 +18,8 @@ export const deserializeFactor = (
   createdAt: factor.created_at,
   updatedAt: factor.updated_at,
   type: factor.type,
-  totp: deserializeTotp(factor.totp),
+  ...(factor.sms ? { sms: deserializeSms(factor.sms) } : {}),
+  ...(factor.totp ? { totp: deserializeTotp(factor.totp) } : {}),
   userId: factor.user_id,
 });
 
@@ -29,6 +31,7 @@ export const deserializeFactorWithSecrets = (
   createdAt: factor.created_at,
   updatedAt: factor.updated_at,
   type: factor.type,
-  totp: deserializeTotpWithSecrets(factor.totp),
+  ...(factor.sms ? { sms: deserializeSms(factor.sms) } : {}),
+  ...(factor.totp ? { totp: deserializeTotpWithSecrets(factor.totp) } : {}),
   userId: factor.user_id,
 });

--- a/src/user-management/serializers/authentication-factor.serializer.ts
+++ b/src/user-management/serializers/authentication-factor.serializer.ts
@@ -31,7 +31,6 @@ export const deserializeFactorWithSecrets = (
   createdAt: factor.created_at,
   updatedAt: factor.updated_at,
   type: factor.type,
-  ...(factor.sms ? { sms: deserializeSms(factor.sms) } : {}),
-  ...(factor.totp ? { totp: deserializeTotpWithSecrets(factor.totp) } : {}),
+  totp: deserializeTotpWithSecrets(factor.totp),
   userId: factor.user_id,
 });


### PR DESCRIPTION
## Description

Fixes DAAP-3034 (Sentry API-2FR): `multiFactorAuth.listUserAuthFactors()` threw `TypeError: Cannot read properties of undefined (reading 'issuer')` for any user with a non-TOTP factor, failing the entire list call.

`GET /user_management/users/:id/auth_factors` returns factors of type `totp`, `sms`, or `generic_otp`, but only TOTP factors include a `totp` object (SMS factors carry `sms: { phone_number }` instead). The user-management `deserializeFactor` called `deserializeTotp(factor.totp)` unconditionally:

```diff
- totp: deserializeTotp(factor.totp),
+ ...(factor.sms ? { sms: deserializeSms(factor.sms) } : {}),
+ ...(factor.totp ? { totp: deserializeTotp(factor.totp) } : {}),
```

This matches the existing (correct) sibling deserializer in `src/multi-factor-auth/serializers/factor.serializer.ts`; the divergence between the two was the whole bug.

### Type fix (why the compiler never caught this)

The `AuthenticationFactor`/`AuthenticationFactorResponse` interfaces hard-coded `type: 'totp'` and a required `totp` object — true of the enroll endpoint, false of list. They now use the shared `FactorType` union (`'sms' | 'totp' | 'generic_otp'`, exported from the MFA module so there's a single source of truth) with optional `sms?` / `totp?`.

Judgment calls:
- **Semver**: widening `type` and making `totp` optional on the list path is technically breaking for TypeScript consumers who destructure `factor.totp` — but the type was lying; that code already crashes at runtime for exactly the users this affects. Shipping as a `fix` (patch) since it corrects the types to the API's actual, long-standing response contract.
- **`WithSecrets` (enroll path) stays narrow**: `EnrollAuthFactorOptions.type` is `'totp'` only, so `createUserAuthFactor` cannot return a non-TOTP factor; `deserializeFactorWithSecrets` keeps the unguarded call so a contract-violating response fails loudly rather than silently returning `undefined` (per review).
- **`sms` field**: now surfaced on the returned list object (previously dropped), matching the MFA sibling. Additive.

Test coverage: both `list-factors.json` fixtures now include `sms` and `generic_otp` factors, exercised through the `listUserAuthFactors` spec and a new `authentication-factor.serializer.spec.ts` — either would have caught the bug.

Note: the production consumer (WorkOS dashboard) is on SDK v8.10.0 (`userManagement.listAuthFactors()`); there is no 8.x maintenance branch, so it will pick this up on upgrade to v9+/v10 where the method is `multiFactorAuth.listUserAuthFactors()`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] No
```


Link to Devin session: https://app.devin.ai/sessions/7fa3a604bb6d415ab2989a8e59fcf403
Requested by: @jeffnv