### PR TITLE
feat: Add Waitlists methods to User Management

### DIFF
--- a/src/user-management/fixtures/list-waitlist-users.json
+++ b/src/user-management/fixtures/list-waitlist-users.json
@@ -1,0 +1,19 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "waitlist_user",
+      "id": "wl_user_01H5JQDV7R7ATEYZDEG0W5PRYS",
+      "email": "marcelina.davis@example.com",
+      "state": "pending",
+      "approved_at": null,
+      "waitlist_id": "waitlist_01H5JQDV7R7ATEYZDEG0W5PRYS",
+      "created_at": "2026-08-04T02:07:19.911Z",
+      "updated_at": "2026-08-04T02:07:19.911Z"
+    }
+  ],
+  "list_metadata": {
+    "before": null,
+    "after": null
+  }
+}

--- a/src/user-management/fixtures/list-waitlists.json
+++ b/src/user-management/fixtures/list-waitlists.json
@@ -1,0 +1,15 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "waitlist",
+      "id": "waitlist_01H5JQDV7R7ATEYZDEG0W5PRYS",
+      "created_at": "2026-08-04T02:07:19.911Z",
+      "updated_at": "2026-08-04T02:07:19.911Z"
+    }
+  ],
+  "list_metadata": {
+    "before": null,
+    "after": null
+  }
+}

--- a/src/user-management/fixtures/waitlist-user.json
+++ b/src/user-management/fixtures/waitlist-user.json
@@ -1,0 +1,10 @@
+{
+  "object": "waitlist_user",
+  "id": "wl_user_01H5JQDV7R7ATEYZDEG0W5PRYS",
+  "email": "marcelina.davis@example.com",
+  "state": "pending",
+  "approved_at": null,
+  "waitlist_id": "waitlist_01H5JQDV7R7ATEYZDEG0W5PRYS",
+  "created_at": "2026-08-04T02:07:19.911Z",
+  "updated_at": "2026-08-04T02:07:19.911Z"
+}

--- a/src/user-management/fixtures/waitlist.json
+++ b/src/user-management/fixtures/waitlist.json
@@ -1,0 +1,6 @@
+{
+  "object": "waitlist",
+  "id": "waitlist_01H5JQDV7R7ATEYZDEG0W5PRYS",
+  "created_at": "2026-08-04T02:07:19.911Z",
+  "updated_at": "2026-08-04T02:07:19.911Z"
+}

--- a/src/user-management/interfaces/create-waitlist-user-options.interface.ts
+++ b/src/user-management/interfaces/create-waitlist-user-options.interface.ts
@@ -1,0 +1,14 @@
+export interface CreateWaitlistUserOptions {
+  /** The email address of the user joining the waitlist. */
+  email: string;
+  /** Additional key/value pairs stored with the waitlist user. Not returned by the API. */
+  additionalFields?: Record<string, string>;
+  /** Whether to send the waitlist confirmation email. Defaults to false. */
+  notify?: boolean;
+}
+
+export interface SerializedCreateWaitlistUserOptions {
+  email: string;
+  additional_fields?: Record<string, string>;
+  notify?: boolean;
+}

--- a/src/user-management/interfaces/index.ts
+++ b/src/user-management/interfaces/index.ts
@@ -55,3 +55,7 @@ export * from './user.interface';
 export * from './user-api-key.interface';
 export * from './user-api-key-with-value.interface';
 export * from './verify-email-options.interface';
+export * from './create-waitlist-user-options.interface';
+export * from './list-waitlist-users-options.interface';
+export * from './waitlist.interface';
+export * from './waitlist-user.interface';

--- a/src/user-management/interfaces/list-waitlist-users-options.interface.ts
+++ b/src/user-management/interfaces/list-waitlist-users-options.interface.ts
@@ -1,0 +1,14 @@
+import { PaginationOptions } from '../../common/interfaces';
+import { WaitlistUserState } from './waitlist-user.interface';
+
+export interface ListWaitlistUsersOptions extends PaginationOptions {
+  /** Filter waitlist users by their state. */
+  state?: WaitlistUserState;
+  /** Filter waitlist users by their exact email address. */
+  email?: string;
+}
+
+export interface SerializedListWaitlistUsersOptions extends PaginationOptions {
+  state?: WaitlistUserState;
+  email?: string;
+}

--- a/src/user-management/interfaces/waitlist-user.interface.ts
+++ b/src/user-management/interfaces/waitlist-user.interface.ts
@@ -1,0 +1,31 @@
+export type WaitlistUserState = 'pending' | 'approved' | 'denied';
+
+export interface WaitlistUser {
+  /** Distinguishes the waitlist user object. */
+  object: 'waitlist_user';
+  /** The unique ID of the waitlist user. */
+  id: string;
+  /** The email address of the waitlist user. */
+  email: string;
+  /** The state of the waitlist user. */
+  state: WaitlistUserState;
+  /** The timestamp when the waitlist user was approved, or null if not yet approved. */
+  approvedAt: string | null;
+  /** The ID of the waitlist the user joined, or null for legacy waitlist users on the default waitlist. */
+  waitlistId: string | null;
+  /** An ISO 8601 timestamp. */
+  createdAt: string;
+  /** An ISO 8601 timestamp. */
+  updatedAt: string;
+}
+
+export interface WaitlistUserResponse {
+  object: 'waitlist_user';
+  id: string;
+  email: string;
+  state: WaitlistUserState;
+  approved_at: string | null;
+  waitlist_id?: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/user-management/interfaces/waitlist.interface.ts
+++ b/src/user-management/interfaces/waitlist.interface.ts
@@ -1,0 +1,17 @@
+export interface Waitlist {
+  /** Distinguishes the waitlist object. */
+  object: 'waitlist';
+  /** The unique ID of the waitlist. */
+  id: string;
+  /** An ISO 8601 timestamp. */
+  createdAt: string;
+  /** An ISO 8601 timestamp. */
+  updatedAt: string;
+}
+
+export interface WaitlistResponse {
+  object: 'waitlist';
+  id: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/user-management/serializers/create-waitlist-user-options.serializer.ts
+++ b/src/user-management/serializers/create-waitlist-user-options.serializer.ts
@@ -1,0 +1,12 @@
+import {
+  CreateWaitlistUserOptions,
+  SerializedCreateWaitlistUserOptions,
+} from '../interfaces/create-waitlist-user-options.interface';
+
+export const serializeCreateWaitlistUserOptions = (
+  options: CreateWaitlistUserOptions,
+): SerializedCreateWaitlistUserOptions => ({
+  email: options.email,
+  additional_fields: options.additionalFields,
+  notify: options.notify,
+});

--- a/src/user-management/serializers/index.ts
+++ b/src/user-management/serializers/index.ts
@@ -29,3 +29,7 @@ export * from './update-user-password-options.serializer';
 export * from './user.serializer';
 export * from './user-api-key.serializer';
 export * from './user-api-key-with-value.serializer';
+export * from './create-waitlist-user-options.serializer';
+export * from './list-waitlist-users-options.serializer';
+export * from './waitlist.serializer';
+export * from './waitlist-user.serializer';

--- a/src/user-management/serializers/list-waitlist-users-options.serializer.ts
+++ b/src/user-management/serializers/list-waitlist-users-options.serializer.ts
@@ -1,0 +1,15 @@
+import {
+  ListWaitlistUsersOptions,
+  SerializedListWaitlistUsersOptions,
+} from '../interfaces/list-waitlist-users-options.interface';
+
+export const serializeListWaitlistUsersOptions = (
+  options: ListWaitlistUsersOptions,
+): SerializedListWaitlistUsersOptions => ({
+  state: options.state,
+  email: options.email,
+  limit: options.limit,
+  before: options.before,
+  after: options.after,
+  order: options.order,
+});

--- a/src/user-management/serializers/waitlist-user.serializer.ts
+++ b/src/user-management/serializers/waitlist-user.serializer.ts
@@ -1,0 +1,17 @@
+import {
+  WaitlistUser,
+  WaitlistUserResponse,
+} from '../interfaces/waitlist-user.interface';
+
+export const deserializeWaitlistUser = (
+  waitlistUser: WaitlistUserResponse,
+): WaitlistUser => ({
+  object: waitlistUser.object,
+  id: waitlistUser.id,
+  email: waitlistUser.email,
+  state: waitlistUser.state,
+  approvedAt: waitlistUser.approved_at,
+  waitlistId: waitlistUser.waitlist_id ?? null,
+  createdAt: waitlistUser.created_at,
+  updatedAt: waitlistUser.updated_at,
+});

--- a/src/user-management/serializers/waitlist.serializer.ts
+++ b/src/user-management/serializers/waitlist.serializer.ts
@@ -1,0 +1,8 @@
+import { Waitlist, WaitlistResponse } from '../interfaces/waitlist.interface';
+
+export const deserializeWaitlist = (waitlist: WaitlistResponse): Waitlist => ({
+  object: waitlist.object,
+  id: waitlist.id,
+  createdAt: waitlist.created_at,
+  updatedAt: waitlist.updated_at,
+});

--- a/src/user-management/user-management.spec.ts
+++ b/src/user-management/user-management.spec.ts
@@ -22,6 +22,10 @@ import passwordResetFixture from './fixtures/password_reset.json';
 import userFixture from './fixtures/user.json';
 import createUserApiKeyFixture from './fixtures/create-user-api-key.json';
 import identityFixture from './fixtures/identity.json';
+import waitlistFixture from './fixtures/waitlist.json';
+import listWaitlistsFixture from './fixtures/list-waitlists.json';
+import waitlistUserFixture from './fixtures/waitlist-user.json';
+import listWaitlistUsersFixture from './fixtures/list-waitlist-users.json';
 import * as jose from 'jose';
 import { sealData } from '../common/crypto/seal';
 
@@ -38,6 +42,8 @@ const invitationId = 'invitation_01H5JQDV7R7ATEYZDEG0W5PRYS';
 const invitationToken = 'Z1uX3RbwcIl5fIGJJJCXXisdI';
 const magicAuthId = 'magic_auth_01H5JQDV7R7ATEYZDEG0W5PRYS';
 const passwordResetId = 'password_reset_01H5JQDV7R7ATEYZDEG0W5PRYS';
+const waitlistId = 'waitlist_01H5JQDV7R7ATEYZDEG0W5PRYS';
+const waitlistUserId = 'wl_user_01H5JQDV7R7ATEYZDEG0W5PRYS';
 
 describe('UserManagement', () => {
   let workos: WorkOS;
@@ -2753,6 +2759,277 @@ describe('UserManagement', () => {
       await expect(
         workos.userManagement.resendInvitation(invitationId),
       ).rejects.toThrow();
+    });
+  });
+
+  describe('listWaitlists', () => {
+    it('lists waitlists', async () => {
+      fetchOnce(listWaitlistsFixture);
+
+      const waitlists = await workos.userManagement.listWaitlists();
+
+      expect(fetchURL()).toContain('/user_management/waitlists');
+      expect(waitlists).toMatchObject({
+        object: 'list',
+        data: [
+          {
+            object: 'waitlist',
+            id: waitlistId,
+            createdAt: '2026-08-04T02:07:19.911Z',
+            updatedAt: '2026-08-04T02:07:19.911Z',
+          },
+        ],
+        listMetadata: {
+          before: null,
+          after: null,
+        },
+      });
+    });
+  });
+
+  describe('getWaitlist', () => {
+    it('sends a Get Waitlist request', async () => {
+      fetchOnce(waitlistFixture);
+
+      const waitlist = await workos.userManagement.getWaitlist(waitlistId);
+
+      expect(fetchURL()).toContain(`/user_management/waitlists/${waitlistId}`);
+      expect(waitlist).toEqual({
+        object: 'waitlist',
+        id: waitlistId,
+        createdAt: '2026-08-04T02:07:19.911Z',
+        updatedAt: '2026-08-04T02:07:19.911Z',
+      });
+    });
+
+    it('resolves the `default` alias', async () => {
+      fetchOnce(waitlistFixture);
+
+      const waitlist = await workos.userManagement.getWaitlist('default');
+
+      expect(fetchURL()).toContain('/user_management/waitlists/default');
+      expect(waitlist).toMatchObject({ object: 'waitlist', id: waitlistId });
+    });
+  });
+
+  describe('listWaitlistUsers', () => {
+    it('lists the users on a waitlist', async () => {
+      fetchOnce(listWaitlistUsersFixture);
+
+      const waitlistUsers =
+        await workos.userManagement.listWaitlistUsers(waitlistId);
+
+      expect(fetchURL()).toContain(
+        `/user_management/waitlists/${waitlistId}/entries`,
+      );
+      expect(waitlistUsers).toMatchObject({
+        object: 'list',
+        data: [
+          {
+            object: 'waitlist_user',
+            id: waitlistUserId,
+            email: 'marcelina.davis@example.com',
+            state: 'pending',
+            approvedAt: null,
+            waitlistId,
+          },
+        ],
+        listMetadata: {
+          before: null,
+          after: null,
+        },
+      });
+    });
+
+    it('sends the correct params when filtering', async () => {
+      fetchOnce(listWaitlistUsersFixture);
+
+      await workos.userManagement.listWaitlistUsers(waitlistId, {
+        state: 'pending',
+        email: 'marcelina.davis@example.com',
+        limit: 10,
+      });
+
+      expect(fetchSearchParams()).toEqual({
+        state: 'pending',
+        email: 'marcelina.davis@example.com',
+        limit: '10',
+        order: 'desc',
+      });
+    });
+
+    it('deserializes a legacy waitlist user without a waitlist ID', async () => {
+      fetchOnce({
+        ...listWaitlistUsersFixture,
+        data: [
+          {
+            object: 'waitlist_user',
+            id: waitlistUserId,
+            email: 'marcelina.davis@example.com',
+            state: 'pending',
+            approved_at: null,
+            created_at: '2026-08-04T02:07:19.911Z',
+            updated_at: '2026-08-04T02:07:19.911Z',
+          },
+        ],
+      });
+
+      const waitlistUsers =
+        await workos.userManagement.listWaitlistUsers(waitlistId);
+
+      expect(waitlistUsers.data[0].waitlistId).toBeNull();
+    });
+  });
+
+  describe('createWaitlistUser', () => {
+    it('sends a Create Waitlist User request', async () => {
+      fetchOnce(waitlistUserFixture, { status: 201 });
+
+      const waitlistUser = await workos.userManagement.createWaitlistUser(
+        waitlistId,
+        {
+          email: 'marcelina.davis@example.com',
+        },
+      );
+
+      expect(fetchURL()).toContain(
+        `/user_management/waitlists/${waitlistId}/entries`,
+      );
+      expect(fetchBody()).toEqual({
+        email: 'marcelina.davis@example.com',
+      });
+      expect(waitlistUser).toEqual({
+        object: 'waitlist_user',
+        id: waitlistUserId,
+        email: 'marcelina.davis@example.com',
+        state: 'pending',
+        approvedAt: null,
+        waitlistId,
+        createdAt: '2026-08-04T02:07:19.911Z',
+        updatedAt: '2026-08-04T02:07:19.911Z',
+      });
+    });
+
+    it('sends the correct params when provided', async () => {
+      fetchOnce(waitlistUserFixture, { status: 201 });
+
+      await workos.userManagement.createWaitlistUser('default', {
+        email: 'marcelina.davis@example.com',
+        additionalFields: { company: 'Foo Corp' },
+        notify: true,
+      });
+
+      expect(fetchURL()).toContain(
+        '/user_management/waitlists/default/entries',
+      );
+      expect(fetchBody()).toEqual({
+        email: 'marcelina.davis@example.com',
+        additional_fields: { company: 'Foo Corp' },
+        notify: true,
+      });
+    });
+
+    it('throws an error when a user with the email already exists (422)', async () => {
+      fetchOnce(
+        {
+          message: 'User already exists.',
+          code: 'user_already_exists',
+        },
+        { status: 422 },
+      );
+
+      await expect(
+        workos.userManagement.createWaitlistUser(waitlistId, {
+          email: 'existing@example.com',
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('approveWaitlistUser', () => {
+    it('sends an Approve Waitlist User request', async () => {
+      fetchOnce({
+        ...waitlistUserFixture,
+        state: 'approved',
+        approved_at: '2026-08-04T02:07:19.911Z',
+      });
+
+      const waitlistUser =
+        await workos.userManagement.approveWaitlistUser(waitlistUserId);
+
+      expect(fetchURL()).toContain(
+        `/user_management/waitlist_entries/${waitlistUserId}/approve`,
+      );
+      expect(waitlistUser).toMatchObject({
+        object: 'waitlist_user',
+        id: waitlistUserId,
+        state: 'approved',
+        approvedAt: '2026-08-04T02:07:19.911Z',
+      });
+    });
+
+    it('throws an error when the waitlist user is already approved (422)', async () => {
+      fetchOnce(
+        {
+          message: 'Waitlist entry is approved and cannot be approved.',
+          code: 'invalid_state',
+        },
+        { status: 422 },
+      );
+
+      await expect(
+        workos.userManagement.approveWaitlistUser(waitlistUserId),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('denyWaitlistUser', () => {
+    it('sends a Deny Waitlist User request', async () => {
+      fetchOnce({
+        ...waitlistUserFixture,
+        state: 'denied',
+      });
+
+      const waitlistUser =
+        await workos.userManagement.denyWaitlistUser(waitlistUserId);
+
+      expect(fetchURL()).toContain(
+        `/user_management/waitlist_entries/${waitlistUserId}/deny`,
+      );
+      expect(waitlistUser).toMatchObject({
+        object: 'waitlist_user',
+        id: waitlistUserId,
+        state: 'denied',
+        approvedAt: null,
+      });
+    });
+
+    it('throws an error when the waitlist user is not pending (422)', async () => {
+      fetchOnce(
+        {
+          message: 'Waitlist entry is approved and cannot be denied.',
+          code: 'invalid_state',
+        },
+        { status: 422 },
+      );
+
+      await expect(
+        workos.userManagement.denyWaitlistUser(waitlistUserId),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('deleteWaitlistUser', () => {
+    it('sends a Delete Waitlist User request', async () => {
+      fetchOnce();
+
+      const response =
+        await workos.userManagement.deleteWaitlistUser(waitlistUserId);
+
+      expect(fetchURL()).toContain(
+        `/user_management/waitlist_entries/${waitlistUserId}`,
+      );
+      expect(response).toBeUndefined();
     });
 
     it('throws an error when invitation is accepted (400)', async () => {

--- a/src/user-management/user-management.ts
+++ b/src/user-management/user-management.ts
@@ -137,6 +137,19 @@ import {
   UpdateOrganizationMembershipOptions,
 } from './interfaces/update-organization-membership-options.interface';
 import {
+  CreateWaitlistUserOptions,
+  SerializedCreateWaitlistUserOptions,
+} from './interfaces/create-waitlist-user-options.interface';
+import {
+  ListWaitlistUsersOptions,
+  SerializedListWaitlistUsersOptions,
+} from './interfaces/list-waitlist-users-options.interface';
+import { Waitlist, WaitlistResponse } from './interfaces/waitlist.interface';
+import {
+  WaitlistUser,
+  WaitlistUserResponse,
+} from './interfaces/waitlist-user.interface';
+import {
   deserializeAuthenticationResponse,
   deserializeEmailVerification,
   deserializeMagicAuth,
@@ -176,6 +189,10 @@ import { serializeResendInvitationOptions } from './serializers/resend-invitatio
 import { deserializeOrganizationMembership } from './serializers/organization-membership.serializer';
 import { serializeSendInvitationOptions } from './serializers/send-invitation-options.serializer';
 import { serializeUpdateOrganizationMembershipOptions } from './serializers/update-organization-membership-options.serializer';
+import { serializeCreateWaitlistUserOptions } from './serializers/create-waitlist-user-options.serializer';
+import { serializeListWaitlistUsersOptions } from './serializers/list-waitlist-users-options.serializer';
+import { deserializeWaitlist } from './serializers/waitlist.serializer';
+import { deserializeWaitlistUser } from './serializers/waitlist-user.serializer';
 import { CookieSession } from './session';
 import { getJose } from '../utils/jose';
 import { Group, GroupResponse } from '../groups/interfaces';
@@ -1470,6 +1487,156 @@ export class UserManagement {
 
     return deserializeInvitation(data);
   }
+
+  // @oagen-ignore-start
+  /**
+   * List waitlists
+   *
+   * Get a list of the waitlists in the environment.
+   * @returns {Promise<AutoPaginatable<Waitlist>>}
+   */
+  async listWaitlists(): Promise<AutoPaginatable<Waitlist>> {
+    return new AutoPaginatable(
+      await fetchAndDeserialize<WaitlistResponse, Waitlist>(
+        this.workos,
+        '/user_management/waitlists',
+        deserializeWaitlist,
+      ),
+      (params) =>
+        fetchAndDeserialize<WaitlistResponse, Waitlist>(
+          this.workos,
+          '/user_management/waitlists',
+          deserializeWaitlist,
+          params,
+        ),
+    );
+  }
+
+  /**
+   * Get a waitlist
+   *
+   * Retrieve an existing waitlist. The ID `'default'` resolves to the
+   * environment's default waitlist.
+   * @param waitlistId - The unique ID of the waitlist, or `'default'`.
+   * @returns {Promise<Waitlist>}
+   * @throws {NotFoundException} 404
+   */
+  async getWaitlist(waitlistId: string): Promise<Waitlist> {
+    const { data } = await this.workos.get<WaitlistResponse>(
+      `/user_management/waitlists/${waitlistId}`,
+    );
+
+    return deserializeWaitlist(data);
+  }
+
+  /**
+   * List waitlist users
+   *
+   * Get a list of the users on a waitlist matching the criteria specified.
+   * @param waitlistId - The unique ID of the waitlist, or `'default'`.
+   * @param options - Pagination and filter options.
+   * @returns {Promise<AutoPaginatable<WaitlistUser, SerializedListWaitlistUsersOptions>>}
+   * @throws {NotFoundException} 404
+   * @throws {UnprocessableEntityException} 422
+   */
+  async listWaitlistUsers(
+    waitlistId: string,
+    options?: ListWaitlistUsersOptions,
+  ): Promise<
+    AutoPaginatable<WaitlistUser, SerializedListWaitlistUsersOptions>
+  > {
+    return new AutoPaginatable(
+      await fetchAndDeserialize<WaitlistUserResponse, WaitlistUser>(
+        this.workos,
+        `/user_management/waitlists/${waitlistId}/entries`,
+        deserializeWaitlistUser,
+        options ? serializeListWaitlistUsersOptions(options) : undefined,
+      ),
+      (params) =>
+        fetchAndDeserialize<WaitlistUserResponse, WaitlistUser>(
+          this.workos,
+          `/user_management/waitlists/${waitlistId}/entries`,
+          deserializeWaitlistUser,
+          params,
+        ),
+      options ? serializeListWaitlistUsersOptions(options) : undefined,
+    );
+  }
+
+  /**
+   * Create a waitlist user
+   *
+   * Adds a user to the waitlist. Idempotent per email address.
+   * @param waitlistId - The unique ID of the waitlist, or `'default'`.
+   * @param payload - Object containing email.
+   * @returns {Promise<WaitlistUser>}
+   * @throws {NotFoundException} 404
+   * @throws {UnprocessableEntityException} 422
+   */
+  async createWaitlistUser(
+    waitlistId: string,
+    payload: CreateWaitlistUserOptions,
+  ): Promise<WaitlistUser> {
+    const { data } = await this.workos.post<
+      WaitlistUserResponse,
+      SerializedCreateWaitlistUserOptions
+    >(
+      `/user_management/waitlists/${waitlistId}/entries`,
+      serializeCreateWaitlistUserOptions(payload),
+    );
+
+    return deserializeWaitlistUser(data);
+  }
+
+  /**
+   * Approve a waitlist user
+   *
+   * Approves a pending or denied waitlist user and sends them an invitation.
+   * @param waitlistUserId - The unique ID of the waitlist user.
+   * @returns {Promise<WaitlistUser>}
+   * @throws {NotFoundException} 404
+   * @throws {UnprocessableEntityException} 422
+   */
+  async approveWaitlistUser(waitlistUserId: string): Promise<WaitlistUser> {
+    const { data } = await this.workos.post<WaitlistUserResponse, null>(
+      `/user_management/waitlist_entries/${waitlistUserId}/approve`,
+      null,
+    );
+
+    return deserializeWaitlistUser(data);
+  }
+
+  /**
+   * Deny a waitlist user
+   *
+   * Denies a pending waitlist user.
+   * @param waitlistUserId - The unique ID of the waitlist user.
+   * @returns {Promise<WaitlistUser>}
+   * @throws {NotFoundException} 404
+   * @throws {UnprocessableEntityException} 422
+   */
+  async denyWaitlistUser(waitlistUserId: string): Promise<WaitlistUser> {
+    const { data } = await this.workos.post<WaitlistUserResponse, null>(
+      `/user_management/waitlist_entries/${waitlistUserId}/deny`,
+      null,
+    );
+
+    return deserializeWaitlistUser(data);
+  }
+
+  /**
+   * Delete a waitlist user
+   *
+   * Permanently removes a user from the waitlist.
+   * @param waitlistUserId - The unique ID of the waitlist user.
+   * @throws {NotFoundException} 404
+   */
+  async deleteWaitlistUser(waitlistUserId: string): Promise<void> {
+    await this.workos.delete(
+      `/user_management/waitlist_entries/${waitlistUserId}`,
+    );
+  }
+  // @oagen-ignore-end
 
   /**
    * Revoke Session


### PR DESCRIPTION
> **Closed without merging**: waitlists SDK support will be generated by oagen from workos/openapi-spec when the endpoints are un-hidden at GA (AUTH-6723) — `adoptMissingServices: true` picks the service up automatically. This branch stays as a reference for the expected surface (method shapes, `notify` param, `default` alias, 422 handling).

## Summary

Adds SDK support for the waitlists REST API on `workos.userManagement`:

- `listWaitlists()` — `GET /user_management/waitlists`
- `getWaitlist(waitlistId)` — `GET /user_management/waitlists/:id` (accepts the `default` alias)
- `listWaitlistUsers(waitlistId, options?)` — `GET /user_management/waitlists/:id/entries`, with `state` and exact-`email` filters plus standard cursor pagination via `AutoPaginatable`
- `createWaitlistUser(waitlistId, payload)` — `POST /user_management/waitlists/:id/entries` with `email`, optional `additionalFields` (sent as `additional_fields`), and optional `notify` (defaults to `false`). Idempotent per email; `422 user_already_exists` when a user with that email already exists. The `default` alias lazily creates the default waitlist on this write path.
- `approveWaitlistUser(waitlistUserId)` — `POST /user_management/waitlist_entries/:id/approve`
- `denyWaitlistUser(waitlistUserId)` — `POST /user_management/waitlist_entries/:id/deny`
- Errors: `422 invalid_state` for approve/deny on an entry in the wrong state, `422 invitation_email_not_sent` when the approval invitation email cannot be sent
- `deleteWaitlistUser(waitlistUserId)` — `DELETE /user_management/waitlist_entries/:id` (204)

Response objects are `waitlist` and `waitlist_user` (matching the existing `waitlist_user.*` webhook events), deserialized to camelCase `Waitlist` / `WaitlistUser` types. `waitlist_id` can be absent or null on legacy entries and is normalized to `waitlistId: null`.

The new methods are wrapped in `@oagen-ignore` markers since the API endpoints are excluded from the public OpenAPI spec while incubating.

> [!WARNING]
> **Do not merge/release until the `waitlist-api` feature flag reaches GA (AUTH-6723).** The API returns 404 for these routes on teams without the flag, so shipping this early would expose broken methods.

## Test plan

- Unit tests with fixtures covering every method: URL/query/body serialization, camelCase deserialization, the `default` alias, legacy null `waitlist_id`, and 422 error paths (`user_already_exists`, `invalid_state`).
- `npm test` (917 passed, 12 skipped), `npm run lint`, `npm run prettier`, and `npm run typecheck` all pass.

https://linear.app/workos/issue/AUTH-6719