### PR TITLE
fix: Restore owner.organization_id on user-owned API keys

### DIFF
--- a/src/api-keys/api-keys.spec.ts
+++ b/src/api-keys/api-keys.spec.ts
@@ -64,6 +64,7 @@ describe('ApiKeys', () => {
             type: 'user',
             id: 'user_01H5JQDV7R7ATEYZDEG0W5PRYS',
             organizationId: 'org_01H5JQDV7R7ATEYZDEG0W5PRYS',
+            organization_id: 'org_01H5JQDV7R7ATEYZDEG0W5PRYS',
           },
           name: 'Test User Api Key',
           obfuscatedValue: 'sk_…PRYS',

--- a/src/api-keys/interfaces/api-key.interface.ts
+++ b/src/api-keys/interfaces/api-key.interface.ts
@@ -14,6 +14,11 @@ export interface ApiKey {
         type: 'user';
         id: string;
         organizationId: string;
+        /**
+         * @deprecated Use `organizationId`. Retained for compatibility with
+         * releases before 10.8.0, which returned the raw API field name.
+         */
+        organization_id: string;
       };
   /** A descriptive name for the API Key. */
   name: string;

--- a/src/api-keys/interfaces/api-key.interface.ts
+++ b/src/api-keys/interfaces/api-key.interface.ts
@@ -18,7 +18,7 @@ export interface ApiKey {
          * @deprecated Use `organizationId`. Retained for compatibility with
          * releases before 10.8.0, which returned the raw API field name.
          */
-        organization_id: string;
+        organization_id?: string;
       };
   /** A descriptive name for the API Key. */
   name: string;

--- a/src/api-keys/serializers/api-key.serializer.ts
+++ b/src/api-keys/serializers/api-key.serializer.ts
@@ -10,6 +10,7 @@ export function deserializeApiKey(apiKey: SerializedApiKey): ApiKey {
             type: 'user',
             id: apiKey.owner.id,
             organizationId: apiKey.owner.organization_id,
+            organization_id: apiKey.owner.organization_id,
           }
         : apiKey.owner,
     name: apiKey.name,


### PR DESCRIPTION
## Description

Customer report ([Slack](https://work-os.slack.com/archives/C0ADE32NA4R/p1785754076189549), [Plain](https://app.plain.com/workspace/w_01KEZ48Y1GZPN4PXQ41666E911/thread/th_01KZ3KSN4V0W4ZHT1WW1E3NVZ0/)): API key validation started rejecting valid keys after upgrading to 10.8.0; downgrading to 10.7.0 fixed it.

#1650 made `deserializeApiKey` remap the `user` owner variant instead of passing `owner` through raw. That was a correct typing fix, but it silently changed the *runtime* shape in a minor release for user-owned keys:

```diff
 owner: {
   type: 'user',
   id: 'user_...',
-  organization_id: 'org_...',   // 10.7.0 (raw passthrough)
+  organizationId: 'org_...',    // 10.8.0
 }
```

Anyone parsing the deserialized object against a schema (the reporter runs `zod` `safeParse` on `validation.apiKey`) now fails on a valid key. Organization-owned keys are unaffected — I diffed 10.7.0 vs 10.8.0 against a stub API and their output is identical.

This emits both keys so the pre-10.8.0 shape keeps working, with `organization_id` marked `@deprecated` for removal in the next major.

Tradeoff worth a second opinion: consumers who already adapted to 10.8.0 *and* strict-parse the owner object will now see an unexpected extra key. The alternative is to leave 10.8.0 as-is and tell affected users to rename — that keeps the surface clean but leaves the minor-release break in place.

Not changed here: `deserializeCreatedApiKey` still passes `owner` through raw, so `createOrganizationApiKey` returns `organization_id` only and never had the `organizationId` field. Worth aligning separately.

## Documentation

```
[ ] Yes
```


Link to Devin session: https://app.devin.ai/sessions/2f3d6911ede0413ca81245dfc637b4e0
Requested by: @KatBrandt