### PR TITLE
fix: reject 5-byte LEB128 encodings that overflow uint32 in decodeUInt32

### DIFF
--- a/src/common/utils/leb128.spec.ts
+++ b/src/common/utils/leb128.spec.ts
@@ -242,6 +242,28 @@ describe('leb128', () => {
           'LEB128 sequence exceeds maximum length for uint32',
         );
       });
+
+      test('throws for a 5-byte encoding whose final byte overflows uint32', () => {
+        // 5 bytes, but the final byte carries data bits above bit 31
+        // (0x10 -> 2^32). Without a range check the 32-bit shift silently drops
+        // the overflow and returns 0 instead of rejecting the value.
+        const data = new Uint8Array([0x80, 0x80, 0x80, 0x80, 0x10]);
+        expect(() => decodeUInt32(data)).toThrow(
+          'LEB128 sequence exceeds uint32 range',
+        );
+      });
+
+      test('throws when the final byte uses all 7 data bits', () => {
+        const data = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x7f]);
+        expect(() => decodeUInt32(data)).toThrow(
+          'LEB128 sequence exceeds uint32 range',
+        );
+      });
+
+      test('accepts MAX_UINT32 whose final byte is exactly 0x0f', () => {
+        const data = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x0f]);
+        expect(decodeUInt32(data).value).toBe(4294967295);
+      });
     });
   });
 

--- a/src/common/utils/leb128.ts
+++ b/src/common/utils/leb128.ts
@@ -9,6 +9,11 @@ const CONTINUATION_BIT = 0x80;
 const DATA_BITS_MASK = 0x7f;
 const DATA_BITS_PER_BYTE = 7;
 const MAX_BYTES_FOR_UINT32 = 5;
+// The 5th byte is read at this shift; a uint32 only has 32 - 28 = 4 data bits
+// left for it, so its 7-bit payload must not exceed 0x0F. A larger payload
+// encodes a value above MAX_UINT32.
+const FINAL_BYTE_SHIFT = (MAX_BYTES_FOR_UINT32 - 1) * DATA_BITS_PER_BYTE;
+const FINAL_BYTE_MAX_DATA = 0x0f;
 
 /**
  * Encodes an unsigned 32-bit integer into LEB128 format.
@@ -63,6 +68,16 @@ export function decodeUInt32(
 
     if (bytesRead > MAX_BYTES_FOR_UINT32) {
       throw new Error('LEB128 sequence exceeds maximum length for uint32');
+    }
+
+    // On the final (5th) byte only 4 of its 7 data bits fit in a uint32. Reject a
+    // larger payload instead of letting the 32-bit `<<` below silently drop the
+    // overflowing bits and return a wrong value for an out-of-range encoding.
+    if (
+      shift === FINAL_BYTE_SHIFT &&
+      (byte & DATA_BITS_MASK) > FINAL_BYTE_MAX_DATA
+    ) {
+      throw new Error('LEB128 sequence exceeds uint32 range');
     }
 
     result |= (byte & DATA_BITS_MASK) << shift;


### PR DESCRIPTION
### Problem

`decodeUInt32` in `src/common/utils/leb128.ts` validates the byte **count** of a LEB128 sequence but not the **range** of its last byte.

A uint32 needs at most 5 bytes. The 5th byte is read at `shift = 28`, and only `32 - 28 = 4` of its 7 data bits fit in a uint32. When the 5th byte carries data above `0x0F`, the value is greater than `MAX_UINT32`, but the JavaScript 32-bit `<<` silently drops the overflowing bits instead of erroring:

```ts
result |= (byte & DATA_BITS_MASK) << shift; // (0x10 << 28) truncates to 0
```

So over-range 5-byte encodings decode to a wrong value rather than being rejected:

| input | decoded value | correct behavior |
|---|---|---|
| `[0x80,0x80,0x80,0x80,0x10]` (2³²) | `0` | reject |
| `[0xFF,0xFF,0xFF,0xFF,0x1F]` | `4294967295` | reject |
| `[0xFF,0xFF,0xFF,0xFF,0x7F]` | `4294967295` | reject |

`encodeUInt32` already validates the uint32 range, and the suite's existing `throws for encoding that exceeds uint32 range` test only covers the *too-many-bytes* case (`[0x80,0x80,0x80,0x80,0x80,0x01]`), so this class of over-range input slipped through — a decoder that's meant to fail on out-of-range input silently returns garbage instead.

### Fix

Reject an over-range final byte before the shift, so the decoder fails loudly to match the encoder:

```ts
if (shift === FINAL_BYTE_SHIFT && (byte & DATA_BITS_MASK) > FINAL_BYTE_MAX_DATA) {
  throw new Error('LEB128 sequence exceeds uint32 range');
}
```

`FINAL_BYTE_SHIFT` is `(MAX_BYTES_FOR_UINT32 - 1) * DATA_BITS_PER_BYTE = 28` and `FINAL_BYTE_MAX_DATA = 0x0F`. Every valid encoding (final byte ≤ `0x0F`, including `MAX_UINT32` → `[0xFF,0xFF,0xFF,0xFF,0x0F]`) is unaffected; only genuinely out-of-range input now throws.

### Tests

Added three cases to the `invalid inputs` block: two over-range 5-byte sequences that must throw `LEB128 sequence exceeds uint32 range`, and one asserting `MAX_UINT32` (final byte exactly `0x0F`) still decodes to `4294967295`. Full `leb128.spec.ts` passes (42/42); reverting only the source change fails the two new "throws" cases, confirming they catch the bug.
